### PR TITLE
feat: establish site continuity foundation

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,152 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,157 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,173 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,106 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │         CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.desloppify/plan.json
+++ b/.desloppify/plan.json
@@ -1,0 +1,272 @@
+{
+  "version": 8,
+  "created": "2026-03-18T06:35:27+00:00",
+  "updated": "2026-03-18T06:35:28+00:00",
+  "queue_order": [
+    "subjective::abstraction_fitness",
+    "subjective::ai_generated_debt",
+    "subjective::api_surface_coherence",
+    "subjective::authorization_consistency",
+    "subjective::contract_coherence",
+    "subjective::convention_outlier",
+    "subjective::cross_module_architecture",
+    "subjective::dependency_health",
+    "subjective::design_coherence",
+    "subjective::error_consistency",
+    "subjective::high_level_elegance",
+    "subjective::incomplete_migration",
+    "subjective::initialization_coupling",
+    "subjective::logic_clarity",
+    "subjective::low_level_elegance",
+    "subjective::mid_level_elegance",
+    "subjective::naming_quality",
+    "subjective::package_organization",
+    "subjective::test_strategy",
+    "subjective::type_safety"
+  ],
+  "deferred": [],
+  "skipped": {},
+  "active_cluster": null,
+  "overrides": {
+    "test_coverage::src/app/page.tsx": {
+      "issue_id": "test_coverage::src/app/page.tsx",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/test_coverage",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "test_coverage::src/app/layout.tsx": {
+      "issue_id": "test_coverage::src/app/layout.tsx",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/test_coverage",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::abstraction_fitness": {
+      "issue_id": "subjective::abstraction_fitness",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::ai_generated_debt": {
+      "issue_id": "subjective::ai_generated_debt",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::api_surface_coherence": {
+      "issue_id": "subjective::api_surface_coherence",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::authorization_consistency": {
+      "issue_id": "subjective::authorization_consistency",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::contract_coherence": {
+      "issue_id": "subjective::contract_coherence",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::convention_outlier": {
+      "issue_id": "subjective::convention_outlier",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::cross_module_architecture": {
+      "issue_id": "subjective::cross_module_architecture",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::dependency_health": {
+      "issue_id": "subjective::dependency_health",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::design_coherence": {
+      "issue_id": "subjective::design_coherence",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::error_consistency": {
+      "issue_id": "subjective::error_consistency",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::high_level_elegance": {
+      "issue_id": "subjective::high_level_elegance",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::incomplete_migration": {
+      "issue_id": "subjective::incomplete_migration",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::initialization_coupling": {
+      "issue_id": "subjective::initialization_coupling",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::logic_clarity": {
+      "issue_id": "subjective::logic_clarity",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::low_level_elegance": {
+      "issue_id": "subjective::low_level_elegance",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::mid_level_elegance": {
+      "issue_id": "subjective::mid_level_elegance",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::naming_quality": {
+      "issue_id": "subjective::naming_quality",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::package_organization": {
+      "issue_id": "subjective::package_organization",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::test_strategy": {
+      "issue_id": "subjective::test_strategy",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    },
+    "subjective::type_safety": {
+      "issue_id": "subjective::type_safety",
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "cluster": "auto/initial-review",
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    }
+  },
+  "clusters": {
+    "auto/test_coverage": {
+      "name": "auto/test_coverage",
+      "description": "Fix 2 test coverage issues",
+      "issue_ids": [
+        "test_coverage::src/app/page.tsx",
+        "test_coverage::src/app/layout.tsx"
+      ],
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "updated_at": "2026-03-18T06:35:27+00:00",
+      "auto": true,
+      "cluster_key": "detector::test_coverage",
+      "action": "add tests for untested production modules \u2014 prioritize by import count",
+      "user_modified": false
+    },
+    "auto/initial-review": {
+      "name": "auto/initial-review",
+      "description": "Initial review of 20 unscored subjective dimensions",
+      "issue_ids": [
+        "subjective::abstraction_fitness",
+        "subjective::ai_generated_debt",
+        "subjective::api_surface_coherence",
+        "subjective::authorization_consistency",
+        "subjective::contract_coherence",
+        "subjective::convention_outlier",
+        "subjective::cross_module_architecture",
+        "subjective::dependency_health",
+        "subjective::design_coherence",
+        "subjective::error_consistency",
+        "subjective::high_level_elegance",
+        "subjective::incomplete_migration",
+        "subjective::initialization_coupling",
+        "subjective::logic_clarity",
+        "subjective::low_level_elegance",
+        "subjective::mid_level_elegance",
+        "subjective::naming_quality",
+        "subjective::package_organization",
+        "subjective::test_strategy",
+        "subjective::type_safety"
+      ],
+      "created_at": "2026-03-18T06:35:27+00:00",
+      "updated_at": "2026-03-18T06:35:27+00:00",
+      "auto": true,
+      "cluster_key": "subjective::unscored",
+      "action": "desloppify review --prepare --dimensions abstraction_fitness,ai_generated_debt,api_surface_coherence,authorization_consistency,contract_coherence,convention_outlier,cross_module_architecture,dependency_health,design_coherence,error_consistency,high_level_elegance,incomplete_migration,initialization_coupling,logic_clarity,low_level_elegance,mid_level_elegance,naming_quality,package_organization,test_strategy,type_safety",
+      "user_modified": false
+    }
+  },
+  "superseded": {},
+  "promoted_ids": [],
+  "plan_start_scores": {
+    "strict": 15.7,
+    "overall": 15.7,
+    "objective": 62.8,
+    "verified": 62.8
+  },
+  "refresh_state": {
+    "lifecycle_phase": "execute"
+  },
+  "execution_log": [
+    {
+      "timestamp": "2026-03-18T06:35:27+00:00",
+      "action": "sync_subjective",
+      "issue_ids": [],
+      "cluster_name": null,
+      "actor": "system",
+      "note": null,
+      "detail": {
+        "changes": true
+      }
+    },
+    {
+      "timestamp": "2026-03-18T06:35:27+00:00",
+      "action": "auto_cluster",
+      "issue_ids": [],
+      "cluster_name": null,
+      "actor": "system",
+      "note": null,
+      "detail": {
+        "changes": true
+      }
+    },
+    {
+      "timestamp": "2026-03-18T06:35:27+00:00",
+      "action": "seed_start_scores",
+      "issue_ids": [],
+      "cluster_name": null,
+      "actor": "system",
+      "note": null,
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-03-18T06:35:28+00:00",
+      "action": "sync_lifecycle_phase",
+      "issue_ids": [],
+      "cluster_name": null,
+      "actor": "system",
+      "note": null,
+      "detail": {
+        "phase": "execute"
+      }
+    }
+  ],
+  "epic_triage_meta": {},
+  "commit_log": [],
+  "uncommitted_issues": [],
+  "commit_tracking_branch": null,
+  "scan_count_at_plan_start": 1
+}

--- a/.desloppify/query.json
+++ b/.desloppify/query.json
@@ -1,0 +1,1186 @@
+{
+  "command": "scan",
+  "overall_score": 15.7,
+  "objective_score": 62.8,
+  "strict_score": 15.7,
+  "verified_strict_score": 62.8,
+  "prev_overall_score": 0.0,
+  "prev_objective_score": 0.0,
+  "prev_strict_score": 0.0,
+  "prev_verified_strict_score": 0.0,
+  "profile": "ci",
+  "noise_budget": 10,
+  "noise_global_budget": 0,
+  "hidden_by_detector": {},
+  "hidden_total": 0,
+  "diff": {
+    "new": 5,
+    "auto_resolved": 0,
+    "reopened": 0,
+    "total_current": 5,
+    "suspect_detectors": [
+      "review"
+    ],
+    "chronic_reopeners": [],
+    "skipped_other_lang": 0,
+    "resolved_out_of_scope": 0,
+    "ignored": 0,
+    "ignore_patterns": 0,
+    "raw_issues": 5,
+    "suppressed_pct": 0.0
+  },
+  "stats": {
+    "total": 5,
+    "auto_resolved": 0,
+    "deferred": 0,
+    "false_positive": 0,
+    "fixed": 0,
+    "open": 5,
+    "triaged_out": 0,
+    "wontfix": 0,
+    "by_tier": {
+      "3": {
+        "auto_resolved": 0,
+        "deferred": 0,
+        "false_positive": 0,
+        "fixed": 0,
+        "open": 5,
+        "triaged_out": 0,
+        "wontfix": 0
+      }
+    }
+  },
+  "open_scope": {
+    "in_scope": 5,
+    "out_of_scope": 0,
+    "global": 5
+  },
+  "warnings": [],
+  "dimension_scores": {
+    "Code quality": {
+      "score": 90.0,
+      "strict": 90.0,
+      "verified_strict_score": 90.0,
+      "checks": 21,
+      "failing": 3,
+      "tier": 3,
+      "detectors": {
+        "unused": {
+          "potential": 2,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "logs": {
+          "potential": 2,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "smells": {
+          "potential": 5,
+          "pass_rate": 0.86,
+          "failing": 1,
+          "weighted_failures": 0.7
+        },
+        "orphaned": {
+          "potential": 4,
+          "pass_rate": 0.65,
+          "failing": 2,
+          "weighted_failures": 1.4
+        },
+        "flat_dirs": {
+          "potential": 1,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "naming": {
+          "potential": 1,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "single_use": {
+          "potential": 2,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "facade": {
+          "potential": 4,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        }
+      }
+    },
+    "Security": {
+      "score": 100.0,
+      "strict": 100.0,
+      "verified_strict_score": 100.0,
+      "checks": 6,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "cycles": {
+          "potential": 4,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "security": {
+          "potential": 2,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        }
+      }
+    },
+    "File health": {
+      "score": 100.0,
+      "strict": 100.0,
+      "verified_strict_score": 100.0,
+      "checks": 2,
+      "failing": 0,
+      "tier": 3,
+      "detectors": {
+        "structural": {
+          "potential": 2,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        }
+      }
+    },
+    "Test health": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 15,
+      "failing": 2,
+      "tier": 4,
+      "detectors": {
+        "test_coverage": {
+          "potential": 15,
+          "pass_rate": 0.0,
+          "failing": 2,
+          "weighted_failures": 15.403648594301345
+        }
+      }
+    },
+    "Abstraction fit": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "abstraction_fitness",
+          "configured_weight": 8.0,
+          "components": []
+        }
+      }
+    },
+    "AI generated debt": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "ai_generated_debt",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "API coherence": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "api_surface_coherence",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Auth consistency": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "authorization_consistency",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Contracts": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "contract_coherence",
+          "configured_weight": 12.0,
+          "components": []
+        }
+      }
+    },
+    "Convention drift": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "convention_outlier",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Cross-module arch": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "cross_module_architecture",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Dep health": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "dependency_health",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Design coherence": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "design_coherence",
+          "configured_weight": 10.0,
+          "components": []
+        }
+      }
+    },
+    "Error consistency": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "error_consistency",
+          "configured_weight": 3.0,
+          "components": []
+        }
+      }
+    },
+    "High elegance": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "high_level_elegance",
+          "configured_weight": 22.0,
+          "components": []
+        }
+      }
+    },
+    "Stale migration": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "incomplete_migration",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Init coupling": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "initialization_coupling",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Logic clarity": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "logic_clarity",
+          "configured_weight": 6.0,
+          "components": []
+        }
+      }
+    },
+    "Low elegance": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "low_level_elegance",
+          "configured_weight": 12.0,
+          "components": []
+        }
+      }
+    },
+    "Mid elegance": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "mid_level_elegance",
+          "configured_weight": 22.0,
+          "components": []
+        }
+      }
+    },
+    "Naming quality": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "naming_quality",
+          "configured_weight": 2.0,
+          "components": []
+        }
+      }
+    },
+    "Structure nav": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "package_organization",
+          "configured_weight": 5.0,
+          "components": []
+        }
+      }
+    },
+    "Test strategy": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "test_strategy",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Type safety": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "type_safety",
+          "configured_weight": 12.0,
+          "components": []
+        }
+      }
+    }
+  },
+  "score_breakdown": {
+    "overall_score": 15.7,
+    "mechanical_fraction": 0.25,
+    "subjective_fraction": 0.75,
+    "mechanical_avg": 62.82608695652174,
+    "subjective_avg": 0.0,
+    "entries": [
+      {
+        "name": "Code quality",
+        "pool": "mechanical",
+        "score": 90.0,
+        "checks": 21.0,
+        "sample_factor": 0.105,
+        "configured_weight": 1.0,
+        "effective_weight": 0.105,
+        "pool_share": 0.4565217391304348,
+        "overall_per_point": 0.1141304347826087,
+        "overall_contribution": 10.271739130434783,
+        "overall_drag": 1.141304347826087
+      },
+      {
+        "name": "Security",
+        "pool": "mechanical",
+        "score": 100.0,
+        "checks": 6.0,
+        "sample_factor": 0.03,
+        "configured_weight": 1.0,
+        "effective_weight": 0.03,
+        "pool_share": 0.13043478260869565,
+        "overall_per_point": 0.03260869565217391,
+        "overall_contribution": 3.260869565217391,
+        "overall_drag": 0.0
+      },
+      {
+        "name": "File health",
+        "pool": "mechanical",
+        "score": 100.0,
+        "checks": 2.0,
+        "sample_factor": 0.01,
+        "configured_weight": 2.0,
+        "effective_weight": 0.02,
+        "pool_share": 0.08695652173913045,
+        "overall_per_point": 0.02173913043478261,
+        "overall_contribution": 2.173913043478261,
+        "overall_drag": 0.0
+      },
+      {
+        "name": "Test health",
+        "pool": "mechanical",
+        "score": 0.0,
+        "checks": 15.0,
+        "sample_factor": 0.075,
+        "configured_weight": 1.0,
+        "effective_weight": 0.075,
+        "pool_share": 0.32608695652173914,
+        "overall_per_point": 0.08152173913043478,
+        "overall_contribution": 0.0,
+        "overall_drag": 8.152173913043478
+      },
+      {
+        "name": "Abstraction fit",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 8.0,
+        "effective_weight": 8.0,
+        "pool_share": 0.06504065040650407,
+        "overall_per_point": 0.04878048780487805,
+        "overall_contribution": 0.0,
+        "overall_drag": 4.878048780487805
+      },
+      {
+        "name": "AI generated debt",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 1.0,
+        "effective_weight": 1.0,
+        "pool_share": 0.008130081300813009,
+        "overall_per_point": 0.006097560975609756,
+        "overall_contribution": 0.0,
+        "overall_drag": 0.6097560975609756
+      },
+      {
+        "name": "API coherence",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 1.0,
+        "effective_weight": 1.0,
+        "pool_share": 0.008130081300813009,
+        "overall_per_point": 0.006097560975609756,
+        "overall_contribution": 0.0,
+        "overall_drag": 0.6097560975609756
+      },
+      {
+        "name": "Auth consistency",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 1.0,
+        "effective_weight": 1.0,
+        "pool_share": 0.008130081300813009,
+        "overall_per_point": 0.006097560975609756,
+        "overall_contribution": 0.0,
+        "overall_drag": 0.6097560975609756
+      },
+      {
+        "name": "Contracts",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 12.0,
+        "effective_weight": 12.0,
+        "pool_share": 0.0975609756097561,
+        "overall_per_point": 0.07317073170731708,
+        "overall_contribution": 0.0,
+        "overall_drag": 7.3170731707317085
+      },
+      {
+        "name": "Convention drift",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 1.0,
+        "effective_weight": 1.0,
+        "pool_share": 0.008130081300813009,
+        "overall_per_point": 0.006097560975609756,
+        "overall_contribution": 0.0,
+        "overall_drag": 0.6097560975609756
+      },
+      {
+        "name": "Cross-module arch",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 1.0,
+        "effective_weight": 1.0,
+        "pool_share": 0.008130081300813009,
+        "overall_per_point": 0.006097560975609756,
+        "overall_contribution": 0.0,
+        "overall_drag": 0.6097560975609756
+      },
+      {
+        "name": "Dep health",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 1.0,
+        "effective_weight": 1.0,
+        "pool_share": 0.008130081300813009,
+        "overall_per_point": 0.006097560975609756,
+        "overall_contribution": 0.0,
+        "overall_drag": 0.6097560975609756
+      },
+      {
+        "name": "Design coherence",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 10.0,
+        "effective_weight": 10.0,
+        "pool_share": 0.08130081300813008,
+        "overall_per_point": 0.06097560975609756,
+        "overall_contribution": 0.0,
+        "overall_drag": 6.097560975609756
+      },
+      {
+        "name": "Error consistency",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 3.0,
+        "effective_weight": 3.0,
+        "pool_share": 0.024390243902439025,
+        "overall_per_point": 0.01829268292682927,
+        "overall_contribution": 0.0,
+        "overall_drag": 1.8292682926829271
+      },
+      {
+        "name": "High elegance",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 22.0,
+        "effective_weight": 22.0,
+        "pool_share": 0.17886178861788618,
+        "overall_per_point": 0.13414634146341464,
+        "overall_contribution": 0.0,
+        "overall_drag": 13.414634146341465
+      },
+      {
+        "name": "Stale migration",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 1.0,
+        "effective_weight": 1.0,
+        "pool_share": 0.008130081300813009,
+        "overall_per_point": 0.006097560975609756,
+        "overall_contribution": 0.0,
+        "overall_drag": 0.6097560975609756
+      },
+      {
+        "name": "Init coupling",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 1.0,
+        "effective_weight": 1.0,
+        "pool_share": 0.008130081300813009,
+        "overall_per_point": 0.006097560975609756,
+        "overall_contribution": 0.0,
+        "overall_drag": 0.6097560975609756
+      },
+      {
+        "name": "Logic clarity",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 6.0,
+        "effective_weight": 6.0,
+        "pool_share": 0.04878048780487805,
+        "overall_per_point": 0.03658536585365854,
+        "overall_contribution": 0.0,
+        "overall_drag": 3.6585365853658542
+      },
+      {
+        "name": "Low elegance",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 12.0,
+        "effective_weight": 12.0,
+        "pool_share": 0.0975609756097561,
+        "overall_per_point": 0.07317073170731708,
+        "overall_contribution": 0.0,
+        "overall_drag": 7.3170731707317085
+      },
+      {
+        "name": "Mid elegance",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 22.0,
+        "effective_weight": 22.0,
+        "pool_share": 0.17886178861788618,
+        "overall_per_point": 0.13414634146341464,
+        "overall_contribution": 0.0,
+        "overall_drag": 13.414634146341465
+      },
+      {
+        "name": "Naming quality",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 2.0,
+        "effective_weight": 2.0,
+        "pool_share": 0.016260162601626018,
+        "overall_per_point": 0.012195121951219513,
+        "overall_contribution": 0.0,
+        "overall_drag": 1.2195121951219512
+      },
+      {
+        "name": "Structure nav",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 5.0,
+        "effective_weight": 5.0,
+        "pool_share": 0.04065040650406504,
+        "overall_per_point": 0.03048780487804878,
+        "overall_contribution": 0.0,
+        "overall_drag": 3.048780487804878
+      },
+      {
+        "name": "Test strategy",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 1.0,
+        "effective_weight": 1.0,
+        "pool_share": 0.008130081300813009,
+        "overall_per_point": 0.006097560975609756,
+        "overall_contribution": 0.0,
+        "overall_drag": 0.6097560975609756
+      },
+      {
+        "name": "Type safety",
+        "pool": "subjective",
+        "score": 0.0,
+        "checks": 0.0,
+        "sample_factor": 1.0,
+        "configured_weight": 12.0,
+        "effective_weight": 12.0,
+        "pool_share": 0.0975609756097561,
+        "overall_per_point": 0.07317073170731708,
+        "overall_contribution": 0.0,
+        "overall_drag": 7.3170731707317085
+      }
+    ]
+  },
+  "subjective_integrity": {
+    "status": "pass",
+    "target_score": 95.0,
+    "matched_count": 0,
+    "matched_dimensions": [],
+    "reset_dimensions": []
+  },
+  "score_confidence": {
+    "status": "full",
+    "confidence": 1.0,
+    "detectors": [],
+    "dimensions": []
+  },
+  "potentials": {
+    "typescript": {
+      "logs": 2,
+      "unused": 2,
+      "exports": 0,
+      "deprecated": 0,
+      "structural": 2,
+      "flat_dirs": 1,
+      "props": 0,
+      "single_use": 2,
+      "coupling": 0,
+      "cycles": 4,
+      "orphaned": 4,
+      "patterns": 0,
+      "naming": 1,
+      "facade": 4,
+      "test_coverage": 15,
+      "smells": 5,
+      "react": 0,
+      "security": 2,
+      "stale_wontfix": 0
+    }
+  },
+  "scan_coverage": {
+    "typescript": {
+      "status": "full",
+      "confidence": 1.0,
+      "detectors": {
+        "security": {
+          "detector": "security",
+          "status": "full",
+          "confidence": 1.0,
+          "summary": "Security coverage complete for enabled detectors.",
+          "impact": "",
+          "remediation": "",
+          "tool": "",
+          "reason": ""
+        }
+      },
+      "warnings": [],
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    }
+  },
+  "zone_distribution": {
+    "production": 2
+  },
+  "narrative": {
+    "phase": "first_scan",
+    "headline": "First scan complete. 5 open issues across 3 dimensions.",
+    "dimensions": {
+      "lowest_dimensions": [
+        {
+          "name": "Test health",
+          "strict": 0.0,
+          "failing": 2,
+          "impact": 0.0
+        },
+        {
+          "name": "Abstraction fit",
+          "strict": 0.0,
+          "failing": 0,
+          "impact": 0.0,
+          "subjective": true,
+          "impact_description": "re-review to improve"
+        },
+        {
+          "name": "AI generated debt",
+          "strict": 0.0,
+          "failing": 0,
+          "impact": 0.0,
+          "subjective": true,
+          "impact_description": "re-review to improve"
+        }
+      ],
+      "biggest_gap_dimensions": [],
+      "stagnant_dimensions": []
+    },
+    "actions": [
+      {
+        "type": "reorganize",
+        "detector": "orphaned",
+        "count": 2,
+        "description": "2 orphaned issues \u2014 delete dead files or relocate with `desloppify move`",
+        "command": "desloppify show orphaned --status open",
+        "impact": 0.0,
+        "dimension": "Code quality",
+        "priority": 1,
+        "lane": "restructure"
+      },
+      {
+        "type": "refactor",
+        "detector": "test_coverage",
+        "count": 2,
+        "description": "2 test_coverage issues in 1 cluster(s) \u2014 run `desloppify next`",
+        "command": "desloppify next",
+        "impact": 0.0,
+        "dimension": "Test health",
+        "priority": 2,
+        "clusters": [
+          "auto/test_coverage"
+        ],
+        "cluster_count": 1,
+        "lane": "test_coverage"
+      },
+      {
+        "type": "manual_fix",
+        "detector": "smells",
+        "count": 1,
+        "description": "1 smells issues \u2014 inspect with `desloppify next` and fix manually",
+        "command": "desloppify show smells --status open",
+        "impact": 0.0,
+        "dimension": "Code quality",
+        "priority": 3,
+        "lane": "refactor"
+      }
+    ],
+    "strategy": {
+      "fixer_leverage": {
+        "auto_fixable_count": 0,
+        "total_count": 5,
+        "coverage": 0.0,
+        "impact_ratio": 0.0,
+        "recommendation": "none"
+      },
+      "lanes": {
+        "restructure": {
+          "actions": [
+            1
+          ],
+          "file_count": 2,
+          "total_impact": 0.0,
+          "automation": "manual",
+          "run_first": false
+        },
+        "refactor": {
+          "actions": [
+            3
+          ],
+          "file_count": 1,
+          "total_impact": 0.0,
+          "automation": "manual",
+          "run_first": false
+        },
+        "test_coverage": {
+          "actions": [
+            2
+          ],
+          "file_count": 2,
+          "total_impact": 0.0,
+          "automation": "manual",
+          "run_first": false
+        }
+      },
+      "can_parallelize": false,
+      "hint": "Work through actions in priority order. Rescan after each fix to track progress."
+    },
+    "tools": {
+      "fixers": [
+        {
+          "name": "dead-useeffect",
+          "detector": "smells",
+          "open_count": 1,
+          "command": "desloppify autofix dead-useeffect --dry-run"
+        },
+        {
+          "name": "empty-if-chain",
+          "detector": "smells",
+          "open_count": 1,
+          "command": "desloppify autofix empty-if-chain --dry-run"
+        }
+      ],
+      "move": {
+        "available": true,
+        "relevant": true,
+        "reason": "2 orphaned files",
+        "usage": "desloppify move <source> <dest> [--dry-run]"
+      },
+      "plan": {
+        "command": "desloppify plan",
+        "description": "Generate prioritized markdown cleanup plan"
+      },
+      "badge": {
+        "generated": false,
+        "in_readme": false,
+        "path": "scorecard.png",
+        "recommendation": null
+      }
+    },
+    "debt": {
+      "overall_gap": 0.0,
+      "wontfix_count": 0,
+      "worst_dimension": null,
+      "worst_gap": 0.0,
+      "trend": "stable"
+    },
+    "milestone": null,
+    "primary_action": {
+      "command": "desloppify show orphaned --status open",
+      "description": "2 orphaned issues \u2014 delete dead files or relocate with `desloppify move`"
+    },
+    "why_now": "Work through actions in priority order. Rescan after each fix to track progress.",
+    "verification_step": {
+      "command": "desloppify scan",
+      "reason": "revalidate after changes"
+    },
+    "risk_flags": [],
+    "strict_target": {
+      "target": 95.0,
+      "current": 15.7,
+      "gap": 79.3,
+      "state": "below",
+      "warning": null
+    },
+    "reminders": [
+      {
+        "type": "report_scores",
+        "message": "ALWAYS share ALL scores with the user: overall, objective, and strict, plus every dimension score (lenient + strict), including subjective dimensions. The goal is to maximize strict scores.",
+        "command": null,
+        "no_decay": true,
+        "priority": 3,
+        "severity": "low"
+      }
+    ],
+    "reminder_history": {
+      "report_scores": 1
+    }
+  },
+  "config": {
+    "target_strict_score": 95,
+    "review_max_age_days": 30,
+    "review_batch_max_files": 80,
+    "holistic_max_age_days": 30,
+    "generate_scorecard": true,
+    "badge_path": "scorecard.png",
+    "exclude": [],
+    "ignore": [],
+    "ignore_metadata": {},
+    "zone_overrides": {},
+    "review_dimensions": [],
+    "large_files_threshold": 0,
+    "props_threshold": 0,
+    "issue_noise_budget": 10,
+    "issue_noise_global_budget": 0,
+    "execution_log_max_entries": 10000,
+    "needs_rescan": false,
+    "languages": {},
+    "commit_tracking_enabled": true,
+    "commit_pr": 0,
+    "commit_default_branch": "",
+    "commit_message_template": "desloppify: {status} {count} issue(s) \u2014 {summary}",
+    "trust_plugins": false
+  },
+  "plan": {
+    "active": true,
+    "focus": null,
+    "total_ordered": 20,
+    "total_skipped": 0,
+    "plan_overrides_narrative": true
+  }
+}

--- a/.desloppify/state-typescript.json
+++ b/.desloppify/state-typescript.json
@@ -1,0 +1,910 @@
+{
+  "version": 1,
+  "created": "2026-03-18T06:35:23+00:00",
+  "last_scan": "2026-03-18T06:35:27+00:00",
+  "scan_count": 1,
+  "overall_score": 15.7,
+  "objective_score": 62.8,
+  "strict_score": 15.7,
+  "verified_strict_score": 62.8,
+  "stats": {
+    "total": 5,
+    "auto_resolved": 0,
+    "deferred": 0,
+    "false_positive": 0,
+    "fixed": 0,
+    "open": 5,
+    "triaged_out": 0,
+    "wontfix": 0,
+    "by_tier": {
+      "3": {
+        "auto_resolved": 0,
+        "deferred": 0,
+        "false_positive": 0,
+        "fixed": 0,
+        "open": 5,
+        "triaged_out": 0,
+        "wontfix": 0
+      }
+    }
+  },
+  "issues": {
+    "orphaned::src/app/page.tsx": {
+      "id": "orphaned::src/app/page.tsx",
+      "detector": "orphaned",
+      "file": "src/app/page.tsx",
+      "tier": 3,
+      "confidence": "medium",
+      "summary": "Orphaned file (95 LOC): zero importers, not an entry point",
+      "detail": {
+        "loc": 95
+      },
+      "status": "open",
+      "note": null,
+      "first_seen": "2026-03-18T06:35:27+00:00",
+      "last_seen": "2026-03-18T06:35:27+00:00",
+      "resolved_at": null,
+      "reopen_count": 0,
+      "lang": "typescript",
+      "zone": "production",
+      "suppressed": false,
+      "suppressed_at": null,
+      "suppression_pattern": null
+    },
+    "orphaned::src/app/layout.tsx": {
+      "id": "orphaned::src/app/layout.tsx",
+      "detector": "orphaned",
+      "file": "src/app/layout.tsx",
+      "tier": 3,
+      "confidence": "medium",
+      "summary": "Orphaned file (32 LOC): zero importers, not an entry point",
+      "detail": {
+        "loc": 32
+      },
+      "status": "open",
+      "note": null,
+      "first_seen": "2026-03-18T06:35:27+00:00",
+      "last_seen": "2026-03-18T06:35:27+00:00",
+      "resolved_at": null,
+      "reopen_count": 0,
+      "lang": "typescript",
+      "zone": "production",
+      "suppressed": false,
+      "suppressed_at": null,
+      "suppression_pattern": null
+    },
+    "test_coverage::src/app/page.tsx": {
+      "id": "test_coverage::src/app/page.tsx",
+      "detector": "test_coverage",
+      "file": "src/app/page.tsx",
+      "tier": 3,
+      "confidence": "high",
+      "summary": "Untested module (95 LOC, 0 importers) \u2014 no test files found",
+      "detail": {
+        "kind": "untested_module",
+        "loc": 95,
+        "importer_count": 0,
+        "loc_weight": 9.746794344808963
+      },
+      "status": "open",
+      "note": null,
+      "first_seen": "2026-03-18T06:35:27+00:00",
+      "last_seen": "2026-03-18T06:35:27+00:00",
+      "resolved_at": null,
+      "reopen_count": 0,
+      "lang": "typescript",
+      "zone": "production",
+      "suppressed": false,
+      "suppressed_at": null,
+      "suppression_pattern": null
+    },
+    "test_coverage::src/app/layout.tsx": {
+      "id": "test_coverage::src/app/layout.tsx",
+      "detector": "test_coverage",
+      "file": "src/app/layout.tsx",
+      "tier": 3,
+      "confidence": "high",
+      "summary": "Untested module (32 LOC, 0 importers) \u2014 no test files found",
+      "detail": {
+        "kind": "untested_module",
+        "loc": 32,
+        "importer_count": 0,
+        "loc_weight": 5.656854249492381
+      },
+      "status": "open",
+      "note": null,
+      "first_seen": "2026-03-18T06:35:27+00:00",
+      "last_seen": "2026-03-18T06:35:27+00:00",
+      "resolved_at": null,
+      "reopen_count": 0,
+      "lang": "typescript",
+      "zone": "production",
+      "suppressed": false,
+      "suppressed_at": null,
+      "suppression_pattern": null
+    },
+    "smells::src/app/page.tsx::hardcoded_url": {
+      "id": "smells::src/app/page.tsx::hardcoded_url",
+      "detector": "smells",
+      "file": "src/app/page.tsx",
+      "tier": 3,
+      "confidence": "medium",
+      "summary": "5x Hardcoded URL in source code",
+      "detail": {
+        "smell_id": "hardcoded_url",
+        "severity": "medium",
+        "count": 5,
+        "lines": [
+          26,
+          40,
+          51,
+          65,
+          79
+        ]
+      },
+      "status": "open",
+      "note": null,
+      "first_seen": "2026-03-18T06:35:27+00:00",
+      "last_seen": "2026-03-18T06:35:27+00:00",
+      "resolved_at": null,
+      "reopen_count": 0,
+      "lang": "typescript",
+      "zone": "production",
+      "suppressed": false,
+      "suppressed_at": null,
+      "suppression_pattern": null
+    }
+  },
+  "scan_coverage": {
+    "typescript": {
+      "status": "full",
+      "confidence": 1.0,
+      "detectors": {
+        "security": {
+          "detector": "security",
+          "status": "full",
+          "confidence": 1.0,
+          "summary": "Security coverage complete for enabled detectors.",
+          "impact": "",
+          "remediation": "",
+          "tool": "",
+          "reason": ""
+        }
+      },
+      "warnings": [],
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    }
+  },
+  "score_confidence": {
+    "status": "full",
+    "confidence": 1.0,
+    "detectors": [],
+    "dimensions": []
+  },
+  "scan_metadata": {
+    "source": "scan"
+  },
+  "subjective_integrity": {
+    "status": "pass",
+    "target_score": 95.0,
+    "matched_count": 0,
+    "matched_dimensions": [],
+    "reset_dimensions": []
+  },
+  "subjective_assessments": {},
+  "scan_history": [
+    {
+      "timestamp": "2026-03-18T06:35:27+00:00",
+      "lang": "typescript",
+      "strict_score": 15.7,
+      "verified_strict_score": 62.8,
+      "objective_score": 62.8,
+      "overall_score": 15.7,
+      "open": 5,
+      "diff_new": 5,
+      "diff_resolved": 0,
+      "ignored": 0,
+      "raw_issues": 5,
+      "suppressed_pct": 0.0,
+      "ignore_patterns": 0,
+      "subjective_integrity": {
+        "status": "pass",
+        "matched_count": 0,
+        "reset_count": 0,
+        "target_score": 95.0
+      },
+      "score_confidence": {
+        "status": "full",
+        "confidence": 1.0,
+        "detector_count": 0,
+        "dimension_count": 0
+      },
+      "dimension_scores": {
+        "Code quality": {
+          "score": 90.0,
+          "strict": 90.0
+        },
+        "Security": {
+          "score": 100.0,
+          "strict": 100.0
+        },
+        "File health": {
+          "score": 100.0,
+          "strict": 100.0
+        },
+        "Test health": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Abstraction fit": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "AI generated debt": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "API coherence": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Auth consistency": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Contracts": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Convention drift": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Cross-module arch": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Dep health": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Design coherence": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Error consistency": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "High elegance": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Stale migration": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Init coupling": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Logic clarity": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Low elegance": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Mid elegance": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Naming quality": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Structure nav": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Test strategy": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Type safety": {
+          "score": 0.0,
+          "strict": 0.0
+        }
+      }
+    }
+  ],
+  "lang_capabilities": {
+    "typescript": {
+      "fixers": [
+        "dead-useeffect",
+        "debug-logs",
+        "empty-if-chain",
+        "unused-imports",
+        "unused-params",
+        "unused-vars"
+      ],
+      "typecheck_cmd": "npx tsc --noEmit"
+    }
+  },
+  "zone_distribution": {
+    "production": 2
+  },
+  "tool_hash": "dd6f84c96708",
+  "scan_path": "src",
+  "scan_completeness": {
+    "typescript": "fast"
+  },
+  "potentials": {
+    "typescript": {
+      "logs": 2,
+      "unused": 2,
+      "exports": 0,
+      "deprecated": 0,
+      "structural": 2,
+      "flat_dirs": 1,
+      "props": 0,
+      "single_use": 2,
+      "coupling": 0,
+      "cycles": 4,
+      "orphaned": 4,
+      "patterns": 0,
+      "naming": 1,
+      "facade": 4,
+      "test_coverage": 15,
+      "smells": 5,
+      "react": 0,
+      "security": 2,
+      "stale_wontfix": 0
+    }
+  },
+  "codebase_metrics": {
+    "typescript": {
+      "total_files": 2,
+      "total_loc": 127,
+      "total_directories": 1
+    }
+  },
+  "dimension_scores": {
+    "Code quality": {
+      "score": 90.0,
+      "strict": 90.0,
+      "verified_strict_score": 90.0,
+      "checks": 21,
+      "failing": 3,
+      "tier": 3,
+      "detectors": {
+        "unused": {
+          "potential": 2,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "logs": {
+          "potential": 2,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "smells": {
+          "potential": 5,
+          "pass_rate": 0.86,
+          "failing": 1,
+          "weighted_failures": 0.7
+        },
+        "orphaned": {
+          "potential": 4,
+          "pass_rate": 0.65,
+          "failing": 2,
+          "weighted_failures": 1.4
+        },
+        "flat_dirs": {
+          "potential": 1,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "naming": {
+          "potential": 1,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "single_use": {
+          "potential": 2,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "facade": {
+          "potential": 4,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        }
+      }
+    },
+    "Security": {
+      "score": 100.0,
+      "strict": 100.0,
+      "verified_strict_score": 100.0,
+      "checks": 6,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "cycles": {
+          "potential": 4,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "security": {
+          "potential": 2,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        }
+      }
+    },
+    "File health": {
+      "score": 100.0,
+      "strict": 100.0,
+      "verified_strict_score": 100.0,
+      "checks": 2,
+      "failing": 0,
+      "tier": 3,
+      "detectors": {
+        "structural": {
+          "potential": 2,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        }
+      }
+    },
+    "Test health": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 15,
+      "failing": 2,
+      "tier": 4,
+      "detectors": {
+        "test_coverage": {
+          "potential": 15,
+          "pass_rate": 0.0,
+          "failing": 2,
+          "weighted_failures": 15.403648594301345
+        }
+      }
+    },
+    "Abstraction fit": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "abstraction_fitness",
+          "configured_weight": 8.0,
+          "components": []
+        }
+      }
+    },
+    "AI generated debt": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "ai_generated_debt",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "API coherence": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "api_surface_coherence",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Auth consistency": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "authorization_consistency",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Contracts": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "contract_coherence",
+          "configured_weight": 12.0,
+          "components": []
+        }
+      }
+    },
+    "Convention drift": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "convention_outlier",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Cross-module arch": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "cross_module_architecture",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Dep health": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "dependency_health",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Design coherence": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "design_coherence",
+          "configured_weight": 10.0,
+          "components": []
+        }
+      }
+    },
+    "Error consistency": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "error_consistency",
+          "configured_weight": 3.0,
+          "components": []
+        }
+      }
+    },
+    "High elegance": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "high_level_elegance",
+          "configured_weight": 22.0,
+          "components": []
+        }
+      }
+    },
+    "Stale migration": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "incomplete_migration",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Init coupling": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "initialization_coupling",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Logic clarity": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "logic_clarity",
+          "configured_weight": 6.0,
+          "components": []
+        }
+      }
+    },
+    "Low elegance": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "low_level_elegance",
+          "configured_weight": 12.0,
+          "components": []
+        }
+      }
+    },
+    "Mid elegance": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "mid_level_elegance",
+          "configured_weight": 22.0,
+          "components": []
+        }
+      }
+    },
+    "Naming quality": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "naming_quality",
+          "configured_weight": 2.0,
+          "components": []
+        }
+      }
+    },
+    "Structure nav": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "package_organization",
+          "configured_weight": 5.0,
+          "components": []
+        }
+      }
+    },
+    "Test strategy": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "test_strategy",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Type safety": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "type_safety",
+          "configured_weight": 12.0,
+          "components": []
+        }
+      }
+    }
+  },
+  "reminder_history": {
+    "report_scores": 1
+  }
+}

--- a/.desloppify/state-typescript.json.bak
+++ b/.desloppify/state-typescript.json.bak
@@ -1,0 +1,907 @@
+{
+  "version": 1,
+  "created": "2026-03-18T06:35:23+00:00",
+  "last_scan": "2026-03-18T06:35:27+00:00",
+  "scan_count": 1,
+  "overall_score": 15.7,
+  "objective_score": 62.8,
+  "strict_score": 15.7,
+  "verified_strict_score": 62.8,
+  "stats": {
+    "total": 5,
+    "auto_resolved": 0,
+    "deferred": 0,
+    "false_positive": 0,
+    "fixed": 0,
+    "open": 5,
+    "triaged_out": 0,
+    "wontfix": 0,
+    "by_tier": {
+      "3": {
+        "auto_resolved": 0,
+        "deferred": 0,
+        "false_positive": 0,
+        "fixed": 0,
+        "open": 5,
+        "triaged_out": 0,
+        "wontfix": 0
+      }
+    }
+  },
+  "issues": {
+    "orphaned::src/app/page.tsx": {
+      "id": "orphaned::src/app/page.tsx",
+      "detector": "orphaned",
+      "file": "src/app/page.tsx",
+      "tier": 3,
+      "confidence": "medium",
+      "summary": "Orphaned file (95 LOC): zero importers, not an entry point",
+      "detail": {
+        "loc": 95
+      },
+      "status": "open",
+      "note": null,
+      "first_seen": "2026-03-18T06:35:27+00:00",
+      "last_seen": "2026-03-18T06:35:27+00:00",
+      "resolved_at": null,
+      "reopen_count": 0,
+      "lang": "typescript",
+      "zone": "production",
+      "suppressed": false,
+      "suppressed_at": null,
+      "suppression_pattern": null
+    },
+    "orphaned::src/app/layout.tsx": {
+      "id": "orphaned::src/app/layout.tsx",
+      "detector": "orphaned",
+      "file": "src/app/layout.tsx",
+      "tier": 3,
+      "confidence": "medium",
+      "summary": "Orphaned file (32 LOC): zero importers, not an entry point",
+      "detail": {
+        "loc": 32
+      },
+      "status": "open",
+      "note": null,
+      "first_seen": "2026-03-18T06:35:27+00:00",
+      "last_seen": "2026-03-18T06:35:27+00:00",
+      "resolved_at": null,
+      "reopen_count": 0,
+      "lang": "typescript",
+      "zone": "production",
+      "suppressed": false,
+      "suppressed_at": null,
+      "suppression_pattern": null
+    },
+    "test_coverage::src/app/page.tsx": {
+      "id": "test_coverage::src/app/page.tsx",
+      "detector": "test_coverage",
+      "file": "src/app/page.tsx",
+      "tier": 3,
+      "confidence": "high",
+      "summary": "Untested module (95 LOC, 0 importers) \u2014 no test files found",
+      "detail": {
+        "kind": "untested_module",
+        "loc": 95,
+        "importer_count": 0,
+        "loc_weight": 9.746794344808963
+      },
+      "status": "open",
+      "note": null,
+      "first_seen": "2026-03-18T06:35:27+00:00",
+      "last_seen": "2026-03-18T06:35:27+00:00",
+      "resolved_at": null,
+      "reopen_count": 0,
+      "lang": "typescript",
+      "zone": "production",
+      "suppressed": false,
+      "suppressed_at": null,
+      "suppression_pattern": null
+    },
+    "test_coverage::src/app/layout.tsx": {
+      "id": "test_coverage::src/app/layout.tsx",
+      "detector": "test_coverage",
+      "file": "src/app/layout.tsx",
+      "tier": 3,
+      "confidence": "high",
+      "summary": "Untested module (32 LOC, 0 importers) \u2014 no test files found",
+      "detail": {
+        "kind": "untested_module",
+        "loc": 32,
+        "importer_count": 0,
+        "loc_weight": 5.656854249492381
+      },
+      "status": "open",
+      "note": null,
+      "first_seen": "2026-03-18T06:35:27+00:00",
+      "last_seen": "2026-03-18T06:35:27+00:00",
+      "resolved_at": null,
+      "reopen_count": 0,
+      "lang": "typescript",
+      "zone": "production",
+      "suppressed": false,
+      "suppressed_at": null,
+      "suppression_pattern": null
+    },
+    "smells::src/app/page.tsx::hardcoded_url": {
+      "id": "smells::src/app/page.tsx::hardcoded_url",
+      "detector": "smells",
+      "file": "src/app/page.tsx",
+      "tier": 3,
+      "confidence": "medium",
+      "summary": "5x Hardcoded URL in source code",
+      "detail": {
+        "smell_id": "hardcoded_url",
+        "severity": "medium",
+        "count": 5,
+        "lines": [
+          26,
+          40,
+          51,
+          65,
+          79
+        ]
+      },
+      "status": "open",
+      "note": null,
+      "first_seen": "2026-03-18T06:35:27+00:00",
+      "last_seen": "2026-03-18T06:35:27+00:00",
+      "resolved_at": null,
+      "reopen_count": 0,
+      "lang": "typescript",
+      "zone": "production",
+      "suppressed": false,
+      "suppressed_at": null,
+      "suppression_pattern": null
+    }
+  },
+  "scan_coverage": {
+    "typescript": {
+      "status": "full",
+      "confidence": 1.0,
+      "detectors": {
+        "security": {
+          "detector": "security",
+          "status": "full",
+          "confidence": 1.0,
+          "summary": "Security coverage complete for enabled detectors.",
+          "impact": "",
+          "remediation": "",
+          "tool": "",
+          "reason": ""
+        }
+      },
+      "warnings": [],
+      "updated_at": "2026-03-18T06:35:27+00:00"
+    }
+  },
+  "score_confidence": {
+    "status": "full",
+    "confidence": 1.0,
+    "detectors": [],
+    "dimensions": []
+  },
+  "scan_metadata": {
+    "source": "scan"
+  },
+  "subjective_integrity": {
+    "status": "pass",
+    "target_score": 95.0,
+    "matched_count": 0,
+    "matched_dimensions": [],
+    "reset_dimensions": []
+  },
+  "subjective_assessments": {},
+  "scan_history": [
+    {
+      "timestamp": "2026-03-18T06:35:27+00:00",
+      "lang": "typescript",
+      "strict_score": 15.7,
+      "verified_strict_score": 62.8,
+      "objective_score": 62.8,
+      "overall_score": 15.7,
+      "open": 5,
+      "diff_new": 5,
+      "diff_resolved": 0,
+      "ignored": 0,
+      "raw_issues": 5,
+      "suppressed_pct": 0.0,
+      "ignore_patterns": 0,
+      "subjective_integrity": {
+        "status": "pass",
+        "matched_count": 0,
+        "reset_count": 0,
+        "target_score": 95.0
+      },
+      "score_confidence": {
+        "status": "full",
+        "confidence": 1.0,
+        "detector_count": 0,
+        "dimension_count": 0
+      },
+      "dimension_scores": {
+        "Code quality": {
+          "score": 90.0,
+          "strict": 90.0
+        },
+        "Security": {
+          "score": 100.0,
+          "strict": 100.0
+        },
+        "File health": {
+          "score": 100.0,
+          "strict": 100.0
+        },
+        "Test health": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Abstraction fit": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "AI generated debt": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "API coherence": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Auth consistency": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Contracts": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Convention drift": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Cross-module arch": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Dep health": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Design coherence": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Error consistency": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "High elegance": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Stale migration": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Init coupling": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Logic clarity": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Low elegance": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Mid elegance": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Naming quality": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Structure nav": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Test strategy": {
+          "score": 0.0,
+          "strict": 0.0
+        },
+        "Type safety": {
+          "score": 0.0,
+          "strict": 0.0
+        }
+      }
+    }
+  ],
+  "lang_capabilities": {
+    "typescript": {
+      "fixers": [
+        "dead-useeffect",
+        "debug-logs",
+        "empty-if-chain",
+        "unused-imports",
+        "unused-params",
+        "unused-vars"
+      ],
+      "typecheck_cmd": "npx tsc --noEmit"
+    }
+  },
+  "zone_distribution": {
+    "production": 2
+  },
+  "tool_hash": "dd6f84c96708",
+  "scan_path": "src",
+  "scan_completeness": {
+    "typescript": "fast"
+  },
+  "potentials": {
+    "typescript": {
+      "logs": 2,
+      "unused": 2,
+      "exports": 0,
+      "deprecated": 0,
+      "structural": 2,
+      "flat_dirs": 1,
+      "props": 0,
+      "single_use": 2,
+      "coupling": 0,
+      "cycles": 4,
+      "orphaned": 4,
+      "patterns": 0,
+      "naming": 1,
+      "facade": 4,
+      "test_coverage": 15,
+      "smells": 5,
+      "react": 0,
+      "security": 2,
+      "stale_wontfix": 0
+    }
+  },
+  "codebase_metrics": {
+    "typescript": {
+      "total_files": 2,
+      "total_loc": 127,
+      "total_directories": 1
+    }
+  },
+  "dimension_scores": {
+    "Code quality": {
+      "score": 90.0,
+      "strict": 90.0,
+      "verified_strict_score": 90.0,
+      "checks": 21,
+      "failing": 3,
+      "tier": 3,
+      "detectors": {
+        "unused": {
+          "potential": 2,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "logs": {
+          "potential": 2,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "smells": {
+          "potential": 5,
+          "pass_rate": 0.86,
+          "failing": 1,
+          "weighted_failures": 0.7
+        },
+        "orphaned": {
+          "potential": 4,
+          "pass_rate": 0.65,
+          "failing": 2,
+          "weighted_failures": 1.4
+        },
+        "flat_dirs": {
+          "potential": 1,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "naming": {
+          "potential": 1,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "single_use": {
+          "potential": 2,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "facade": {
+          "potential": 4,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        }
+      }
+    },
+    "Security": {
+      "score": 100.0,
+      "strict": 100.0,
+      "verified_strict_score": 100.0,
+      "checks": 6,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "cycles": {
+          "potential": 4,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        },
+        "security": {
+          "potential": 2,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        }
+      }
+    },
+    "File health": {
+      "score": 100.0,
+      "strict": 100.0,
+      "verified_strict_score": 100.0,
+      "checks": 2,
+      "failing": 0,
+      "tier": 3,
+      "detectors": {
+        "structural": {
+          "potential": 2,
+          "pass_rate": 1.0,
+          "failing": 0,
+          "weighted_failures": 0.0
+        }
+      }
+    },
+    "Test health": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 15,
+      "failing": 2,
+      "tier": 4,
+      "detectors": {
+        "test_coverage": {
+          "potential": 15,
+          "pass_rate": 0.0,
+          "failing": 2,
+          "weighted_failures": 15.403648594301345
+        }
+      }
+    },
+    "Abstraction fit": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "abstraction_fitness",
+          "configured_weight": 8.0,
+          "components": []
+        }
+      }
+    },
+    "AI generated debt": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "ai_generated_debt",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "API coherence": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "api_surface_coherence",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Auth consistency": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "authorization_consistency",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Contracts": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "contract_coherence",
+          "configured_weight": 12.0,
+          "components": []
+        }
+      }
+    },
+    "Convention drift": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "convention_outlier",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Cross-module arch": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "cross_module_architecture",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Dep health": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "dependency_health",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Design coherence": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "design_coherence",
+          "configured_weight": 10.0,
+          "components": []
+        }
+      }
+    },
+    "Error consistency": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "error_consistency",
+          "configured_weight": 3.0,
+          "components": []
+        }
+      }
+    },
+    "High elegance": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "high_level_elegance",
+          "configured_weight": 22.0,
+          "components": []
+        }
+      }
+    },
+    "Stale migration": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "incomplete_migration",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Init coupling": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "initialization_coupling",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Logic clarity": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "logic_clarity",
+          "configured_weight": 6.0,
+          "components": []
+        }
+      }
+    },
+    "Low elegance": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "low_level_elegance",
+          "configured_weight": 12.0,
+          "components": []
+        }
+      }
+    },
+    "Mid elegance": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "mid_level_elegance",
+          "configured_weight": 22.0,
+          "components": []
+        }
+      }
+    },
+    "Naming quality": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "naming_quality",
+          "configured_weight": 2.0,
+          "components": []
+        }
+      }
+    },
+    "Structure nav": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "package_organization",
+          "configured_weight": 5.0,
+          "components": []
+        }
+      }
+    },
+    "Test strategy": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "test_strategy",
+          "configured_weight": 1.0,
+          "components": []
+        }
+      }
+    },
+    "Type safety": {
+      "score": 0.0,
+      "strict": 0.0,
+      "verified_strict_score": 0.0,
+      "checks": 10,
+      "failing": 0,
+      "tier": 4,
+      "detectors": {
+        "subjective_assessment": {
+          "potential": 10,
+          "pass_rate": 0.0,
+          "failing": 0,
+          "weighted_failures": 10.0,
+          "assessment_score": 0.0,
+          "placeholder": true,
+          "dimension_key": "type_safety",
+          "configured_weight": 12.0,
+          "components": []
+        }
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ public/audio/
 # Audio cache
 .audio-cache.json
 .s3-upload-cache.json
+
+# Dolt database files (added by bd init)
+.dolt/
+*.db

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,26 @@ commit: ## Create a commit with AI-generated message
 	@echo "$(YELLOW)This will analyze changes and create a commit$(NC)"
 	git add -A && git commit
 
+# Content Creation Commands
+.PHONY: post
+post: ## Create a new blog post with Claude (interactive dialogue)
+	@echo "$(BLUE)Starting Claude post creation...$(NC)"
+	@claude "/post"
+
+.PHONY: publish
+publish: ## Full publish pipeline: images → audio → git push → auto-deploy
+	@echo "$(BLUE)Running full publish pipeline...$(NC)"
+	@echo "$(BLUE)Step 1/4: Optimizing images...$(NC)"
+	@npm run optimize-images || true
+	@echo "$(BLUE)Step 2/4: Generating audio...$(NC)"
+	@npm run audio-pipeline || echo "$(YELLOW)Audio generation skipped (check API key or no new posts)$(NC)"
+	@echo "$(BLUE)Step 3/4: Committing changes...$(NC)"
+	@git add -A
+	@git commit -m "feat: publish new post" || echo "$(YELLOW)No changes to commit$(NC)"
+	@echo "$(BLUE)Step 4/4: Pushing to deploy...$(NC)"
+	@git push
+	@echo "$(GREEN)✓ Published! Vercel will auto-deploy.$(NC)"
+
 # Utility Commands
 .PHONY: clean
 clean: ## Clean build artifacts and caches

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,508 +1,126 @@
-'use client';
+import type { Metadata } from 'next';
+import { EditorialPageFrame } from '../components/EditorialPageFrame';
 
-import React, { useState } from 'react';
-import { Metadata } from 'next';
+export const metadata: Metadata = {
+  title: 'About | Ben Labaschin',
+  description: 'Background, current work, and the through-line across Ben Labaschin’s writing, talks, and engineering work.',
+};
 
-/**
- * About component displaying professional information
- */
+const experience = [
+  {
+    role: 'Principal Machine Learning Engineer',
+    company: 'Workhelix',
+    period: '2022 to present',
+    summary:
+      'Founding engineer on enterprise-scale GenAI and agent systems, building async LLM infrastructure, analytics platforms, and production workflows for major customers.',
+  },
+  {
+    role: 'Senior Data Scientist',
+    company: 'Hopper',
+    period: '2021 to 2022',
+    summary:
+      'Led machine-learning work for Hopper Cloud partnerships and helped build the platform systems that supported travel intelligence products at scale.',
+  },
+  {
+    role: 'Earlier data science work',
+    company: 'XPO Logistics, Revantage, Arity',
+    period: '2017 to 2021',
+    summary:
+      'Worked across forecasting, experimentation, optimization, and business-facing ML systems, with a parallel thread of economics and transportation writing.',
+  },
+];
+
+const proofPoints = [
+  'O’Reilly reports on AI agents and memory systems',
+  'AEA Papers and Proceedings publication on firm-level exposure to GPTs',
+  'Conference and community talks on memory, validation, and production AI systems',
+  'Hands-on platform work spanning LLM APIs, analytics infrastructure, and deployment',
+];
+
 export default function AboutPage() {
-  const [activeSection, setActiveSection] = useState<string>('overview');
-
-  /**
-   * Scroll to a specific section
-   */
-  const scrollToSection = (sectionId: string): void => {
-    const element = document.getElementById(sectionId);
-    if (element) {
-      element.scrollIntoView({ behavior: 'smooth' });
-      setActiveSection(sectionId);
-    }
-  };
-
   return (
-    <div className="about-container">
-      <div className="about-hero">
-        <div className="about-hero-content">
-          <div className="about-hero-text">
-            <h1>Ben Labaschin</h1>
-            <h2>Principal Machine Learning Engineer</h2>
-            <p className="about-tagline">
-              Building intelligent systems that deliver measurable impact—from pioneering enterprise-scale
-              GenAI platforms to developing ML systems that drive millions in business value.
+    <EditorialPageFrame currentPath="/about">
+      <section className="editorial-page-hero editorial-about-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">About</p>
+          <h1 className="editorial-page-title">Ben Labaschin</h1>
+          <p className="editorial-page-copy">
+            I work at the intersection of AI systems, technical writing, and research. This site is where those threads meet: essays, talks, reports, and the forthcoming book on agent memory.
+          </p>
+        </div>
+        <aside className="editorial-page-aside editorial-about-photo-card">
+          <img src="/assets/atlas_and_I.jpg" alt="Ben Labaschin with Atlas" />
+        </aside>
+      </section>
+
+      <section className="editorial-home-proof-strip" aria-label="About summary">
+        <span>Principal ML Engineer</span>
+        <span>/</span>
+        <span>writer and speaker</span>
+        <span>/</span>
+        <span>AI systems + memory</span>
+        <span>/</span>
+        <span>economics background</span>
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Current focus</p>
+          <h2 className="editorial-page-section-title">The through-line is practical AI systems that actually work.</h2>
+        </div>
+        <div className="editorial-two-column">
+          <article className="editorial-home-card">
+            <p className="editorial-home-card-label">What I spend time on</p>
+            <h3>Production AI, memory, retrieval, and the messy middle.</h3>
+            <p>
+              Most of my work sits between research ideas and the engineering realities of enterprise systems: memory management, async LLM infrastructure, evaluation, developer workflows, and the trade-offs that appear once systems leave the demo stage.
             </p>
-            <a href="/benjamin_labaschin_resume.pdf" download className="cv-download-link">
-              Download Resume
+          </article>
+          <article className="editorial-home-card">
+            <p className="editorial-home-card-label">What this site is for</p>
+            <h3>A public platform, not just a resume.</h3>
+            <p>
+              I still keep the professional signal here, but the point of the site is to make the writing, talks, reports, and upcoming book feel like one coherent body of work.
+            </p>
+            <a href="/benjamin_labaschin_resume.pdf" download className="editorial-post-link">
+              Download resume
             </a>
-          </div>
-          <div className="about-hero-image">
-            <img src="/assets/atlas_and_I.jpg" alt="Ben Labaschin with Atlas" />
-          </div>
+          </article>
         </div>
-      </div>
+      </section>
 
-      <div className="about-layout">
-        <div className="about-sidebar">
-          <div className="about-nav">
-            <button
-              className={`about-nav-item ${activeSection === 'overview' ? 'active' : ''}`}
-              onClick={() => scrollToSection('overview')}
-            >
-              Overview
-            </button>
-            <button
-              className={`about-nav-item ${activeSection === 'experience' ? 'active' : ''}`}
-              onClick={() => scrollToSection('experience')}
-            >
-              Experience
-            </button>
-            <button
-              className={`about-nav-item ${activeSection === 'skills' ? 'active' : ''}`}
-              onClick={() => scrollToSection('skills')}
-            >
-              Skills
-            </button>
-            <button
-              className={`about-nav-item ${activeSection === 'publications' ? 'active' : ''}`}
-              onClick={() => scrollToSection('publications')}
-            >
-              Publications & Talks
-            </button>
-            <button
-              className={`about-nav-item ${activeSection === 'education' ? 'active' : ''}`}
-              onClick={() => scrollToSection('education')}
-            >
-              Education
-            </button>
-          </div>
-
-          <div className="about-contact">
-            <h3>Get In Touch</h3>
-            <div className="about-social-links">
-              <a href="https://github.com/econoben" target="_blank" rel="noopener noreferrer" className="about-social-link">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
-                </svg>
-                <span>GitHub</span>
-              </a>
-              <a href="https://linkedin.com/in/benjamin-labaschin" target="_blank" rel="noopener noreferrer" className="about-social-link">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path>
-                  <rect x="2" y="9" width="4" height="12"></rect>
-                  <circle cx="4" cy="4" r="2"></circle>
-                </svg>
-                <span>LinkedIn</span>
-              </a>
-              <a href="mailto:benjaminlabaschin@gmail.com" className="about-social-link">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
-                  <polyline points="22,6 12,13 2,6"></polyline>
-                </svg>
-                <span>Email</span>
-              </a>
-            </div>
-          </div>
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Proof</p>
+          <h2 className="editorial-page-section-title">The strongest signals to put in front of a new visitor.</h2>
         </div>
-
-        <div className="about-content">
-          <section id="overview" className="about-section">
-            <h2>Overview</h2>
-            <div className="about-card">
-              <p>
-                I'm a Principal Machine Learning Engineer at Workhelix, where I've been building enterprise-scale GenAI platforms and production ML systems as a founding engineer. I've written two O'Reilly books—"What Are AI Agents?" and "Managing Memory for AI Agents"—covering the practical considerations of building and deploying AI agent systems. I recently published research in AEA Papers and Proceedings on measuring firm-level exposure to large language models and their potential productivity impacts. I spend most of my time figuring out how to actually deploy AI systems that work reliably in production—from async LLM APIs and embedding systems to the messy real-world challenges of putting GenAI into enterprise workflows. My work spans the full stack, and I split my interests between the theory of AI and its impacts on labor, to deploying production grade LLMs and AI Agents.
-              </p>
-              <div className="about-highlights">
-                <div className="highlight-item">
-                  <div className="highlight-icon">🚀</div>
-                  <div className="highlight-text">
-                    <h4>AI Systems Architect</h4>
-                    <p>Building scalable ML infrastructure from the ground up</p>
-                  </div>
-                </div>
-                <div className="highlight-item">
-                  <div className="highlight-icon">💡</div>
-                  <div className="highlight-text">
-                    <h4>Innovation Driver</h4>
-                    <p>2 patents and multiple business-critical ML innovations</p>
-                  </div>
-                </div>
-                <div className="highlight-item">
-                  <div className="highlight-icon">📊</div>
-                  <div className="highlight-text">
-                    <h4>Value Creator</h4>
-                    <p>Delivered $8M+ in savings and helped secure $96M investment</p>
-                  </div>
-                </div>
-                <div className="highlight-item">
-                  <div className="highlight-icon">🔬</div>
-                  <div className="highlight-text">
-                    <h4>Researcher & Author</h4>
-                    <p>See recent research on firm-level exposure to LLMs in AEA Papers and Proceedings, and see O'Reilly series on AI Agents</p>
-                  </div>
-                </div>
-              </div>
+        <div className="editorial-proof-list">
+          {proofPoints.map((item) => (
+            <div key={item} className="editorial-proof-item">
+              {item}
             </div>
-          </section>
-
-          <section id="experience" className="about-section">
-            <h2>Experience</h2>
-
-            <div className="timeline">
-              <div className="timeline-item">
-                <div className="timeline-marker"></div>
-                <div className="timeline-content">
-                  <div className="about-card">
-                    <div className="job-header">
-                      <h3>Principal Machine Learning Engineer</h3>
-                      <div className="job-meta">
-                        <div className="company">Workhelix</div>
-                        <div className="duration">Apr. 2022 - Present</div>
-                      </div>
-                    </div>
-                    <ul className="job-achievements">
-                      <li>
-                        <strong>Founding Engineer:</strong> Leads core platform development at Workhelix, parallelizing highly scalable async LLM APIs and custom SOTA embedding systems, building and maintaining our internal LLM and agent deployment platform for Fortune 50 enterprise customers.
-                      </li>
-                      <li>
-                        <strong>ML/GenAI Analytics Platform:</strong> Architected multi-container Docker system for real-time data embedding and workflow analysis, combining proprietary "task" classification algorithms with predictive models (PyTorch, FastAPI, AWS ECR/ECS).
-                      </li>
-                      <li>
-                        <strong>Analytics & Insights:</strong> Developed novel complexity metrics to quantify and forecast GenAI's impact on engineering workflows, enabling data-driven insights on productivity for enterprise customers.
-                      </li>
-                      <li>
-                        <strong>API Architecture & Data Pipeline Engineering:</strong> Engineered high-throughput GitHub/GitLab extraction system with asyncio rate limiting and GraphQL cursor pagination, building robust task queues/concurrency controls that reduced repository processing time from 30 to 2 minutes.
-                      </li>
-                      <li>
-                        <strong>Seed to Series A Growth:</strong> Drove critical technical development that enabled Workhelix's growth from seed to Series A ($75M valuation), attracting investment from AI leaders including Andrew Ng, Mira Murati, and Yann LeCun.
-                      </li>
-                    </ul>
-                    <div className="job-tech">
-                      <span className="tech-tag">PyTorch</span>
-                      <span className="tech-tag">FastAPI</span>
-                      <span className="tech-tag">AWS</span>
-                      <span className="tech-tag">Docker</span>
-                      <span className="tech-tag">GraphQL</span>
-                      <span className="tech-tag">LLM</span>
-                      <span className="tech-tag">Causal Inference</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="timeline-item">
-                <div className="timeline-marker"></div>
-                <div className="timeline-content">
-                  <div className="about-card">
-                    <div className="job-header">
-                      <h3>Senior Data Scientist</h3>
-                      <div className="job-meta">
-                        <div className="company">Hopper</div>
-                        <div className="duration">Aug. 2021 - Apr. 2022</div>
-                      </div>
-                    </div>
-                    <ul className="job-achievements">
-                      <li>
-                        <strong>Strategic Partnership Leadership:</strong> Led ML engineering for Capital One Travel partnership, creating foundational ML systems that helped secure a $96M investment and drove Hopper Cloud to 40% of company revenue.
-                      </li>
-                      <li>
-                        <strong>Technical Architecture:</strong> Designed and implemented multi-tenant ML systems including multi-arm bandits and price freeze algorithms using GCP, enabling secure and scalable travel booking solutions for enterprise partners.
-                      </li>
-                      <li>
-                        <strong>MLOps Innovation:</strong> Spearheaded DevOps/MLOps implementation for Hopper Cloud, establishing CI/CD pipelines and orchestration workflows with GitHub Actions and Kubeflow to support rapid scaling of the B2B platform.
-                      </li>
-                    </ul>
-                    <div className="job-tech">
-                      <span className="tech-tag">GCP</span>
-                      <span className="tech-tag">MLOps</span>
-                      <span className="tech-tag">GitHub Actions</span>
-                      <span className="tech-tag">Kubeflow</span>
-                      <span className="tech-tag">Multi-arm Bandits</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="timeline-item">
-                <div className="timeline-marker"></div>
-                <div className="timeline-content">
-                  <div className="about-card">
-                    <div className="job-header">
-                      <h3>Data Scientist</h3>
-                      <div className="job-meta">
-                        <div className="company">XPO Logistics</div>
-                        <div className="duration">Jan. 2021 - Aug. 2021</div>
-                      </div>
-                    </div>
-                    <ul className="job-achievements">
-                      <li>
-                        <strong>Cost Optimization & ML Systems:</strong> Delivered $8M in savings through optimized shipment prioritization and automated pricing systems, a result from spearheading A/B testing and ML initiatives using XGBoost.
-                      </li>
-                    </ul>
-                    <div className="job-tech">
-                      <span className="tech-tag">XGBoost</span>
-                      <span className="tech-tag">A/B Testing</span>
-                      <span className="tech-tag">Python</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="timeline-item">
-                <div className="timeline-marker"></div>
-                <div className="timeline-content">
-                  <div className="about-card">
-                    <div className="job-header">
-                      <h3>Data Scientist</h3>
-                      <div className="job-meta">
-                        <div className="company">Revantage (Blackstone)</div>
-                        <div className="duration">Oct. 2019 - Jan. 2021</div>
-                      </div>
-                    </div>
-                    <ul className="job-achievements">
-                      <li>
-                        <strong>Investment Analytics:</strong> Led A/B testing with power analysis and regression modeling to optimize real estate investment decisions, driving multi-million dollar property savings.
-                      </li>
-                      <li>
-                        <strong>Analytics Engineering:</strong> Developed Python analytics pipeline (scipy, scikit-learn) for apartment renovation ROI analysis and geodata-based warehouse investment models.
-                      </li>
-                    </ul>
-                    <div className="job-tech">
-                      <span className="tech-tag">SciPy</span>
-                      <span className="tech-tag">scikit-learn</span>
-                      <span className="tech-tag">Regression</span>
-                      <span className="tech-tag">GeoData</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="timeline-item">
-                <div className="timeline-marker"></div>
-                <div className="timeline-content">
-                  <div className="about-card">
-                    <div className="job-header">
-                      <h3>Economist Researcher / Data Scientist</h3>
-                      <div className="job-meta">
-                        <div className="company">Arity (Allstate)</div>
-                        <div className="duration">Sept. 2017 - Oct. 2019</div>
-                      </div>
-                    </div>
-                    <ul className="job-achievements">
-                      <li>
-                        <strong>Risk Innovation:</strong> Pioneered telematics-based risk modeling for shared mobility companies, resulting in two patent applications and creating a new business vertical.
-                      </li>
-                      <li>
-                        <strong>Innovation Recognition:</strong> Won 2019 Hackathon for AWS-based NLP modeling, with research featured in Business Insider.
-                      </li>
-                    </ul>
-                    <div className="job-tech">
-                      <span className="tech-tag">Telematics</span>
-                      <span className="tech-tag">Risk Models</span>
-                      <span className="tech-tag">NLP</span>
-                      <span className="tech-tag">AWS</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="timeline-item">
-                <div className="timeline-marker"></div>
-                <div className="timeline-content">
-                  <div className="about-card">
-                    <div className="job-header">
-                      <h3>Adjunct Lecturer</h3>
-                      <div className="job-meta">
-                        <div className="company">Chapman University</div>
-                        <div className="duration">Aug. 2023 - Dec. 2024</div>
-                      </div>
-                    </div>
-                    <ul className="job-achievements">
-                      <li>
-                        Developed and taught Python-based AI/ML curriculum to 30+ students, bridging academic concepts with industry applications.
-                      </li>
-                    </ul>
-                    <div className="job-tech">
-                      <span className="tech-tag">Education</span>
-                      <span className="tech-tag">Python</span>
-                      <span className="tech-tag">AI/ML</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section id="skills" className="about-section">
-            <h2>Skills</h2>
-            <div className="about-card">
-              <div className="skills-grid">
-                <div className="skill-category">
-                  <h3>Programming</h3>
-                  <div className="skill-tags">
-                    <span className="skill-tag">Python</span>
-                    <span className="skill-tag">Java</span>
-                    <span className="skill-tag">C#</span>
-                    <span className="skill-tag">R</span>
-                    <span className="skill-tag">SQL</span>
-                    <span className="skill-tag">Shell</span>
-                    <span className="skill-tag">JavaScript</span>
-                    <span className="skill-tag">CSS</span>
-                    <span className="skill-tag">HTML</span>
-                  </div>
-                </div>
-
-                <div className="skill-category">
-                  <h3>AI/ML</h3>
-                  <div className="skill-tags">
-                    <span className="skill-tag">GenAI (LLama, Mistral, OpenAI, Claude)</span>
-                    <span className="skill-tag">Fine-Tuning</span>
-                    <span className="skill-tag">PyTorch</span>
-                    <span className="skill-tag">Tensorflow</span>
-                    <span className="skill-tag">Deep Learning</span>
-                    <span className="skill-tag">Transformers</span>
-                    <span className="skill-tag">NLP</span>
-                    <span className="skill-tag">Machine Learning</span>
-                    <span className="skill-tag">Ensembles</span>
-                    <span className="skill-tag">Boosted Trees</span>
-                  </div>
-                </div>
-
-                <div className="skill-category">
-                  <h3>Distributed Systems</h3>
-                  <div className="skill-tags">
-                    <span className="skill-tag">PySpark</span>
-                    <span className="skill-tag">Hadoop</span>
-                  </div>
-                </div>
-
-                <div className="skill-category">
-                  <h3>Cloud</h3>
-                  <div className="skill-tags">
-                    <span className="skill-tag">AWS</span>
-                    <span className="skill-tag">GCP</span>
-                    <span className="skill-tag">Azure</span>
-                  </div>
-                </div>
-
-                <div className="skill-category">
-                  <h3>Deployment</h3>
-                  <div className="skill-tags">
-                    <span className="skill-tag">GitHub Actions</span>
-                    <span className="skill-tag">GitLab</span>
-                    <span className="skill-tag">Docker</span>
-                    <span className="skill-tag">FastAPI</span>
-                    <span className="skill-tag">Flask</span>
-                    <span className="skill-tag">Modal</span>
-                  </div>
-                </div>
-
-                <div className="skill-category">
-                  <h3>Databases</h3>
-                  <div className="skill-tags">
-                    <span className="skill-tag">PostgreSQL</span>
-                    <span className="skill-tag">MySQL</span>
-                    <span className="skill-tag">DuckDB</span>
-                    <span className="skill-tag">BigQuery</span>
-                    <span className="skill-tag">Databricks</span>
-                    <span className="skill-tag">Snowflake</span>
-                    <span className="skill-tag">Athena</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section id="publications" className="about-section">
-            <h2>Publications & Talks</h2>
-            <div className="about-card">
-              <div className="publication-list">
-
-                  <div className="publication-item">
-                    <div className="publication-year">2025</div>
-                    <div className="publication-details">
-                      <h3>Building Stateful AI Agents</h3>
-                      <p className="publication-venue">ODSC West (Talk)</p>
-                    </div>
-                  </div>
-
-                  <div className="publication-item">
-                    <div className="publication-year">2025</div>
-                    <div className="publication-details">
-                      <h3>Managing Memory for AI Agents</h3>
-                      <p className="publication-venue">O'Reilly Media (Book)</p>
-                    </div>
-                  </div>
-
-                  <div className="publication-item">
-                    <div className="publication-year">2025</div>
-                    <div className="publication-details">
-                      <h3>Extending "GPTs Are GPTs" to Firms</h3>
-                      <p className="publication-venue">AEA Papers and Proceedings</p>
-                    </div>
-                  </div>
-
-                <div className="publication-item">
-                  <div className="publication-year">2024</div>
-                  <div className="publication-details">
-                    <h3>Building With AI: How I Build Quick POCs with LLMs</h3>
-                    <p className="publication-venue">Wharton Guest Lecture</p>
-                  </div>
-                </div>
-
-                <div className="publication-item">
-                  <div className="publication-year">2024</div>
-                  <div className="publication-details">
-                    <h3>A Normie Approach to Validating LLM Outputs</h3>
-                    <p className="publication-venue">AI.Science Talk</p>
-                  </div>
-                </div>
-
-                <div className="publication-item">
-                  <div className="publication-year">2023</div>
-                  <div className="publication-details">
-                    <h3>What Are AI Agents?</h3>
-                    <p className="publication-venue">O'Reilly Media (Book)</p>
-                  </div>
-                </div>
-
-                <div className="publication-item">
-                  <div className="publication-year">2023</div>
-                  <div className="publication-details">
-                    <h3>Building an HTTPS Model API for Cheap: AWS, Docker, and the Normconf API</h3>
-                    <p className="publication-venue">Talk</p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="patents-section">
-                <h3>Patents</h3>
-                <div className="patent-item">
-                  <h4>Shared Mobility Simulation and Prediction System</h4>
-                  <p className="patent-id">USPTO 20190347941</p>
-                </div>
-                <div className="patent-item">
-                  <h4>Matching Drivers With Shared Vehicles To Optimize Shared Vehicle Services</h4>
-                  <p className="patent-id">USPTO 20190347582</p>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section id="education" className="about-section">
-            <h2>Education</h2>
-            <div className="about-card">
-              <div className="education-item">
-                <div className="degree">B.A. Economics, cum laude</div>
-                <div className="education-details">
-                  <div className="university">Lake Forest College</div>
-                  <div className="location">Lake Forest, Illinois</div>
-                  <div className="year">2016</div>
-                </div>
-              </div>
-            </div>
-          </section>
+          ))}
         </div>
-      </div>
-    </div>
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Experience</p>
+          <h2 className="editorial-page-section-title">A shorter version of the operating history.</h2>
+        </div>
+        <div className="editorial-timeline">
+          {experience.map((item) => (
+            <article key={`${item.company}-${item.role}`} className="editorial-timeline-item">
+              <div className="editorial-post-meta">
+                <span>{item.company}</span>
+                <span>{item.period}</span>
+              </div>
+              <h3>{item.role}</h3>
+              <p className="editorial-post-summary">{item.summary}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+    </EditorialPageFrame>
   );
 }

--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import { EditorialPageFrame } from '../components/EditorialPageFrame';
+
+export default function BookPage() {
+  return (
+    <EditorialPageFrame currentPath="/book">
+        <section className="editorial-book-hero">
+          <div>
+            <p className="editorial-home-kicker">Forthcoming O&apos;Reilly book</p>
+            <h1>Agent Memory</h1>
+            <p className="editorial-home-subtitle">
+              A practical guide to how AI systems should remember, retrieve, compress, and act on information in production.
+            </p>
+            <div className="editorial-home-actions">
+              <a href="mailto:benjaminlabaschindev@gmail.com?subject=Agent%20Memory%20updates" className="editorial-home-button editorial-home-button-primary">
+                Get updates
+              </a>
+              <Link href="/publications" className="editorial-home-button editorial-home-button-secondary">
+                See related work
+              </Link>
+            </div>
+          </div>
+
+          <aside className="editorial-home-book-card">
+            <p className="editorial-home-card-label">Working direction</p>
+            <h2>Why it belongs here</h2>
+            <p>
+              One domain, one body of work, one list. The book should strengthen the platform, not split it into a second identity.
+            </p>
+          </aside>
+        </section>
+
+        <section className="editorial-home-grid">
+          <article className="editorial-home-card">
+            <p className="editorial-home-card-label">What belongs here</p>
+            <h3>Context, audience, and updates.</h3>
+            <p>
+              Explain why the book matters, who it is for, and why readers should follow the project now instead of waiting for launch week.
+            </p>
+          </article>
+          <article className="editorial-home-card">
+            <p className="editorial-home-card-label">How it connects</p>
+            <h3>The reports, talks, and book should read as one arc.</h3>
+            <p>
+              This page should point back to the O&apos;Reilly reports, talks, and essays so the book feels like the next step in the same public body of work.
+            </p>
+          </article>
+        </section>
+    </EditorialPageFrame>
+  );
+}

--- a/app/components/ClientLayout.tsx
+++ b/app/components/ClientLayout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { usePathname } from 'next/navigation';
 import Sidebar from './Sidebar';
 import SocialLinks from './SocialLinks';
 import DarkModeToggle from './DarkModeToggle';
@@ -11,6 +12,7 @@ interface ClientLayoutProps {
 }
 
 const ClientLayout: React.FC<ClientLayoutProps> = ({ children }) => {
+  const pathname = usePathname();
   // Default to open on desktop (production parity)
   const [sidebarOpen, setSidebarOpen] = useState(() => {
     if (typeof window !== 'undefined') {
@@ -90,8 +92,11 @@ const ClientLayout: React.FC<ClientLayoutProps> = ({ children }) => {
     };
   }, [isResizing, sidebarWidth]);
 
+  const editorialShellRoutes = new Set(['/', '/book', '/posts', '/publications', '/talks', '/about']);
+  const useEditorialShell = editorialShellRoutes.has(pathname);
+
   // Don't render sidebar on mobile
-  if (isMobile) {
+  if (isMobile || useEditorialShell) {
     return (
       <>
         {children}

--- a/app/components/EditorialPageFrame.tsx
+++ b/app/components/EditorialPageFrame.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+
+const navItems = [
+  { href: '/', label: 'Home' },
+  { href: '/posts', label: 'Posts' },
+  { href: '/talks', label: 'Talks' },
+  { href: '/publications', label: 'Publications' },
+  { href: '/book', label: 'Book' },
+  { href: '/about', label: 'About' },
+];
+
+interface EditorialPageFrameProps {
+  children: ReactNode;
+  currentPath: string;
+  pageClassName?: string;
+}
+
+export function EditorialTopbar({ currentPath }: { currentPath: string }) {
+  return (
+    <header className="editorial-home-topbar">
+      <div className="editorial-home-brand">
+        <p className="editorial-home-brand-name">BEN LABASCHIN</p>
+      </div>
+      <nav className="editorial-home-nav" aria-label="Editorial navigation">
+        {navItems.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={`editorial-home-nav-link ${currentPath === item.href ? 'is-active' : ''}`}
+            aria-current={currentPath === item.href ? 'page' : undefined}
+          >
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+    </header>
+  );
+}
+
+export function EditorialPageFrame({
+  children,
+  currentPath,
+  pageClassName = 'editorial-book-page',
+}: EditorialPageFrameProps) {
+  return (
+    <div className={pageClassName}>
+      <div className="editorial-home-shell">
+        <EditorialTopbar currentPath={currentPath} />
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/app/components/MainContent.tsx
+++ b/app/components/MainContent.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 import Link from 'next/link';
+import { EditorialPageFrame } from './EditorialPageFrame';
 
 interface Post {
   slug: string;
@@ -22,72 +23,11 @@ interface DefaultHomeContentProps {
   posts: Post[];
 }
 
-/**
- * Get hero title lines from post title
- */
-const getHeroTitleLines = (title: string): string[] => {
-  // Split by natural breaks like commas, semicolons, or dashes
-  const splitChars = /[,;:-]/;
-  if (splitChars.test(title)) {
-    return title.split(splitChars).map(line => line.trim()).filter(line => line);
-  }
-
-  // If no natural breaks, try to split in the middle of the title
-  const words = title.split(' ');
-
-  // For longer titles, try to create more balanced lines for better animation
-  if (words.length >= 8) {
-    const wordsPerLine = Math.ceil(words.length / 4); // Create up to 4 lines for very long titles
-    return [
-      words.slice(0, wordsPerLine).join(' '),
-      words.slice(wordsPerLine, wordsPerLine * 2).join(' '),
-      words.slice(wordsPerLine * 2, wordsPerLine * 3).join(' '),
-      words.slice(wordsPerLine * 3).join(' ')
-    ].filter(line => line.trim());
-  }
-
-  // For medium-long titles, create 3 lines
-  if (words.length >= 6) {
-    const wordsPerLine = Math.ceil(words.length / 3);
-    return [
-      words.slice(0, wordsPerLine).join(' '),
-      words.slice(wordsPerLine, wordsPerLine * 2).join(' '),
-      words.slice(wordsPerLine * 2).join(' ')
-    ].filter(line => line.trim());
-  }
-
-  // For medium titles, create 2 lines
-  if (words.length >= 3) {
-    const midpoint = Math.floor(words.length / 2);
-    return [
-      words.slice(0, midpoint).join(' '),
-      words.slice(midpoint).join(' ')
-    ];
-  }
-
-  // For short titles, just use as is
-  return [title];
-};
-
-/**
- * Calculate estimated reading time based on content length
- */
-const calculateReadingTime = (content: string): number => {
-  const wordsPerMinute = 200; // Average reading speed
-  const wordCount = content.split(/\s+/).length;
-  return Math.max(1, Math.ceil(wordCount / wordsPerMinute));
-};
-
-/**
- * Get excerpt from post content, preferring the summary field if available
- */
 const getExcerpt = (content: string, summary?: string): string => {
-  // If a summary is provided in frontmatter, use it
   if (summary && summary.trim()) {
     return summary.length <= 150 ? summary : summary.substring(0, 147) + '...';
   }
 
-  // Fallback to first paragraph if no summary is available
   const firstParagraph = content.split('\n\n')[0];
   if (firstParagraph.length <= 150) {
     return firstParagraph;
@@ -95,22 +35,7 @@ const getExcerpt = (content: string, summary?: string): string => {
   return firstParagraph.substring(0, 147) + '...';
 };
 
-/**
- * Extract tech keywords from post tags
- */
-const getTechBadges = (tags: string[]): Array<{icon: string, name: string}> => {
-  // All tech badges will use hashtag icon
-  return tags.map(tag => {
-    return {
-      icon: '#', // Using hashtag instead of emoji icons
-      name: tag
-    };
-  }).slice(0, 4); // Only show maximum of 4 tech badges
-};
-
 const DefaultHomeContent: React.FC<DefaultHomeContentProps> = ({ posts }) => {
-  const [activeCategory, setActiveCategory] = useState<string>('all');
-
   if (!posts || posts.length === 0) {
     return (
       <div className="home-loading">
@@ -120,256 +45,112 @@ const DefaultHomeContent: React.FC<DefaultHomeContentProps> = ({ posts }) => {
     );
   }
 
-  // Get the newest post for hero section
   const newestPost = posts[0];
-  
-  // Get next 3 posts as featured (exclude the hero post)
-  const featuredPosts = posts.slice(1, 4);
-
-  // Extract unique categories from post tags
-  const categories = Array.from(new Set(posts.flatMap(post => post.tags)));
-
-  // Filter posts by category/tag
-  const getFilteredPosts = (): Post[] => {
-    if (activeCategory === 'all') {
-      return posts;
-    }
-    return posts.filter(post => post.tags.includes(activeCategory));
-  };
-
-  // Get title lines and tech badges from newest post
-  const titleLines = getHeroTitleLines(newestPost.title);
-  const techBadges = getTechBadges(newestPost.tags);
-  const postExcerpt = getExcerpt(newestPost.content, newestPost.summary);
+  const secondaryPost = posts[1] ?? newestPost;
+  const tertiaryPost = posts[2] ?? secondaryPost;
+  const newestExcerpt = getExcerpt(newestPost.content, newestPost.summary);
 
   return (
-    <div className="home-container">
-      {/* Hero Section based on newest post */}
-      <section className="hero-section">
-        <div className="hero-content">
-          <h1 className="hero-title">
-            <Link href={`/posts/${newestPost.slug}`} className="hero-title-link">
-              {titleLines.map((line: string, index: number) => (
-                <span key={index} className="hero-line">{line}</span>
-              ))}
-            </Link>
-          </h1>
-          <p className="hero-subtitle">
-            {postExcerpt}
-          </p>
-          <div className="hero-cta">
-            <Link href={`/posts/${newestPost.slug}`} className="hero-button primary">
-              Read Article
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <line x1="5" y1="12" x2="19" y2="12"></line>
-                <polyline points="12 5 19 12 12 19"></polyline>
-              </svg>
-            </Link>
-            <Link href="/about" className="hero-button secondary">
-              About Me
-            </Link>
-          </div>
-          <div className="tech-badges">
-            {techBadges.map((tech, index: number) => (
-              <div key={index} className="tech-badge">
-                <Link href={`/tags/${tech.name}`} className="tech-badge-link">
-                  <span className="tech-icon">{tech.icon}</span>
-                  <span className="tech-name">{tech.name}</span>
-                </Link>
-              </div>
-            ))}
-          </div>
-        </div>
-        <div className="hero-decoration">
-          <div className="hero-graphic">
-            <svg
-              width="600"
-              height="600"
-              viewBox="-50 -50 500 500"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              className="animated-graphic"
-            >
-              <circle cx="200" cy="200" r="180" stroke="var(--accent-color)" strokeWidth="2" strokeDasharray="4 4" className="outer-circle" />
-              <circle cx="200" cy="200" r="150" stroke="var(--accent-color-secondary)" strokeWidth="2" opacity="0.7" className="middle-circle" />
-              <circle cx="200" cy="200" r="120" stroke="var(--accent-color)" strokeWidth="2" strokeDasharray="8 8" opacity="0.5" className="inner-circle" />
-
-              {/* Neural network nodes */}
-              {/* Input layer */}
-              <circle cx="100" cy="150" r="10" fill="var(--accent-color)" fillOpacity="0.2" stroke="var(--accent-color)" strokeWidth="1.5" className="node input-node-1" />
-              <circle cx="100" cy="200" r="10" fill="var(--accent-color)" fillOpacity="0.2" stroke="var(--accent-color)" strokeWidth="1.5" className="node input-node-2" />
-              <circle cx="100" cy="250" r="10" fill="var(--accent-color)" fillOpacity="0.2" stroke="var(--accent-color)" strokeWidth="1.5" className="node input-node-3" />
-
-              {/* Hidden layer */}
-              <circle cx="200" cy="130" r="10" fill="var(--accent-color-secondary)" fillOpacity="0.2" stroke="var(--accent-color-secondary)" strokeWidth="1.5" className="node hidden-node-1" />
-              <circle cx="200" cy="200" r="10" fill="var(--accent-color-secondary)" fillOpacity="0.2" stroke="var(--accent-color-secondary)" strokeWidth="1.5" className="node hidden-node-2" />
-              <circle cx="200" cy="270" r="10" fill="var(--accent-color-secondary)" fillOpacity="0.2" stroke="var(--accent-color-secondary)" strokeWidth="1.5" className="node hidden-node-3" />
-
-              {/* Output layer */}
-              <circle cx="300" cy="170" r="10" fill="var(--accent-color)" fillOpacity="0.2" stroke="var(--accent-color)" strokeWidth="1.5" className="node output-node-1" />
-              <circle cx="300" cy="230" r="10" fill="var(--accent-color)" fillOpacity="0.2" stroke="var(--accent-color)" strokeWidth="1.5" className="node output-node-2" />
-
-              {/* Connections from input to hidden layer */}
-              <path d="M110 150 L190 130" stroke="var(--accent-color)" strokeWidth="1" strokeDasharray="3 3" opacity="0.4" className="connection i1-h1" />
-              <path d="M110 150 L190 200" stroke="var(--accent-color)" strokeWidth="1" strokeDasharray="3 3" opacity="0.4" className="connection i1-h2" />
-              <path d="M110 150 L190 270" stroke="var(--accent-color)" strokeWidth="1" strokeDasharray="3 3" opacity="0.4" className="connection i1-h3" />
-
-              <path d="M110 200 L190 130" stroke="var(--accent-color)" strokeWidth="1" strokeDasharray="3 3" opacity="0.4" className="connection i2-h1" />
-              <path d="M110 200 L190 200" stroke="var(--accent-color)" strokeWidth="1" strokeDasharray="3 3" opacity="0.4" className="connection i2-h2" />
-              <path d="M110 200 L190 270" stroke="var(--accent-color)" strokeWidth="1" strokeDasharray="3 3" opacity="0.4" className="connection i2-h3" />
-
-              <path d="M110 250 L190 130" stroke="var(--accent-color)" strokeWidth="1" strokeDasharray="3 3" opacity="0.4" className="connection i3-h1" />
-              <path d="M110 250 L190 200" stroke="var(--accent-color)" strokeWidth="1" strokeDasharray="3 3" opacity="0.4" className="connection i3-h2" />
-              <path d="M110 250 L190 270" stroke="var(--accent-color)" strokeWidth="1" strokeDasharray="3 3" opacity="0.4" className="connection i3-h3" />
-
-              {/* Connections from hidden to output layer */}
-              <path d="M210 130 L290 170" stroke="var(--accent-color-secondary)" strokeWidth="1" strokeDasharray="3 3" opacity="0.4" className="connection h1-o1" />
-              <path d="M210 130 L290 230" stroke="var(--accent-color-secondary)" strokeWidth="1" strokeDasharray="3 3" opacity="0.4" className="connection h1-o2" />
-
-              <path d="M210 200 L290 170" stroke="var(--accent-color-secondary)" strokeWidth="1" strokeDasharray="3 3" opacity="0.4" className="connection h2-o1" />
-              <path d="M210 200 L290 230" stroke="var(--accent-color-secondary)" strokeWidth="1" strokeDasharray="3 3" opacity="0.4" className="connection h2-o2" />
-
-              <path d="M210 270 L290 170" stroke="var(--accent-color-secondary)" strokeWidth="1" strokeDasharray="3 3" opacity="0.4" className="connection h3-o1" />
-              <path d="M210 270 L290 230" stroke="var(--accent-color-secondary)" strokeWidth="1" strokeDasharray="3 3" opacity="0.4" className="connection h3-o2" />
-
-              {/* Center decoration */}
-              <circle cx="200" cy="200" r="40" fill="var(--accent-color)" fillOpacity="0.1" stroke="var(--accent-color)" strokeWidth="2" className="center-circle" />
-            </svg>
-          </div>
-        </div>
-      </section>
-
-      {/* Featured Posts Section */}
-      <section className="featured-section">
-        <div className="section-header">
-          <h2 className="section-title">Featured Posts</h2>
-          <div className="section-line"></div>
-        </div>
-        <div className="featured-posts">
-          {featuredPosts.map(post => (
-            <div className="featured-post-card" key={post.slug}>
-              <div className="featured-post-content">
-                <span className="featured-label">Featured</span>
-                <h3 className="featured-post-title">
-                  <Link href={`/posts/${post.slug}`}>{post.title}</Link>
-                </h3>
-                <div className="featured-post-meta">
-                  <span className="featured-post-date">
-                    {post.date.toLocaleDateString('en-US', {
-                      month: 'long',
-                      day: 'numeric',
-                      year: 'numeric'
-                    })}
-                  </span>
-                  <span className="featured-post-reading-time">
-                    {calculateReadingTime(post.content)} min read
-                  </span>
-                </div>
-                <p className="featured-post-excerpt">{getExcerpt(post.content, post.summary)}</p>
-                <Link href={`/posts/${post.slug}`} className="featured-post-link">
-                  Read Article
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <line x1="5" y1="12" x2="19" y2="12"></line>
-                    <polyline points="12 5 19 12 12 19"></polyline>
-                  </svg>
-                </Link>
-              </div>
+    <EditorialPageFrame currentPath="/" pageClassName="editorial-home-page">
+        <section className="editorial-home-hero">
+          <div className="editorial-home-hero-copy">
+            <p className="editorial-home-kicker">Technical editorial platform</p>
+            <h1>Writing about how AI systems remember, fail, and scale.</h1>
+            <p className="editorial-home-subtitle">
+              A public platform for essays, talks, O&apos;Reilly reports, and the forthcoming book on agent memory.
+            </p>
+            <div className="editorial-home-actions">
+              <Link href="/book" className="editorial-home-button editorial-home-button-primary">
+                Follow the book
+              </Link>
+              <Link href={`/posts/${newestPost.slug}`} className="editorial-home-button editorial-home-button-secondary">
+                Browse selected writing
+              </Link>
             </div>
-          ))}
-        </div>
-      </section>
-
-      {/* All Posts Section with Category Filter */}
-      <section className="posts-section">
-        <div className="section-header">
-          <h2 className="section-title">Latest Articles</h2>
-          <div className="section-line"></div>
-        </div>
-
-        <div className="category-filter">
-          <button
-            className={`category-button ${activeCategory === 'all' ? 'active' : ''}`}
-            onClick={() => setActiveCategory('all')}
-          >
-            All
-          </button>
-          {categories.slice(0, 10).map(category => (
-            <button
-              key={category}
-              className={`category-button ${activeCategory === category ? 'active' : ''}`}
-              onClick={() => setActiveCategory(category)}
-            >
-              {category}
-            </button>
-          ))}
-        </div>
-
-        <div className="blog-cards-container">
-          {getFilteredPosts().map((post, index) => (
-            <div key={post.slug} className="blog-card">
-              <div className="blog-card-accent"></div>
-              <div className="blog-card-content">
-                <h3 className="blog-card-title">
-                  <Link href={`/posts/${post.slug}`}>{post.title}</Link>
-                </h3>
-                <div className="blog-card-meta">
-                  <span className="blog-card-date">
-                    {post.date.toLocaleDateString('en-US', {
-                      month: 'long',
-                      day: 'numeric',
-                      year: 'numeric'
-                    })}
-                  </span>
-                  <span className="blog-card-reading-time">
-                    {calculateReadingTime(post.content)} min read
-                  </span>
-                </div>
-                <p className="blog-card-excerpt">
-                  {getExcerpt(post.content, post.summary)}
-                </p>
-                <div className="blog-card-footer">
-                  <div className="blog-card-tags">
-                    {post.tags.slice(0, 3).map((tag) => (
-                      <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="blog-card-tag">
-                        #{tag}
-                      </Link>
-                    ))}
-                  </div>
-                  <div className="blog-card-action">
-                    <Link href={`/posts/${post.slug}`} className="blog-card-read-more">
-                      Read Article
-                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                        <line x1="5" y1="12" x2="19" y2="12"></line>
-                        <polyline points="12 5 19 12 12 19"></polyline>
-                      </svg>
-                    </Link>
-                  </div>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-
-        {getFilteredPosts().length === 0 && (
-          <div className="no-posts-message">
-            <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round">
-              <circle cx="12" cy="12" r="10"></circle>
-              <line x1="12" y1="8" x2="12" y2="12"></line>
-              <line x1="12" y1="16" x2="12.01" y2="16"></line>
-            </svg>
-            <p>No posts found in this category.</p>
           </div>
-        )}
-      </section>
-    </div>
+
+          <aside className="editorial-home-book-card">
+            <p className="editorial-home-card-label">Book in progress</p>
+            <h2>Agent Memory</h2>
+            <p>
+              A forthcoming O&apos;Reilly book on how modern AI systems structure retrieval, memory, and long-running context.
+            </p>
+            <div className="editorial-home-book-meta">
+              <span>Q1 2027</span>
+              <span>O&apos;Reilly</span>
+              <span>newsletter-led launch</span>
+            </div>
+            <Link href="/book" className="editorial-home-button editorial-home-button-accent">
+              Read updates
+            </Link>
+          </aside>
+        </section>
+
+        <section className="editorial-home-proof-strip" aria-label="Proof of work">
+          <span>Principal ML Engineer</span>
+          <span>/</span>
+          <span>O&apos;Reilly reports</span>
+          <span>/</span>
+          <span>ODSC + Agents in Production talks</span>
+          <span>/</span>
+          <span>forthcoming book</span>
+        </section>
+
+        <section className="editorial-home-section">
+          <p className="editorial-home-section-label">Selected work</p>
+          <h2>A homepage that curates, instead of dumping a feed.</h2>
+          <div className="editorial-home-grid">
+            <article className="editorial-home-card">
+              <p className="editorial-home-card-label">Essay</p>
+              <h3>The strongest writing gets space to breathe.</h3>
+              <p>
+                Feature one important post or report with enough room for an opinion, not just a thumbnail and a date.
+              </p>
+              <Link href={`/posts/${newestPost.slug}`} className="editorial-home-card-link">
+                {newestPost.title}
+              </Link>
+              <p className="editorial-home-card-footnote">{newestExcerpt}</p>
+            </article>
+
+            <article className="editorial-home-card">
+              <p className="editorial-home-card-label">Talks + proof</p>
+              <h3>Pull authority forward. Don&apos;t hide it in subpages.</h3>
+              <p>
+                Talks, reports, and current work should reinforce the same story visitors infer from the hero.
+              </p>
+              <div className="editorial-home-proof-links">
+                <Link href="/talks">See talks</Link>
+                <Link href="/publications">See publications</Link>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section className="editorial-home-cta-band">
+          <div>
+            <p className="editorial-home-card-label">Newsletter + book</p>
+            <h3>A lightweight conversion layer. Present, not pushy.</h3>
+            <p>
+              Make the next action obvious: follow the book, subscribe for updates, or browse the strongest writing and talks.
+            </p>
+          </div>
+          <Link href="/book" className="editorial-home-button editorial-home-button-primary">
+            Start the list
+          </Link>
+        </section>
+    </EditorialPageFrame>
   );
 };
 
 export const MainContent: React.FC<MainContentProps> = ({ posts, children }) => {
+  if (!children) {
+    return <DefaultHomeContent posts={posts} />;
+  }
+
   return (
     <div className="main-content">
       <div className="content-wrapper">
-        {children || <DefaultHomeContent posts={posts} />}
+        {children}
       </div>
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;500&family=Roboto:wght@400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;700&display=swap');
 @import './styles/mobile-search-fixes.css';
 
 /* CSS Variables */
@@ -7860,7 +7861,740 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
     padding-bottom: 10px;
   }
   
-  .category-button {
+.category-button {
     white-space: nowrap;
+  }
+}
+
+/* Editorial Shell */
+.editorial-home-page,
+.editorial-book-page {
+  --editorial-paper: #f3ede4;
+  --editorial-surface: #fbf8f2;
+  --editorial-ink: #182431;
+  --editorial-navy: #102236;
+  --editorial-blue: #2b63f6;
+  --editorial-blue-soft: #dde7ff;
+  --editorial-sand: #d9c9af;
+  --editorial-slate: #66758b;
+  --editorial-shadow: 0 20px 60px rgba(16, 34, 54, 0.12);
+  --editorial-card-shadow: 0 12px 28px rgba(24, 36, 49, 0.08);
+  background: #1f1f1f;
+  color: var(--editorial-ink);
+  margin-top: -10px;
+  min-height: 100vh;
+  padding: 22px 22px 36px;
+}
+
+.editorial-home-shell {
+  background: var(--editorial-paper);
+  border-radius: 22px;
+  box-shadow: var(--editorial-shadow);
+  margin: 0 auto;
+  max-width: 1180px;
+  padding: 22px 58px 44px;
+}
+
+.editorial-home-topbar {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 58px;
+}
+
+.editorial-home-brand {
+  min-width: 140px;
+}
+
+.editorial-home-brand-name,
+.editorial-home-nav a,
+.editorial-home-kicker,
+.editorial-home-card-label,
+.editorial-home-section-label {
+  font-family: 'IBM Plex Mono', 'Roboto Mono', monospace;
+}
+
+.editorial-home-brand-name {
+  color: var(--editorial-ink);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.editorial-home-nav {
+  align-items: center;
+  display: flex;
+  gap: 16px;
+}
+
+.editorial-home-nav a {
+  color: rgba(24, 36, 49, 0.78);
+  font-size: 0.78rem;
+  font-weight: 500;
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+.editorial-home-nav a:hover {
+  color: var(--editorial-ink);
+}
+
+.editorial-home-nav-link.is-active {
+  color: var(--editorial-ink);
+  font-weight: 700;
+}
+
+.editorial-home-hero,
+.editorial-book-hero {
+  align-items: start;
+  display: grid;
+  gap: 44px;
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 360px);
+  margin-bottom: 34px;
+}
+
+.editorial-home-hero-copy {
+  max-width: 640px;
+}
+
+.editorial-home-kicker,
+.editorial-home-card-label,
+.editorial-home-section-label {
+  color: var(--editorial-blue);
+  font-size: 0.67rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.editorial-home-kicker {
+  margin-bottom: 22px;
+}
+
+.editorial-home-hero h1,
+.editorial-book-hero h1 {
+  color: var(--editorial-ink);
+  font-family: 'Space Grotesk', 'Inter', sans-serif;
+  font-size: clamp(3rem, 5.2vw, 4.6rem);
+  font-weight: 700;
+  letter-spacing: -0.055em;
+  line-height: 0.94;
+  margin-bottom: 18px;
+  max-width: 10.2ch;
+}
+
+.editorial-book-hero h1 {
+  max-width: none;
+}
+
+.editorial-home-subtitle,
+.editorial-home-card p,
+.editorial-home-book-card p {
+  color: var(--editorial-slate);
+  font-family: 'Inter', var(--font-body);
+  font-size: 1.06rem;
+  line-height: 1.45;
+}
+
+.editorial-home-subtitle {
+  max-width: 600px;
+}
+
+.editorial-home-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 30px;
+}
+
+.editorial-home-button {
+  align-items: center;
+  border-radius: 14px;
+  display: inline-flex;
+  font-family: 'Inter', var(--font-body);
+  font-size: 0.92rem;
+  font-weight: 700;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 20px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.editorial-home-button:hover {
+  box-shadow: 0 8px 24px rgba(24, 36, 49, 0.12);
+  transform: translateY(-1px);
+}
+
+.editorial-home-button-primary {
+  background: var(--editorial-ink);
+  color: #fff;
+}
+
+.editorial-home-button-primary:hover {
+  color: #fff;
+}
+
+.editorial-home-button-secondary {
+  background: rgba(255, 255, 255, 0.55);
+  color: var(--editorial-ink);
+  box-shadow: inset 0 0 0 1px rgba(16, 34, 54, 0.08);
+}
+
+.editorial-home-button-secondary:hover {
+  color: var(--editorial-ink);
+}
+
+.editorial-home-button-accent {
+  background: var(--editorial-blue);
+  color: #fff;
+}
+
+.editorial-home-button-accent:hover {
+  color: #fff;
+}
+
+.editorial-home-book-card,
+.editorial-home-card {
+  background: var(--editorial-surface);
+  border: 1px solid rgba(16, 34, 54, 0.08);
+  border-radius: 18px;
+  box-shadow: var(--editorial-card-shadow);
+}
+
+.editorial-home-book-card {
+  align-self: start;
+  padding: 22px 24px 24px;
+}
+
+.editorial-home-book-card h2,
+.editorial-home-card h3,
+.editorial-home-section h2,
+.editorial-home-cta-band h3 {
+  color: var(--editorial-ink);
+  font-family: 'Space Grotesk', 'Inter', sans-serif;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+
+.editorial-home-book-card h2 {
+  font-size: 2rem;
+  line-height: 1.02;
+  margin-bottom: 10px;
+}
+
+.editorial-home-book-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin: 18px 0 20px;
+}
+
+.editorial-home-book-meta span {
+  color: var(--editorial-slate);
+  font-family: 'IBM Plex Mono', 'Roboto Mono', monospace;
+  font-size: 0.72rem;
+}
+
+.editorial-home-proof-strip {
+  align-items: center;
+  background: var(--editorial-navy);
+  border-radius: 16px;
+  color: rgba(255, 255, 255, 0.92);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-family: 'Inter', var(--font-body);
+  font-size: 0.96rem;
+  font-weight: 500;
+  margin-bottom: 46px;
+  padding: 20px 24px;
+}
+
+.editorial-home-proof-strip span:nth-child(even) {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.editorial-home-section {
+  margin-bottom: 42px;
+}
+
+.editorial-home-section-label {
+  margin-bottom: 12px;
+}
+
+.editorial-home-section h2 {
+  font-size: clamp(2rem, 3vw, 2.7rem);
+  line-height: 1.06;
+  margin-bottom: 24px;
+  max-width: 13ch;
+}
+
+.editorial-home-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.editorial-home-card {
+  min-height: 246px;
+  padding: 26px 24px 24px;
+}
+
+.editorial-home-card h3 {
+  font-size: 2rem;
+  line-height: 1.02;
+  margin: 14px 0 14px;
+  max-width: 12ch;
+}
+
+.editorial-home-card p {
+  max-width: 38ch;
+}
+
+.editorial-home-card-link {
+  color: var(--editorial-ink);
+  display: inline-flex;
+  font-family: 'Inter', var(--font-body);
+  font-size: 0.96rem;
+  font-weight: 700;
+  margin-top: 18px;
+}
+
+.editorial-home-card-footnote {
+  margin-top: 10px;
+}
+
+.editorial-home-proof-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  margin-top: 22px;
+}
+
+.editorial-home-proof-links a {
+  color: var(--editorial-ink);
+  font-family: 'Inter', var(--font-body);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.editorial-home-cta-band {
+  align-items: center;
+  background: var(--editorial-blue-soft);
+  border-radius: 18px;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 28px 28px;
+}
+
+.editorial-home-cta-band h3 {
+  font-size: 2.2rem;
+  line-height: 1.02;
+  margin: 10px 0 12px;
+  max-width: 12ch;
+}
+
+.editorial-home-cta-band p {
+  color: var(--editorial-slate);
+  font-family: 'Inter', var(--font-body);
+  font-size: 1rem;
+  line-height: 1.45;
+  max-width: 48ch;
+}
+
+.editorial-book-page .editorial-home-shell {
+  padding-bottom: 52px;
+}
+
+.editorial-book-hero {
+  margin-bottom: 28px;
+}
+
+.editorial-book-hero .editorial-home-subtitle {
+  max-width: 54ch;
+}
+
+.editorial-page-hero {
+  align-items: start;
+  display: grid;
+  gap: 32px;
+  grid-template-columns: minmax(0, 1.45fr) minmax(260px, 320px);
+  margin-bottom: 28px;
+}
+
+.editorial-page-hero-copy {
+  max-width: 700px;
+}
+
+.editorial-page-title {
+  color: var(--editorial-ink);
+  font-family: 'Space Grotesk', 'Inter', sans-serif;
+  font-size: clamp(3rem, 5vw, 4.3rem);
+  font-weight: 700;
+  letter-spacing: -0.055em;
+  line-height: 0.96;
+  margin-bottom: 16px;
+}
+
+.editorial-page-copy {
+  color: var(--editorial-slate);
+  font-family: 'Inter', var(--font-body);
+  font-size: 1.05rem;
+  line-height: 1.48;
+  max-width: 58ch;
+}
+
+.editorial-page-aside {
+  background: rgba(255, 255, 255, 0.52);
+  border: 1px solid rgba(16, 34, 54, 0.08);
+  border-radius: 18px;
+  box-shadow: var(--editorial-card-shadow);
+  padding: 22px 24px;
+}
+
+.editorial-page-metric-list {
+  display: grid;
+  gap: 18px;
+  margin-top: 14px;
+}
+
+.editorial-page-metric-list > div {
+  display: grid;
+  gap: 4px;
+}
+
+.editorial-page-metric-value {
+  color: var(--editorial-ink);
+  font-family: 'Space Grotesk', 'Inter', sans-serif;
+  font-size: 1.6rem;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+
+.editorial-page-metric-label {
+  color: var(--editorial-slate);
+  font-family: 'Inter', var(--font-body);
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
+.editorial-list-section {
+  margin-bottom: 40px;
+}
+
+.editorial-list-heading {
+  margin-bottom: 22px;
+}
+
+.editorial-page-section-title {
+  color: var(--editorial-ink);
+  font-family: 'Space Grotesk', 'Inter', sans-serif;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  font-weight: 700;
+  letter-spacing: -0.045em;
+  line-height: 1.05;
+  max-width: 16ch;
+}
+
+.editorial-post-grid,
+.editorial-publication-grid,
+.editorial-talk-grid,
+.editorial-timeline,
+.editorial-proof-list {
+  display: grid;
+  gap: 18px;
+}
+
+.editorial-post-grid,
+.editorial-publication-grid,
+.editorial-talk-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.editorial-post-card,
+.editorial-publication-card,
+.editorial-talk-card,
+.editorial-timeline-item,
+.editorial-proof-item {
+  background: var(--editorial-surface);
+  border: 1px solid rgba(16, 34, 54, 0.08);
+  border-radius: 18px;
+  box-shadow: var(--editorial-card-shadow);
+}
+
+.editorial-post-card,
+.editorial-publication-card,
+.editorial-talk-card,
+.editorial-timeline-item {
+  padding: 22px 24px 24px;
+}
+
+.editorial-post-card h2,
+.editorial-publication-card h3,
+.editorial-talk-card h3,
+.editorial-timeline-item h3 {
+  color: var(--editorial-ink);
+  font-family: 'Space Grotesk', 'Inter', sans-serif;
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.045em;
+  line-height: 1.03;
+  margin: 14px 0 14px;
+}
+
+.editorial-post-meta {
+  color: var(--editorial-slate);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  font-family: 'IBM Plex Mono', 'Roboto Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.editorial-post-summary,
+.editorial-publication-authors,
+.editorial-publication-venue {
+  color: var(--editorial-slate);
+  font-family: 'Inter', var(--font-body);
+  font-size: 0.98rem;
+  line-height: 1.48;
+}
+
+.editorial-publication-authors {
+  margin-bottom: 4px;
+}
+
+.editorial-publication-venue {
+  margin-bottom: 12px;
+}
+
+.editorial-chip-row,
+.editorial-link-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.editorial-chip {
+  background: rgba(43, 99, 246, 0.08);
+  border-radius: 999px;
+  color: var(--editorial-blue);
+  font-family: 'IBM Plex Mono', 'Roboto Mono', monospace;
+  font-size: 0.68rem;
+  padding: 7px 10px;
+  text-transform: uppercase;
+}
+
+.editorial-post-link {
+  color: var(--editorial-ink);
+  display: inline-flex;
+  font-family: 'Inter', var(--font-body);
+  font-size: 0.94rem;
+  font-weight: 700;
+  margin-top: 18px;
+}
+
+.editorial-publication-card {
+  align-items: start;
+  display: grid;
+  gap: 18px;
+  grid-template-columns: 108px minmax(0, 1fr);
+}
+
+.editorial-publication-card.is-featured {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(251, 248, 242, 0.98));
+}
+
+.editorial-publication-cover {
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.editorial-publication-cover img,
+.editorial-about-photo-card img {
+  display: block;
+  height: auto;
+  width: 100%;
+}
+
+.editorial-about-photo-card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.editorial-about-hero {
+  grid-template-columns: minmax(0, 1.35fr) minmax(220px, 300px);
+}
+
+.editorial-two-column {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.editorial-proof-list {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.editorial-proof-item {
+  color: var(--editorial-ink);
+  font-family: 'Inter', var(--font-body);
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.45;
+  padding: 20px 22px;
+}
+
+@media (max-width: 980px) {
+  .editorial-home-shell {
+    padding: 20px 28px 34px;
+  }
+
+  .editorial-home-topbar {
+    margin-bottom: 40px;
+  }
+
+  .editorial-home-hero,
+  .editorial-book-hero,
+  .editorial-page-hero,
+  .editorial-home-cta-band {
+    grid-template-columns: 1fr;
+  }
+
+  .editorial-home-book-card {
+    max-width: 420px;
+  }
+}
+
+@media (max-width: 760px) {
+  .editorial-home-page,
+  .editorial-book-page {
+    padding: 14px 12px 24px;
+  }
+
+  .editorial-home-shell {
+    border-radius: 18px;
+    padding: 16px 16px 24px;
+  }
+
+  .editorial-home-topbar {
+    margin-bottom: 30px;
+  }
+
+  .editorial-home-nav {
+    display: none;
+  }
+
+  .editorial-home-hero,
+  .editorial-book-hero,
+  .editorial-page-hero {
+    gap: 28px;
+    margin-bottom: 24px;
+  }
+
+  .editorial-home-hero h1,
+  .editorial-book-hero h1 {
+    font-size: clamp(2.8rem, 13vw, 4rem);
+    line-height: 0.94;
+    max-width: 8.7ch;
+  }
+
+  .editorial-book-hero h1 {
+    max-width: none;
+  }
+
+  .editorial-home-subtitle,
+  .editorial-home-card p,
+  .editorial-home-book-card p,
+  .editorial-home-cta-band p {
+    font-size: 0.97rem;
+  }
+
+  .editorial-home-actions {
+    gap: 10px;
+    margin-top: 22px;
+  }
+
+  .editorial-home-button {
+    min-height: 46px;
+    width: 100%;
+  }
+
+  .editorial-home-book-card {
+    display: none;
+  }
+
+  .editorial-home-proof-strip {
+    font-size: 0.92rem;
+    gap: 8px;
+    margin-bottom: 28px;
+    padding: 18px 18px;
+  }
+
+  .editorial-home-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .editorial-post-grid,
+  .editorial-publication-grid,
+  .editorial-talk-grid,
+  .editorial-two-column,
+  .editorial-proof-list {
+    grid-template-columns: 1fr;
+  }
+
+  .editorial-publication-card {
+    grid-template-columns: 1fr;
+  }
+
+  .editorial-home-card {
+    min-height: 0;
+    padding: 22px 18px 20px;
+  }
+
+  .editorial-home-card h3,
+  .editorial-home-section h2,
+  .editorial-home-cta-band h3 {
+    max-width: none;
+  }
+
+  .editorial-home-card h3 {
+    font-size: 1.9rem;
+  }
+
+  .editorial-home-section h2 {
+    font-size: 2.25rem;
+    margin-bottom: 18px;
+  }
+
+  .editorial-home-cta-band {
+    gap: 18px;
+    padding: 22px 18px;
+  }
+
+  .editorial-home-cta-band h3 {
+    font-size: 2rem;
+  }
+
+  .editorial-page-title,
+  .editorial-post-card h2,
+  .editorial-publication-card h3,
+  .editorial-talk-card h3,
+  .editorial-timeline-item h3 {
+    font-size: 1.9rem;
+  }
+
+  .editorial-page-section-title {
+    font-size: 2.1rem;
+    max-width: none;
+  }
+
+  .editorial-page-aside {
+    padding: 18px 18px;
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,10 @@
-import Link from 'next/link';
 import { postService } from './services/PostService';
 import { MainContent } from './components/MainContent';
-import MobileLayout from './components/MobileLayout';
 
 export default async function HomePage() {
   const posts = await postService.getAllPosts();
 
   return (
-    <MobileLayout>
-      <MainContent posts={posts} />
-    </MobileLayout>
+    <MainContent posts={posts} />
   );
 }

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -1,72 +1,91 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
+import { EditorialPageFrame } from '../components/EditorialPageFrame';
 import { postService } from '../services/PostService';
 
 export const metadata: Metadata = {
-  title: 'All Posts | Economic Notes',
-  description: 'Browse all blog posts on economics, technology, and AI.',
+  title: 'Posts | Ben Labaschin',
+  description: 'Essays on AI systems, engineering, memory, and adjacent technical work.',
 };
 
 export default async function PostsPage() {
   const posts = await postService.getAllPosts();
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+  const featuredPost = posts[0];
 
   return (
-    <div className="posts-page">
-      <div className="page-header">
-        <h1 className="page-title">All Posts</h1>
-        <p className="page-subtitle">
-          {posts.length} posts on economics, technology, and more
-        </p>
-      </div>
+    <EditorialPageFrame currentPath="/posts">
+      <section className="editorial-page-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">Writing archive</p>
+          <h1 className="editorial-page-title">Posts</h1>
+          <p className="editorial-page-copy">
+            Essays on agent memory, AI systems, developer tooling, and the occasional detour into economics.
+          </p>
+        </div>
+        <aside className="editorial-page-aside">
+          <p className="editorial-home-card-label">At a glance</p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">{posts.length}</span>
+              <span className="editorial-page-metric-label">published posts</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">{featuredPost?.tags[0] ?? 'AI'}</span>
+              <span className="editorial-page-metric-label">current leading theme</span>
+            </div>
+          </div>
+          {featuredPost && (
+            <Link href={`/posts/${featuredPost.slug}`} className="editorial-home-button editorial-home-button-secondary">
+              Start with the latest essay
+            </Link>
+          )}
+        </aside>
+      </section>
 
-      <div className="posts-grid">
+      <section className="editorial-home-proof-strip" aria-label="Posts summary">
+        <span>long-form essays</span>
+        <span>/</span>
+        <span>systems + infrastructure</span>
+        <span>/</span>
+        <span>agent memory</span>
+        <span>/</span>
+        <span>developer workflow</span>
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Archive</p>
+          <h2 className="editorial-page-section-title">Recent writing with enough room to read.</h2>
+        </div>
+
+        <div className="editorial-post-grid">
         {posts.map((post) => (
-          <article key={post.slug} className="blog-card">
-            <Link href={`/posts/${post.slug}`}>
-              <div className="blog-card-content">
-                {post.coverImage && (
-                  <div className="blog-card-image">
-                    <img src={post.coverImage} alt={post.title} />
-                  </div>
-                )}
-                
-                <h2 className="blog-card-title">{post.title}</h2>
-                
-                <time className="blog-card-date">
-                  {post.date.toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric'
-                  })}
-                </time>
-                
-                {post.summary && (
-                  <p className="blog-card-summary">{post.summary}</p>
-                )}
-                
-                <div className="blog-card-footer">
-                  <div className="blog-card-tags">
-                    {post.tags.slice(0, 3).map((tag) => (
-                      <span key={tag} className="tag">
-                        {tag}
-                      </span>
-                    ))}
-                    {post.tags.length > 3 && (
-                      <span className="tag tag-more">
-                        +{post.tags.length - 3}
-                      </span>
-                    )}
-                  </div>
-                  
-                  <span className="read-more-link">
-                    Read more →
-                  </span>
-                </div>
-              </div>
+          <article key={post.slug} className="editorial-post-card">
+            <div className="editorial-post-meta">
+              <span>{post.tags[0] ?? 'Essay'}</span>
+              <span>{formatter.format(post.date)}</span>
+            </div>
+            <h2>{post.title}</h2>
+            {post.summary && <p className="editorial-post-summary">{post.summary}</p>}
+            <div className="editorial-chip-row">
+              {post.tags.slice(0, 3).map((tag) => (
+                <span key={tag} className="editorial-chip">
+                  {tag}
+                </span>
+              ))}
+            </div>
+            <Link href={`/posts/${post.slug}`} className="editorial-post-link">
+              Read the post
             </Link>
           </article>
         ))}
-      </div>
-    </div>
+        </div>
+      </section>
+    </EditorialPageFrame>
   );
 }

--- a/app/publications/page.tsx
+++ b/app/publications/page.tsx
@@ -1,32 +1,50 @@
 import { Metadata } from 'next';
-import { publicationsConfig } from '../config/publicationsConfig';
+import { EditorialPageFrame } from '../components/EditorialPageFrame';
+import { publicationsConfig, Publication } from '../config/publicationsConfig';
 
 export const metadata: Metadata = {
-  title: 'Publications | Economic Notes',
-  description: 'Articles, whitepapers, and books on economics, technology, and AI.',
+  title: 'Publications | Ben Labaschin',
+  description: 'Reports, research, and long-form publications across AI systems and economics.',
 };
 
 export default function PublicationsPage() {
-  const { title, subtitle, publications } = publicationsConfig;
-  
-  // Sort publications by year (newest first)
+  const { publications } = publicationsConfig;
   const sortedPublications = [...publications].sort((a, b) => b.year - a.year);
-  
-  // Group by featured status
   const featuredPublications = sortedPublications.filter(pub => pub.featured);
   const otherPublications = sortedPublications.filter(pub => !pub.featured);
 
   return (
-    <div className="publications-page">
-      <div className="page-header">
-        <h1 className="page-title">{title}</h1>
-        <p className="page-subtitle">{subtitle}</p>
-      </div>
+    <EditorialPageFrame currentPath="/publications">
+      <section className="editorial-page-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">Public record</p>
+          <h1 className="editorial-page-title">Publications</h1>
+          <p className="editorial-page-copy">
+            O&apos;Reilly work, formal research, and longer-form pieces that anchor the writing and talks elsewhere on the site.
+          </p>
+        </div>
+        <aside className="editorial-page-aside">
+          <p className="editorial-home-card-label">What&apos;s here</p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">{publications.length}</span>
+              <span className="editorial-page-metric-label">major publications</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">2025</span>
+              <span className="editorial-page-metric-label">latest release year</span>
+            </div>
+          </div>
+        </aside>
+      </section>
 
       {featuredPublications.length > 0 && (
-        <section className="publications-section">
-          <h2 className="section-title">Featured Publications</h2>
-          <div className="publications-grid">
+        <section className="editorial-list-section">
+          <div className="editorial-list-heading">
+            <p className="editorial-home-section-label">Featured</p>
+            <h2 className="editorial-page-section-title">The work most likely to orient a first-time reader.</h2>
+          </div>
+          <div className="editorial-publication-grid">
             {featuredPublications.map((pub) => (
               <PublicationCard key={pub.id} publication={pub} featured />
             ))}
@@ -35,112 +53,86 @@ export default function PublicationsPage() {
       )}
 
       {otherPublications.length > 0 && (
-        <section className="publications-section">
-          <h2 className="section-title">Other Reports</h2>
-          <div className="publications-grid">
+        <section className="editorial-list-section">
+          <div className="editorial-list-heading">
+            <p className="editorial-home-section-label">Archive</p>
+            <h2 className="editorial-page-section-title">Background reports and earlier writing.</h2>
+          </div>
+          <div className="editorial-publication-grid">
             {otherPublications.map((pub) => (
               <PublicationCard key={pub.id} publication={pub} />
             ))}
           </div>
         </section>
       )}
-    </div>
+    </EditorialPageFrame>
   );
 }
 
 function PublicationCard({ publication, featured = false }: { 
-  publication: any; 
+  publication: Publication; 
   featured?: boolean;
 }) {
-  const typeColors: Record<string, string> = {
-    book: 'type-badge-book',
-    journal: 'type-badge-journal',
-    conference: 'type-badge-conference',
-    report: 'type-badge-report',
-    workshop: 'type-badge-workshop',
-    other: 'type-badge-other'
-  };
+  const displayType = (() => {
+    if (publication.venue === "O'Reilly Media") {
+      return "O'Reilly report";
+    }
+    const labels: Record<Publication['type'], string> = {
+      book: 'Book',
+      journal: 'Journal',
+      conference: 'Conference',
+      report: 'Report',
+      workshop: 'Workshop',
+      other: 'Writing',
+    };
+    return labels[publication.type];
+  })();
+
+  const actionHref = publication.url || publication.pdfUrl || (publication.doi ? `https://doi.org/${publication.doi}` : undefined);
+  const actionLabel = publication.url ? 'View publication' : publication.pdfUrl ? 'Open PDF' : publication.doi ? 'View DOI' : undefined;
 
   return (
-    <article 
+    <article
       id={publication.id}
-      className={`publication-card ${featured ? 'publication-featured' : ''}`}
+      className={`editorial-publication-card ${featured ? 'is-featured' : ''}`}
     >
-      <div className="publication-card-content">
-        <div className="publication-header">
-          {publication.coverImage && (
-            <div className="publication-cover">
-              <img 
-                src={publication.coverImage} 
-                alt={`Cover for ${publication.title}`}
-              />
-            </div>
-          )}
-          
-          <div className="publication-meta">
-            <div className="publication-type-and-date">
-              <span className={`publication-type ${typeColors[publication.type]}`}>
-                {publication.type}
-              </span>
-              <span className="publication-date">{publication.year}</span>
-            </div>
-            
-            <h3 className="publication-title">{publication.title}</h3>
-            <p className="publication-authors">{publication.authors}</p>
-            {publication.venue && (
-              <p className="publication-venue">{publication.venue}</p>
-            )}
-          </div>
+      {publication.coverImage && (
+        <div className="editorial-publication-cover">
+          <img
+            src={publication.coverImage}
+            alt={`Cover for ${publication.title}`}
+          />
+        </div>
+      )}
+      <div className="editorial-publication-content">
+        <div className="editorial-post-meta">
+          <span>{displayType}</span>
+          <span>{publication.year}</span>
         </div>
 
-        {publication.abstract && (
-          <div className="publication-body">
-            <p className="publication-abstract">{publication.abstract}</p>
-          </div>
+        <h3>{publication.title}</h3>
+        <p className="editorial-publication-authors">{publication.authors}</p>
+        {publication.venue && <p className="editorial-publication-venue">{publication.venue}</p>}
+        {publication.abstract && <p className="editorial-post-summary">{publication.abstract}</p>}
+
+        <div className="editorial-chip-row">
+          {publication.topics.slice(0, 4).map((topic) => (
+            <span key={topic} className="editorial-chip">
+              {topic}
+            </span>
+          ))}
+        </div>
+
+        {actionHref && actionLabel && (
+          <a
+            href={actionHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="editorial-post-link"
+          >
+            {actionLabel}
+          </a>
         )}
-
-        <div className="publication-footer">
-          <div className="publication-topics">
-            {publication.topics.map((topic: string) => (
-              <span key={topic} className="publication-topic-tag">
-                {topic}
-              </span>
-            ))}
-          </div>
-
-          <div className="publication-actions">
-            {publication.url && (
-              <a 
-                href={publication.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="publication-action-button"
-              >
-                View →
-              </a>
-            )}
-            {publication.pdfUrl && (
-              <a 
-                href={publication.pdfUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="publication-action-button pdf-button"
-              >
-                PDF ↓
-              </a>
-            )}
-            {publication.doi && (
-              <a 
-                href={`https://doi.org/${publication.doi}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="publication-action-button doi-button"
-              >
-                DOI →
-              </a>
-            )}
-          </div>
-        </div>
       </div>
     </article>
   );

--- a/app/talks/page.tsx
+++ b/app/talks/page.tsx
@@ -1,11 +1,114 @@
-import { Metadata } from 'next';
-import TalksClient from './TalksClient';
+import type { Metadata } from 'next';
+import { EditorialPageFrame } from '../components/EditorialPageFrame';
+import { talksConfig } from '../config/talksConfig';
 
 export const metadata: Metadata = {
   title: 'Talks | Ben Labaschin',
-  description: 'Conference talks, presentations, and live streams on tech topics.',
+  description: 'Conference talks, podcasts, and public talks on AI systems, memory, and engineering.',
 };
 
+const formatDate = (dateStr: string) =>
+  new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }).format(new Date(dateStr));
+
 export default function TalksPage() {
-  return <TalksClient />;
+  const talks = [...talksConfig.talks].sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
+
+  return (
+    <EditorialPageFrame currentPath="/talks">
+      <section className="editorial-page-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">Speaking</p>
+          <h1 className="editorial-page-title">Talks</h1>
+          <p className="editorial-page-copy">
+            A running record of talks, podcasts, and community appearances on memory systems, AI engineering, and production workflows.
+          </p>
+        </div>
+        <aside className="editorial-page-aside">
+          <p className="editorial-home-card-label">Speaking themes</p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">memory</span>
+              <span className="editorial-page-metric-label">agent systems and retrieval</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">production</span>
+              <span className="editorial-page-metric-label">real deployment and operations</span>
+            </div>
+          </div>
+        </aside>
+      </section>
+
+      <section className="editorial-home-proof-strip" aria-label="Talks summary">
+        <span>MLOps Community</span>
+        <span>/</span>
+        <span>ODSC West</span>
+        <span>/</span>
+        <span>Normconf</span>
+        <span>/</span>
+        <span>podcasts and streams</span>
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Appearances</p>
+          <h2 className="editorial-page-section-title">Selected talks and recordings.</h2>
+        </div>
+        <div className="editorial-talk-grid">
+          {talks.map((talk) => {
+            const primaryUrl = talk.spotifyUrl
+              ? talk.spotifyUrl
+              : talk.youtubeId
+                ? `https://www.youtube.com/watch?v=${talk.youtubeId}`
+                : undefined;
+
+            return (
+              <article key={talk.id} className="editorial-talk-card">
+                <div className="editorial-post-meta">
+                  <span>{talk.event}</span>
+                  <span>{formatDate(talk.date)}</span>
+                </div>
+                <h3>{talk.title}</h3>
+                <p className="editorial-post-summary">{talk.description}</p>
+                <div className="editorial-chip-row">
+                  {talk.topics.slice(0, 4).map((topic) => (
+                    <span key={topic} className="editorial-chip">
+                      {topic}
+                    </span>
+                  ))}
+                </div>
+                <div className="editorial-link-row">
+                  {primaryUrl && (
+                    <a
+                      href={primaryUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="editorial-post-link"
+                    >
+                      {talk.spotifyUrl ? 'Listen' : 'Watch'}
+                    </a>
+                  )}
+                  {talk.transcriptUrl && (
+                    <a
+                      href={talk.transcriptUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="editorial-post-link"
+                    >
+                      Read transcript
+                    </a>
+                  )}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+    </EditorialPageFrame>
+  );
 }

--- a/openspec/changes/preserve-site-parity-before-expansion/.openspec.yaml
+++ b/openspec/changes/preserve-site-parity-before-expansion/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-22

--- a/openspec/changes/preserve-site-parity-before-expansion/design.md
+++ b/openspec/changes/preserve-site-parity-before-expansion/design.md
@@ -1,0 +1,110 @@
+## Context
+
+The `blog` repo is the implementation target for the public site at `econoben.dev`. It is a Next.js App Router application with content and behavior spread across route components in `app/`, config-driven sections in `app/config/`, markdown posts in `src/posts/`, and service logic in `app/services/`.
+
+The current working tree already contains exploratory editorial redesign work, including a new shell and a `/book` route. That work should continue, but it must not cause silent loss of content or features from the existing site. The canonical baseline is still the current site as currently implemented and shipped: its routes, wording, content corpus, metadata, feeds, and user-visible behaviors.
+
+This change exists to prevent content loss while the redesign moves forward. Without continuity guardrails, the migration can easily drop posts, routes, metadata, or feature surfaces while the new visual system is being built.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Preserve the existing public site's routes, posts, wording, and feature surfaces while the redesign proceeds.
+- Allow redesign and expansion work to move forward in parallel once content-continuity guardrails are in place.
+- Make content loss obvious through lightweight inventories and checks instead of a heavyweight parity chart.
+- Keep copy changes deliberate by freezing existing wording unless a later explicit change approves them.
+
+**Non-Goals:**
+- Rewriting copy accidentally during layout or design work.
+- Treating exploratory design changes as permission to drop existing content or behaviors.
+- Building a formal route-by-route parity spreadsheet or chart as a prerequisite to development.
+- Redesigning the content model at the same time as the site shell unless continuity is preserved.
+
+## Decisions
+
+### 1. The canonical baseline is the current site, but redesign work can proceed in parallel
+The migration source of truth is still the current public site and its existing repo behavior, but the redesign does not need to wait for a formal parity signoff. Instead, the redesign proceeds while continuity guards prevent regressions.
+
+Alternatives considered:
+- Use the exploratory redesign as the new baseline: rejected because it makes it too easy to lose content or routes accidentally.
+- Freeze all redesign work until parity is finished: rejected because it slows progress unnecessarily and is not what the user wants.
+
+### 2. Use lightweight continuity inventories instead of an explicit parity chart
+We still need to know what must be preserved, but that inventory should be operational and lightweight: canonical content sources, public route surfaces, feature-backed routes, and generated outputs.
+
+Alternatives considered:
+- Build a formal parity matrix for every route before coding: rejected because it adds planning overhead without enough additional protection.
+- Skip inventory entirely: rejected because it makes missing content harder to catch.
+
+### 3. Existing wording is frozen by default during redesign
+Canonical wording remains in place unless a deliberate change later chooses to rewrite it. Layout and design work do not get to rewrite copy by accident.
+
+Alternatives considered:
+- Allow opportunistic copy cleanup during redesign: rejected because it makes it harder to separate design work from content decisions.
+- Rewrite top-level copy immediately: rejected because the user wants to keep current wording until intentional revisions are discussed.
+
+### 4. Expansion work is allowed as long as continuity protections stay in place
+Book surfaces, newsletter placement, and editorial refinement can be built while route modernization is underway, provided they do not remove baseline content or silently replace existing wording.
+
+Alternatives considered:
+- Force all expansion into a later change: rejected because the user wants to keep building the site now.
+- Allow unrestricted expansion with no guardrails: rejected because it increases the risk of losing content or features.
+
+### 5. Validation focuses on continuity, not perfect one-to-one parity
+Automated build/runtime checks plus targeted human review are enough, as long as they confirm that posts, routes, metadata, and feature surfaces still exist and work.
+
+Alternatives considered:
+- Rely only on `next build`: rejected because content loss can still slip through.
+- Require exhaustive visual parity review for every route before building new surfaces: rejected because it over-constrains progress.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A[Current Site Baseline] --> B[Continuity Guardrails]
+    A1[Routes in app/] --> B
+    A2[Markdown posts in src/posts/] --> B
+    A3[Config in app/config/] --> B
+    A4[Services and generated outputs] --> B
+
+    B --> C[Shared Site Foundation]
+    C --> D[Parallel Route Modernization]
+    C --> E[Parallel Expansion Surfaces]
+
+    D --> F[Continuity Checks]
+    E --> F
+    B --> F
+
+    F --> G[Review and Refinement Queue]
+```
+
+## Risks / Trade-offs
+
+- **[Redesign work can still hide regressions]** → Add lightweight continuity checks for posts, routes, outputs, and feature-backed pages.
+- **[Existing exploratory code may diverge from current behavior]** → Keep the current site as the content/feature source of truth even when the new design moves ahead.
+- **[Current repo has tooling gaps]** → Record repo-level validation limits, such as missing ESLint wiring, and lean on build/runtime plus targeted review until stronger checks exist.
+- **[Parallel work can blur content vs design decisions]** → Freeze wording by default and track intentional copy changes separately.
+
+## Migration Plan
+
+1. Freeze the parity baseline: route inventory, content inventory, wording freeze, and known exploratory deltas.
+2. Build the shared site foundation so redesign work can move ahead without orphaning baseline routes and features.
+3. Modernize content routes and expansion surfaces in parallel while preserving existing content sources and wording by default.
+4. Verify dynamic systems and outputs: search, tags, archives, code-and-tools, metadata, RSS, sitemap, and robots.
+5. Review the redesigned site for continuity gaps, then queue copy/book/newsletter refinements for the next pass.
+
+## Execution Constraints
+
+- Implementation proceeds on non-`main` branches only.
+- Parallel implementation should use git worktrees so multiple route families can advance independently.
+- Each parallel slice should land in its own PR and remain unmerged until human review approves the branch set.
+- Shared foundation work that changes common files such as layout shells, shared components, or global styles should establish the integration base first; page-specific work should branch from that base to reduce conflicts.
+- PRs created for this change are review checkpoints, not merge signals. Nothing should be merged into `main` until the user explicitly approves it.
+
+Rollback strategy:
+- If a redesign slice drops route availability, content coverage, or feature continuity, revert that slice to the last safe state rather than layering more design work on top.
+
+## Open Questions
+
+- What is the minimum continuity check set that gives enough protection without turning into the formal parity chart you do not want?
+- How visible should `/book` be while the broader site redesign is still preserving baseline content and wording?

--- a/openspec/changes/preserve-site-parity-before-expansion/design.md
+++ b/openspec/changes/preserve-site-parity-before-expansion/design.md
@@ -6,6 +6,8 @@ The current working tree already contains exploratory editorial redesign work, i
 
 This change exists to prevent content loss while the redesign moves forward. Without continuity guardrails, the migration can easily drop posts, routes, metadata, or feature surfaces while the new visual system is being built.
 
+The first implementation wave is already split into stacked draft PRs for the shared foundation, structured pages, posts, discovery routes, and continuity-backed surfaces. The next wave should move from "safe continuity" toward "closer to final" by using an integrated preview branch plus focused polish branches for shared visual fidelity, language, and subpage refinement.
+
 ## Goals / Non-Goals
 
 **Goals:**
@@ -92,6 +94,7 @@ flowchart TD
 3. Modernize content routes and expansion surfaces in parallel while preserving existing content sources and wording by default.
 4. Verify dynamic systems and outputs: search, tags, archives, code-and-tools, metadata, RSS, sitemap, and robots.
 5. Review the redesigned site for continuity gaps, then queue copy/book/newsletter refinements for the next pass.
+6. Create an integrated preview branch from the active stacked slices and run a second pass for shared visual fidelity, language, and subpage polish.
 
 ## Execution Constraints
 
@@ -99,6 +102,7 @@ flowchart TD
 - Parallel implementation should use git worktrees so multiple route families can advance independently.
 - Each parallel slice should land in its own PR and remain unmerged until human review approves the branch set.
 - Shared foundation work that changes common files such as layout shells, shared components, or global styles should establish the integration base first; page-specific work should branch from that base to reduce conflicts.
+- Once multiple draft slices exist, an integration preview branch may stack them together so later polish work can target the real combined experience without merging anything into `main`.
 - PRs created for this change are review checkpoints, not merge signals. Nothing should be merged into `main` until the user explicitly approves it.
 
 Rollback strategy:

--- a/openspec/changes/preserve-site-parity-before-expansion/proposal.md
+++ b/openspec/changes/preserve-site-parity-before-expansion/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The redesign should move forward now, not wait behind a rigid parity phase. The real risk is not that pages look different while we build; it is that posts, routes, wording, metadata, or features silently disappear during the redesign.
+
+## What Changes
+
+- Define continuity guardrails so redesign work can proceed in parallel without losing posts, routes, wording, metadata, or current feature surfaces.
+- Preserve the existing content corpus and feature inventory while allowing the new site shell, page designs, and book/newsletter surfaces to be built now.
+- Replace the explicit parity-chart requirement with lighter-weight source inventories and validation checks focused on preventing content loss.
+- Break the work into execution-ready tasks that cover shared site foundation, route modernization, feature continuity, and redesign review.
+
+## Capabilities
+
+### New Capabilities
+- `route-content-parity`: Preserve the current route map, content corpus, and canonical wording while redesign work proceeds.
+- `behavior-system-parity`: Preserve the current site behaviors and system outputs, including navigation, search, tags, archives, markdown/audio rendering, code-and-tools content, and crawl surfaces.
+- `expansion-gates`: Add guardrails that allow expansion work to proceed without dropping baseline content or silently changing wording.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected code: `app/`, `app/components/`, `app/services/`, `app/config/`, `src/posts/`, metadata/SEO outputs, and route handlers.
+- Affected systems: Next.js App Router pages, markdown content loading, audio manifest usage, unified search, publications/talks config rendering, RSS/sitemap/robots generation, and mobile/desktop navigation behaviors.
+- Affected workflow: OpenSpec becomes the planning source of truth for a continuity-first redesign, and Beads becomes the execution breakdown for parallel redesign and preservation work.

--- a/openspec/changes/preserve-site-parity-before-expansion/specs/behavior-system-parity/spec.md
+++ b/openspec/changes/preserve-site-parity-before-expansion/specs/behavior-system-parity/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Preserve current navigation and layout behaviors during redesign
+The site SHALL preserve the current navigation and layout behaviors on desktop and mobile while the new design system is introduced.
+
+#### Scenario: Current navigation remains usable
+- **WHEN** a user navigates the site on desktop or mobile
+- **THEN** the redesigned site MUST preserve access to the existing top-level destinations and their current navigation behavior unless an intentional replacement is shipped without removing access
+
+#### Scenario: Current site controls continue to work
+- **WHEN** existing pages are reimplemented
+- **THEN** dark mode, sidebar or mobile navigation behavior, and route access patterns MUST remain usable unless an approved continuity exception documents a temporary limitation
+
+### Requirement: Preserve current dynamic content behaviors
+The site SHALL preserve the current dynamic behaviors that are backed by site services, config, and route handlers while surfaces are modernized.
+
+#### Scenario: Search continuity is maintained
+- **WHEN** a user searches through `/search` or `/api/search`
+- **THEN** the redesigned site MUST continue to query the same content sources and return equivalent result types for posts, talks, publications, archives, and code-and-tools entries
+
+#### Scenario: Config-driven sections retain their current behavior
+- **WHEN** a user browses talks, publications, or code-and-tools content
+- **THEN** the redesigned site MUST preserve the current config-driven items, categories, links, and rendering behaviors while visual and IA changes are introduced
+
+#### Scenario: Archive and tag behavior remains consistent
+- **WHEN** a user navigates tag or archive surfaces
+- **THEN** the redesigned site MUST preserve the current grouping, sorting, and linking behavior derived from the existing post corpus
+
+### Requirement: Capture continuity validation evidence during redesign
+The redesign SHALL include lightweight evidence that the current site's content and behavior baseline remains intact as changes land.
+
+#### Scenario: Visual and runtime evidence is recorded
+- **WHEN** a redesigned route or surface is considered ready for review
+- **THEN** the route MUST have targeted review evidence covering desktop, mobile, and any route-specific interactive behavior that could regress
+
+#### Scenario: Build and runtime checks pass for redesign work
+- **WHEN** redesign work is prepared for review
+- **THEN** the redesigned site MUST complete the project's available build/runtime validation steps and record any repo-level tooling gaps that prevent stricter validation

--- a/openspec/changes/preserve-site-parity-before-expansion/specs/expansion-gates/spec.md
+++ b/openspec/changes/preserve-site-parity-before-expansion/specs/expansion-gates/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Expansion work is allowed when continuity is protected
+The redesign SHALL allow expansion work to proceed as long as baseline content, routes, wording, and core behaviors remain protected.
+
+#### Scenario: Expansion does not remove baseline content
+- **WHEN** new IA, copy experiments, book surfaces, newsletter placement, editorial styling changes, or route additions are introduced
+- **THEN** they MUST NOT remove existing posts, routes, wording-by-default, or feature-backed surfaces from the public site
+
+#### Scenario: Exploratory redesign work does not erase the baseline
+- **WHEN** exploratory redesign code exists in the working tree or proposal discussions
+- **THEN** that work MUST NOT be treated as permission to drop baseline routes, content, or behaviors
+
+### Requirement: Approved deltas are explicit and reviewable
+Any deviation from the current site during the redesign SHALL be documented explicitly and reviewed as an intentional delta.
+
+#### Scenario: Intentional continuity exceptions are documented
+- **WHEN** a redesign implementation cannot exactly preserve an existing behavior, route, or content surface because of a technical constraint or planned deferment
+- **THEN** the exception MUST be recorded with the affected route or feature, the reason, and the follow-up work needed to close the gap
+
+#### Scenario: Refinement work follows continuity review
+- **WHEN** the redesign has been reviewed for continuity
+- **THEN** further copy, book, newsletter, and aesthetic refinements MAY proceed without creating a separate parity phase, provided the continuity guardrails remain in force

--- a/openspec/changes/preserve-site-parity-before-expansion/specs/route-content-parity/spec.md
+++ b/openspec/changes/preserve-site-parity-before-expansion/specs/route-content-parity/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Preserve the current public route inventory while redesign proceeds
+The site SHALL keep the current public route inventory available while redesign and expansion work proceed in parallel.
+
+#### Scenario: Canonical public routes are known
+- **WHEN** redesign work is planned or implemented
+- **THEN** it MUST include `/`, `/posts`, `/posts/[slug]`, `/archive`, `/archives/[month]`, `/tags`, `/tags/[tag]`, `/talks`, `/publications`, `/about`, `/search`, `/code-ai`, `/code-ai/[id]`, `/rss.xml`, `/sitemap.xml`, and `/robots.txt`
+
+#### Scenario: Existing routes remain available
+- **WHEN** a user visits an existing public route during the redesign
+- **THEN** that route MUST remain available and reachable even as new surfaces or layouts are introduced
+
+### Requirement: Preserve the existing content corpus and canonical wording
+The site SHALL preserve the existing content corpus and page wording by default until a later approved change explicitly modifies that wording.
+
+#### Scenario: Post corpus matches the existing blog
+- **WHEN** the post corpus is loaded from `src/posts/`
+- **THEN** the redesigned site MUST expose the same post slugs, titles, dates, summaries, tags, and markdown bodies as the current site
+
+#### Scenario: Canonical wording is not changed accidentally
+- **WHEN** an existing page is reimplemented during redesign
+- **THEN** its user-facing wording MUST match the current site unless an approved change explicitly records the intentional copy update
+
+### Requirement: Preserve existing content surfaces and metadata outputs
+The site SHALL preserve the current content surfaces and associated metadata outputs while page designs evolve.
+
+#### Scenario: Post detail preserves rendering surfaces
+- **WHEN** a user opens `/posts/[slug]`
+- **THEN** the redesigned site MUST preserve markdown rendering, tag links, metadata generation, and audio player availability consistent with the current implementation
+
+#### Scenario: Crawl and feed outputs remain intact
+- **WHEN** crawlers or readers access `/rss.xml`, `/sitemap.xml`, or `/robots.txt`
+- **THEN** the redesigned site MUST preserve those outputs and their current content sources while redesign work is underway

--- a/openspec/changes/preserve-site-parity-before-expansion/tasks.md
+++ b/openspec/changes/preserve-site-parity-before-expansion/tasks.md
@@ -38,3 +38,10 @@
 - [ ] 6.1 Review redesigned pages on desktop and mobile with targeted evidence for changed surfaces
 - [ ] 6.2 Confirm that no posts, routes, or feature surfaces were lost during the redesign
 - [ ] 6.3 Queue the next round of copy, book, newsletter, and aesthetic refinements after continuity review
+
+## 7. End-State Polish
+
+- [ ] 7.1 Create an integrated preview branch that stacks the active redesign slices without merging into `main`
+- [ ] 7.2 Refine the shared shell, global styles, and homepage toward the intended end-state visual system
+- [ ] 7.3 Refine the language and narrative positioning across the homepage and key top-level pages
+- [ ] 7.4 Refine posts, discovery routes, and code/tools subpages so they feel consistent with the final-direction theme

--- a/openspec/changes/preserve-site-parity-before-expansion/tasks.md
+++ b/openspec/changes/preserve-site-parity-before-expansion/tasks.md
@@ -1,0 +1,40 @@
+## 1. Content Continuity Guardrails
+
+- [ ] 0.1 Establish the execution model: non-`main` branches only, worktrees for parallel slices, PRs for every slice, and no merges before explicit review
+- [ ] 1.1 Inventory canonical content sources and public site surfaces without building a formal parity chart
+- [ ] 1.2 Add lightweight checks so posts, slugs, metadata, and feature-backed content cannot disappear silently
+- [ ] 1.3 Record the wording-freeze-by-default rule for existing pages and content
+- [ ] 1.4 Decide how experimental surfaces like `/book` coexist with the baseline content while redesign proceeds
+
+## 2. Shared Site Foundation
+
+- [ ] 2.1 Build the shared site shell and navigation direction without dropping existing destinations
+- [ ] 2.2 Reconcile root layout, metadata defaults, dark mode, sidebar/mobile behavior, and search/nav access with the baseline site
+- [ ] 2.3 Ensure redesigned pages do not orphan legacy routes, posts, or feature surfaces
+
+## 3. Core Route Modernization
+
+- [ ] 3.1 Redesign `/` and `/posts` while preserving existing content, links, and wording by default
+- [ ] 3.2 Redesign `/posts/[slug]` while preserving markdown rendering, tag links, metadata, and audio behavior
+- [ ] 3.3 Redesign `/archive` and `/archives/[month]` without losing grouping, sorting, or linking behavior
+- [ ] 3.4 Redesign `/tags` and `/tags/[tag]` without losing tag counts or navigation behavior
+- [ ] 3.5 Redesign `/search` without losing query handling or result coverage
+
+## 4. Structured Content Modernization
+
+- [ ] 4.1 Redesign `/talks` while preserving current items, links, and interaction expectations
+- [ ] 4.2 Redesign `/publications` while preserving current items, wording by default, and action links
+- [ ] 4.3 Redesign `/about` while preserving current content until deliberate copy changes are approved
+- [ ] 4.4 Redesign `/code-ai` and `/code-ai/[id]` while preserving categories, search, views, gist-backed content, and code rendering
+
+## 5. Feature and Output Continuity
+
+- [ ] 5.1 Verify `/rss.xml`, `/sitemap.xml`, `/robots.txt`, and metadata outputs still reflect the full site content
+- [ ] 5.2 Verify search, sidebar, TTS, and related route handlers still support the redesigned site correctly
+- [ ] 5.3 Close any tooling or validation gaps that would let content loss slip through unnoticed
+
+## 6. Review and Refinement
+
+- [ ] 6.1 Review redesigned pages on desktop and mobile with targeted evidence for changed surfaces
+- [ ] 6.2 Confirm that no posts, routes, or feature surfaces were lost during the redesign
+- [ ] 6.3 Queue the next round of copy, book, newsletter, and aesthetic refinements after continuity review


### PR DESCRIPTION
## Context

The site redesign had already started locally, but it existed only as an unmerged working tree on top of the current `nextjs-migration-complete` branch. Before splitting the redesign into parallel workstreams, that shared shell work needed to become a stable branch that other branches could safely build from.

This PR creates that integration base. It captures the initial editorial shell, the first pass on the homepage and key top-level pages, the experimental `/book` route, and the continuity-first OpenSpec planning artifacts that now govern the migration. The goal is not to finish the redesign here. The goal is to establish a buildable, reviewable base branch for stacked follow-on PRs.

The planning model also changed in this pass. We are no longer treating parity as a freeze gate before any redesign can happen. Instead, the redesign can proceed in parallel as long as posts, routes, wording-by-default, metadata, and feature surfaces are not silently lost.

## What changed

- **editorial shell**: Added the first shared editorial frame and top navigation for the new site direction.
- **top-level pages**: Reworked the homepage, posts index, talks, publications, about, and book pages onto the new shell as the initial redesign baseline.
- **global styling**: Added the first pass of the editorial visual system and shared styles used by the redesigned pages.
- **OpenSpec workflow**: Added `openspec/` plus the Claude OpenSpec commands/skills, and updated the active change to require continuity protection while redesign work proceeds.
- **repo ignore rules**: Ignored Dolt database files created by `bd` so local task tracking state does not leak into commits.

## Why this matters

Without a shared foundation branch, parallel implementation would either branch from stale code or fight over an uncommitted working tree. This PR gives the redesign a concrete base that can support stacked PRs from multiple worktrees.

It also locks in the correct planning contract before more code lands. The real risk in this migration is not visual difference from the old site. It is accidentally dropping posts, routes, metadata, or behaviors while the new design is being built.

## Next steps

- Split route families and continuity systems into stacked worktree PRs.
- Keep all child PRs unmerged until the redesign slices are reviewed together.
- Refine copy and visual fidelity after the continuity pass is complete.

## Test plan

- [x] `npm run build`
- [x] Verified the generated route set still includes posts, archives, tags, talks, publications, about, search, code-and-tools, feeds, and the new `/book` route
- [ ] Manual browser review still needed across the stacked child PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
