### PR TITLE
feat: redesign discovery routes

### DIFF
--- a/app/archive/page.tsx
+++ b/app/archive/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
+import { EditorialPageFrame } from '../components/EditorialPageFrame';
 import { postService } from '../services/PostService';
 
 export const metadata: Metadata = {
@@ -9,33 +10,30 @@ export const metadata: Metadata = {
 
 export default async function ArchivePage() {
   const posts = await postService.getAllPosts();
-  
-  // Group posts by year and month
   const postsByYearMonth = posts.reduce((acc, post) => {
     const year = post.date.getFullYear();
     const month = post.date.getMonth();
-    const key = `${year}-${month}`;
-    
-    if (!acc[key]) {
-      acc[key] = {
+    const monthKey = `${year}-${String(month + 1).padStart(2, '0')}`;
+
+    if (!acc[monthKey]) {
+      acc[monthKey] = {
         year,
         month,
-        monthName: post.date.toLocaleDateString('en-US', { month: 'long' }),
-        posts: []
+        monthLabel: post.date.toLocaleDateString('en-US', { month: 'long' }),
+        monthHref: `/archives/${monthKey}`,
+        posts: [],
       };
     }
-    
-    acc[key].posts.push(post);
-    return acc;
-  }, {} as Record<string, { year: number; month: number; monthName: string; posts: typeof posts }>);
 
-  // Sort by year and month
+    acc[monthKey].posts.push(post);
+    return acc;
+  }, {} as Record<string, { year: number; month: number; monthLabel: string; monthHref: string; posts: typeof posts }>);
+
   const sortedEntries = Object.values(postsByYearMonth).sort((a, b) => {
     if (a.year !== b.year) return b.year - a.year;
     return b.month - a.month;
   });
 
-  // Group by year for display
   const postsByYear = sortedEntries.reduce((acc, entry) => {
     if (!acc[entry.year]) {
       acc[entry.year] = [];
@@ -45,73 +43,67 @@ export default async function ArchivePage() {
   }, {} as Record<number, typeof sortedEntries>);
 
   const years = Object.keys(postsByYear).map(Number).sort((a, b) => b - a);
+  const uniqueTags = new Set(posts.flatMap((post) => post.tags)).size;
 
   return (
-    <div className="archive-page">
-      <div className="page-header">
-        <h1 className="page-title">Archive</h1>
-        <p className="page-subtitle">
-          {posts.length} posts across {years.length} years
-        </p>
-      </div>
-
-      <div className="archive-content">
-        {years.map(year => (
-          <section key={year} className="archive-year">
-            <h2 className="year-heading">{year}</h2>
-            
-            <div className="months-grid">
-              {postsByYear[year].map(({ monthName, posts: monthPosts }) => (
-                <div key={`${year}-${monthName}`} className="month-section">
-                  <h3 className="month-heading">
-                    {monthName} 
-                    <span className="post-count">({monthPosts.length})</span>
-                  </h3>
-                  
-                  <ul className="posts-list">
-                    {monthPosts.map(post => (
-                      <li key={post.slug} className="archive-post">
-                        <Link href={`/posts/${post.slug}`}>
-                          <time className="archive-post-date">
-                            {post.date.getDate().toString().padStart(2, '0')}
-                          </time>
-                          <span className="archive-post-title">{post.title}</span>
-                        </Link>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </div>
-          </section>
-        ))}
-      </div>
-
-      <div className="archive-stats">
-        <h2 className="stats-heading">Post Statistics</h2>
-        <div className="stats-grid">
-          <div className="stat-card">
-            <div className="stat-value">{posts.length}</div>
-            <div className="stat-label">Total Posts</div>
-          </div>
-          <div className="stat-card">
-            <div className="stat-value">{years.length}</div>
-            <div className="stat-label">Years Active</div>
-          </div>
-          <div className="stat-card">
-            <div className="stat-value">
-              {Math.round(posts.length / years.length)}
-            </div>
-            <div className="stat-label">Posts per Year</div>
-          </div>
-          <div className="stat-card">
-            <div className="stat-value">
-              {new Set(posts.flatMap(p => p.tags)).size}
-            </div>
-            <div className="stat-label">Unique Tags</div>
-          </div>
+    <EditorialPageFrame currentPath="/archive" pageClassName="editorial-book-page">
+      <section className="editorial-page-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">Archive</p>
+          <h1 className="editorial-page-title">Archive</h1>
+          <p className="editorial-page-copy">
+            Browse the full post history by year and month, with links preserved at both the month and individual post level.
+          </p>
         </div>
-      </div>
-    </div>
+        <aside className="editorial-page-aside">
+          <p className="editorial-home-card-label">Archive at a glance</p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">{posts.length}</span>
+              <span className="editorial-page-metric-label">total posts</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">{years.length}</span>
+              <span className="editorial-page-metric-label">years represented</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">{uniqueTags}</span>
+              <span className="editorial-page-metric-label">unique tags across the archive</span>
+            </div>
+          </div>
+        </aside>
+      </section>
+
+      {years.map((year) => (
+        <section key={year} className="editorial-list-section">
+          <div className="editorial-list-heading">
+            <p className="editorial-home-section-label">Year {year}</p>
+            <h2 className="editorial-page-section-title">Monthly index for {year}.</h2>
+          </div>
+          <div className="months-grid">
+            {postsByYear[year].map(({ monthLabel, monthHref, posts: monthPosts }) => (
+              <div key={`${year}-${monthLabel}`} className="month-section">
+                <h3 className="month-heading">
+                  <Link href={monthHref}>{monthLabel}</Link>
+                  <span className="post-count">({monthPosts.length})</span>
+                </h3>
+                <ul className="posts-list">
+                  {monthPosts.map((post) => (
+                    <li key={post.slug} className="archive-post">
+                      <Link href={`/posts/${post.slug}`}>
+                        <time className="archive-post-date">
+                          {post.date.getDate().toString().padStart(2, '0')}
+                        </time>
+                        <span className="archive-post-title">{post.title}</span>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </EditorialPageFrame>
   );
 }

--- a/app/archives/[month]/page.tsx
+++ b/app/archives/[month]/page.tsx
@@ -1,6 +1,8 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { EditorialPageFrame } from '../../components/EditorialPageFrame';
 import { postService } from '../../services/PostService';
-import BlogCard from '../../components/BlogCard';
 
 interface ArchivePageProps {
   params: Promise<{
@@ -10,89 +12,120 @@ interface ArchivePageProps {
 
 export default async function ArchivePage({ params }: ArchivePageProps) {
   const { month } = await params;
-  
-  // Parse month parameter (expected format: YYYY-MM)
   const [year, monthNum] = month.split('-');
-  
+
   if (!year || !monthNum || isNaN(parseInt(year)) || isNaN(parseInt(monthNum))) {
     notFound();
   }
-  
+
   const allPosts = await postService.getAllPosts();
-  
-  // Filter posts by month
-  const monthPosts = allPosts.filter(post => {
+  const monthPosts = allPosts.filter((post) => {
     const postDate = new Date(post.date);
     const postYear = postDate.getFullYear().toString();
     const postMonth = (postDate.getMonth() + 1).toString().padStart(2, '0');
-    
+
     return postYear === year && postMonth === monthNum;
   });
-  
+
   if (monthPosts.length === 0) {
     notFound();
   }
-  
+
   const monthName = new Date(parseInt(year), parseInt(monthNum) - 1).toLocaleDateString('en-US', {
     year: 'numeric',
-    month: 'long'
+    month: 'long',
   });
-  
+
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-8">Posts from {monthName}</h1>
-      
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {monthPosts.map((post) => (
-          <BlogCard 
-            key={post.slug} 
-            slug={post.slug}
-            title={post.title}
-            date={post.date}
-            tags={post.tags}
-            excerpt={post.summary || ''}
-            readingTime={post.readingTime}
-            coverImage={post.coverImage}
-          />
-        ))}
-      </div>
-    </div>
+    <EditorialPageFrame currentPath="/archive" pageClassName="editorial-book-page">
+      <section className="editorial-page-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">Archive month</p>
+          <h1 className="editorial-page-title">{monthName}</h1>
+          <p className="editorial-page-copy">
+            Posts published in {monthName}, ordered newest first and linked back to the archive index.
+          </p>
+        </div>
+        <aside className="editorial-page-aside">
+          <p className="editorial-home-card-label">Month at a glance</p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">{monthPosts.length}</span>
+              <span className="editorial-page-metric-label">posts in this month</span>
+            </div>
+            <div>
+              <Link href="/archive" className="editorial-post-link">
+                Back to archive
+              </Link>
+            </div>
+          </div>
+        </aside>
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Posts</p>
+          <h2 className="editorial-page-section-title">Everything published during this month.</h2>
+        </div>
+        <div className="editorial-post-grid">
+          {monthPosts.map((post) => (
+            <article key={post.slug} className="editorial-post-card">
+              <div className="editorial-post-meta">
+                <span>{post.date.toLocaleDateString('en-US', { month: 'long' })}</span>
+                <span>{post.date.getFullYear()}</span>
+              </div>
+              <h2>{post.title}</h2>
+              {post.summary && <p className="editorial-post-summary">{post.summary}</p>}
+              <div className="editorial-chip-row">
+                {post.tags.slice(0, 4).map((tag) => (
+                  <span key={tag} className="editorial-chip">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+              <Link href={`/posts/${post.slug}`} className="editorial-post-link">
+                Read post
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+    </EditorialPageFrame>
   );
 }
 
 export async function generateStaticParams() {
   const allPosts = await postService.getAllPosts();
-  
-  // Get unique months from all posts
+
   const months = new Set<string>();
-  
-  allPosts.forEach(post => {
+
+  allPosts.forEach((post) => {
     const postDate = new Date(post.date);
     const year = postDate.getFullYear();
     const month = (postDate.getMonth() + 1).toString().padStart(2, '0');
     months.add(`${year}-${month}`);
   });
-  
-  return Array.from(months).map(month => ({
+
+  return Array.from(months).map((month) => ({
     month,
   }));
 }
 
-export async function generateMetadata({ params }: ArchivePageProps) {
+export async function generateMetadata({ params }: ArchivePageProps): Promise<Metadata> {
   const { month } = await params;
   const [year, monthNum] = month.split('-');
-  
+
   if (!year || !monthNum) {
     return {
       title: 'Archive Not Found',
     };
   }
-  
+
   const monthName = new Date(parseInt(year), parseInt(monthNum) - 1).toLocaleDateString('en-US', {
     year: 'numeric',
-    month: 'long'
+    month: 'long',
   });
-  
+
   return {
     title: `Posts from ${monthName} - Economic Notes`,
     description: `Browse all blog posts from ${monthName}`,

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,148 +1,180 @@
 'use client';
 
-import { useState, useEffect, Suspense } from 'react';
-import { useSearchParams } from 'next/navigation';
+import type { FormEvent } from 'react';
+import { Suspense, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { SearchResult } from '../services/UnifiedSearchService';
+import { EditorialPageFrame } from '../components/EditorialPageFrame';
+import type { SearchResult } from '../services/UnifiedSearchService';
+
+function formatResultDate(date?: Date) {
+  if (!date) return null;
+
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(new Date(date));
+}
 
 function SearchContent() {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const query = searchParams.get('q') || '';
-  
+
   const [results, setResults] = useState<SearchResult[]>([]);
   const [loading, setLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState(query);
 
   useEffect(() => {
-    if (query) {
-      performSearch(query);
-    }
-  }, [query]);
+    setSearchQuery(query);
 
-  const performSearch = async (searchTerm: string) => {
-    if (!searchTerm.trim()) {
-      setResults([]);
+    const performSearch = async (searchTerm: string) => {
+      if (!searchTerm.trim()) {
+        setResults([]);
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const response = await fetch(`/api/search?q=${encodeURIComponent(searchTerm)}`);
+        const data = await response.json();
+        setResults(data.results || []);
+      } catch (error) {
+        console.error('Search error:', error);
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (query) {
+      void performSearch(query);
       return;
     }
 
-    setLoading(true);
-    try {
-      const response = await fetch(`/api/search?q=${encodeURIComponent(searchTerm)}`);
-      const data = await response.json();
-      setResults(data.results || []);
-    } catch (error) {
-      console.error('Search error:', error);
-      setResults([]);
-    } finally {
-      setLoading(false);
-    }
-  };
+    setResults([]);
+  }, [query]);
 
-  const handleSearch = (e: React.FormEvent) => {
+  const handleSearch = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (searchQuery.trim()) {
-      window.location.href = `/search?q=${encodeURIComponent(searchQuery)}`;
+
+    const nextQuery = searchQuery.trim();
+    if (!nextQuery) {
+      router.replace('/search');
+      return;
     }
+
+    router.replace(`/search?q=${encodeURIComponent(nextQuery)}`);
   };
 
   const typeLabels: Record<string, string> = {
-    post: 'Blog Post',
+    post: 'Blog post',
     talk: 'Talk',
     publication: 'Publication',
     archive: 'Archive',
-    'code-ai': 'Code & Tools'
-  };
-
-  const typeColors: Record<string, string> = {
-    post: 'bg-blue-100 text-blue-800',
-    talk: 'bg-green-100 text-green-800',
-    publication: 'bg-purple-100 text-purple-800',
-    archive: 'bg-gray-100 text-gray-800',
-    'code-ai': 'bg-orange-100 text-orange-800'
+    'code-ai': 'Code & tools',
   };
 
   return (
-    <div className="search-results-page">
-      <div className="page-header">
-        <h1 className="page-title">Search Results</h1>
-      </div>
-
-      <form onSubmit={handleSearch} className="search-input-container">
-        <input
-          type="text"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          placeholder="Search posts, talks, publications..."
-          className="search-input-large"
-          autoFocus
-        />
-      </form>
-
-      {loading ? (
-        <div className="search-loading">
-          <div className="loading-spinner"></div>
-          <p>Searching...</p>
-        </div>
-      ) : query && results.length === 0 ? (
-        <div className="no-results">
-          <p>No results found for "{query}"</p>
-          <p className="text-sm text-gray-600 mt-2">
-            Try different keywords or check your spelling
+    <EditorialPageFrame currentPath="/search" pageClassName="editorial-book-page">
+      <section className="editorial-page-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">Search</p>
+          <h1 className="editorial-page-title">Search Results</h1>
+          <p className="editorial-page-copy">
+            Search posts, talks, publications, and code notes without leaving the editorial index.
           </p>
         </div>
-      ) : results.length > 0 ? (
-        <div className="search-results-container">
-          <p className="results-count">
-            Found {results.length} result{results.length !== 1 ? 's' : ''} for "{query}"
-          </p>
-          
-          {results.map((result) => (
-            <Link 
-              key={`${result.type}-${result.title}`}
-              href={result.url}
-              className="search-result-item"
-            >
-              <div className="search-result-content">
-                
-                <div className="search-result-details">
-                  <span className={`search-result-type ${typeColors[result.type]}`}>
-                    {typeLabels[result.type]}
-                  </span>
-                  
-                  <h2 className="search-result-title">{result.title}</h2>
-                  
-                  <p className="search-result-description">
-                    {result.description}
-                  </p>
-                  
-                  <div className="search-result-meta">
-                    {result.date && (
-                      <time>
-                        {new Date(result.date).toLocaleDateString('en-US', {
-                          year: 'numeric',
-                          month: 'long',
-                          day: 'numeric'
-                        })}
-                      </time>
-                    )}
-                    
-                    {result.tags && result.tags.length > 0 && (
-                      <div className="search-result-tags">
-                        {result.tags.slice(0, 3).map((tag: string) => (
-                          <span key={tag} className="tag-small">
-                            {tag}
-                          </span>
-                        ))}
-                      </div>
-                    )}
+        <aside className="editorial-page-aside">
+          <p className="editorial-home-card-label">Search status</p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">{results.length}</span>
+              <span className="editorial-page-metric-label">results on the current query</span>
+            </div>
+            <div>
+              <Link href="/archive" className="editorial-post-link">
+                Browse archive
+              </Link>
+            </div>
+          </div>
+        </aside>
+      </section>
+
+      <section className="editorial-list-section">
+        <form onSubmit={handleSearch} className="search-input-container">
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search posts, talks, publications..."
+            className="search-input-large"
+            autoFocus
+          />
+        </form>
+
+        {!query ? (
+          <div className="editorial-page-aside">
+            <p className="editorial-home-card-label">Try searching for</p>
+            <div className="editorial-chip-row">
+              {['memory', 'retrieval', 'economics', 'forecasting'].map((term) => (
+                <Link key={term} href={`/search?q=${encodeURIComponent(term)}`} className="editorial-chip">
+                  {term}
+                </Link>
+              ))}
+            </div>
+          </div>
+        ) : loading ? (
+          <div className="search-loading">
+            <div className="loading-spinner"></div>
+            <p>Searching...</p>
+          </div>
+        ) : results.length === 0 ? (
+          <div className="no-results">
+            <p>No results found for "{query}"</p>
+            <p className="text-sm text-gray-600 mt-2">
+              Try different keywords or check your spelling
+            </p>
+          </div>
+        ) : (
+          <>
+            <p className="results-count">
+              Found {results.length} result{results.length !== 1 ? 's' : ''} for "{query}"
+            </p>
+
+            <div className="editorial-post-grid">
+              {results.map((result) => (
+                <Link
+                  key={`${result.type}-${result.title}`}
+                  href={result.url}
+                  className="editorial-post-card search-result-item"
+                >
+                  <div className="editorial-post-meta">
+                    <span>{typeLabels[result.type]}</span>
+                    {formatResultDate(result.date) && <span>{formatResultDate(result.date)}</span>}
                   </div>
-                </div>
-              </div>
-            </Link>
-          ))}
-        </div>
-      ) : null}
-    </div>
+
+                  <h2>{result.title}</h2>
+
+                  {result.description && <p className="editorial-post-summary">{result.description}</p>}
+
+                  <div className="editorial-chip-row">
+                    {result.tags?.slice(0, 3).map((tag) => (
+                      <span key={tag} className="editorial-chip">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+
+                  <span className="editorial-post-link">Open result</span>
+                </Link>
+              ))}
+            </div>
+          </>
+        )}
+      </section>
+    </EditorialPageFrame>
   );
 }
 

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -1,17 +1,19 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
-import { postService } from '../../../services/PostService';
 import { notFound } from 'next/navigation';
-import { Metadata } from 'next';
+import { EditorialPageFrame } from '../../components/EditorialPageFrame';
+import { postService } from '../../../services/PostService';
 
 interface TagPageProps {
-  params: {
+  params: Promise<{
     tag: string;
-  };
+  }>;
 }
 
-export async function generateMetadata({ params }: { params: Promise<{ tag: string }> }): Promise<Metadata> {
+export async function generateMetadata({ params }: TagPageProps): Promise<Metadata> {
   const { tag: encodedTag } = await params;
   const tag = decodeURIComponent(encodedTag);
+
   return {
     title: `${tag} | Economic Notes`,
     description: `Browse all posts tagged with "${tag}".`,
@@ -25,50 +27,73 @@ export async function generateStaticParams() {
   }));
 }
 
-export default async function TagPage({ params }: { params: Promise<{ tag: string }> }) {
+export default async function TagPage({ params }: TagPageProps) {
   const { tag: encodedTag } = await params;
   const tag = decodeURIComponent(encodedTag);
   const posts = await postService.getPostsByTag(tag);
-  
+
   if (posts.length === 0) {
     notFound();
   }
 
   return (
-    <div className="tag-page">
-      <div className="page-header">
-        <h1 className="page-title">Posts tagged with "{tag}"</h1>
-        <p className="page-subtitle">{posts.length} post{posts.length !== 1 ? 's' : ''} found</p>
-      </div>
-      
-      <div className="posts-grid">
-        {posts.map((post: any) => (
-          <article key={post.slug} className="blog-card">
-            <Link href={`/posts/${post.slug}`}>
-              <div className="blog-card-content">
-                <h2 className="blog-card-title">{post.title}</h2>
-                <time className="blog-card-date">
-                  {post.date.toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric'
-                  })}
-                </time>
-                {post.summary && (
-                  <p className="blog-card-summary">{post.summary}</p>
-                )}
-                <div className="blog-card-tags">
-                  {post.tags.map((t: string) => (
-                    <span key={t} className={`tag ${t === tag ? 'tag-active' : ''}`}>
-                      {t}
-                    </span>
-                  ))}
-                </div>
+    <EditorialPageFrame currentPath="/tags" pageClassName="editorial-book-page">
+      <section className="editorial-page-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">Tag archive</p>
+          <h1 className="editorial-page-title">{tag}</h1>
+          <p className="editorial-page-copy">
+            {posts.length} post{posts.length !== 1 ? 's' : ''} found for this topic, ordered newest first.
+          </p>
+        </div>
+        <aside className="editorial-page-aside">
+          <p className="editorial-home-card-label">Browse links</p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">{posts.length}</span>
+              <span className="editorial-page-metric-label">posts in this tag</span>
+            </div>
+            <div>
+              <Link href="/tags" className="editorial-post-link">
+                Back to tags
+              </Link>
+            </div>
+          </div>
+        </aside>
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Posts</p>
+          <h2 className="editorial-page-section-title">Everything indexed under {tag}.</h2>
+        </div>
+        <div className="editorial-post-grid">
+          {posts.map((post) => (
+            <article key={post.slug} className="editorial-post-card">
+              <div className="editorial-post-meta">
+                <span>{post.date.toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}</span>
+                <span>{post.tags.length} tags</span>
               </div>
-            </Link>
-          </article>
-        ))}
-      </div>
-    </div>
+              <h2>{post.title}</h2>
+              {post.summary && <p className="editorial-post-summary">{post.summary}</p>}
+              <div className="editorial-chip-row">
+                {post.tags.map((postTag) => (
+                  <span key={postTag} className="editorial-chip">
+                    {postTag}
+                  </span>
+                ))}
+              </div>
+              <Link href={`/posts/${post.slug}`} className="editorial-post-link">
+                Read post
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+    </EditorialPageFrame>
   );
 }

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -1,5 +1,6 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
+import { EditorialPageFrame } from '../components/EditorialPageFrame';
 import { postService } from '../services/PostService';
 
 export const metadata: Metadata = {
@@ -9,21 +10,17 @@ export const metadata: Metadata = {
 
 export default async function TagsPage() {
   const posts = await postService.getAllPosts();
-  
-  // Extract all unique tags with counts
+
   const tagCounts = new Map<string, number>();
-  posts.forEach(post => {
-    post.tags.forEach(tag => {
+  posts.forEach((post) => {
+    post.tags.forEach((tag) => {
       tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
     });
   });
 
-  // Convert to array and sort by count
-  const sortedTags = Array.from(tagCounts.entries())
-    .sort((a, b) => b[1] - a[1]);
-
-  // Group tags by first letter
+  const sortedTags = Array.from(tagCounts.entries()).sort((a, b) => b[1] - a[1]);
   const tagsByLetter = new Map<string, Array<[string, number]>>();
+
   sortedTags.forEach(([tag, count]) => {
     const firstLetter = tag[0].toUpperCase();
     if (!tagsByLetter.has(firstLetter)) {
@@ -32,62 +29,87 @@ export default async function TagsPage() {
     tagsByLetter.get(firstLetter)!.push([tag, count]);
   });
 
-  // Sort letters
   const sortedLetters = Array.from(tagsByLetter.keys()).sort();
+  const topTagCount = sortedTags[0]?.[1] || 0;
 
   return (
-    <div className="tags-page">
-      <div className="page-header">
-        <h1 className="page-title">Tags</h1>
-        <p className="page-subtitle">
-          Explore topics across {posts.length} posts
-        </p>
-      </div>
-
-      <div className="tag-cloud">
-        <h2 className="section-title">All Tags</h2>
-        <div className="tag-cloud-container">
-          {sortedTags.map(([tag, count]) => {
-            // Calculate relative size based on count
-            const maxCount = sortedTags[0][1];
-            const minSize = 0.9;
-            const maxSize = 1.8;
-            const size = minSize + (count / maxCount) * (maxSize - minSize);
-            
-            return (
-              <Link
-                key={tag}
-                href={`/tags/${encodeURIComponent(tag)}`}
-                className="tag-cloud-item"
-                style={{ fontSize: `${size}rem` }}
-                title={`${count} post${count !== 1 ? 's' : ''}`}
-              >
-                {tag}
-              </Link>
-            );
-          })}
+    <EditorialPageFrame currentPath="/tags" pageClassName="editorial-book-page">
+      <section className="editorial-page-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">Topics</p>
+          <h1 className="editorial-page-title">Tags</h1>
+          <p className="editorial-page-copy">
+            Explore topics across {posts.length} posts, with links preserved to every tag-specific archive.
+          </p>
         </div>
-      </div>
+        <aside className="editorial-page-aside">
+          <p className="editorial-home-card-label">Tag index</p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">{sortedTags.length}</span>
+              <span className="editorial-page-metric-label">unique tags</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">{topTagCount}</span>
+              <span className="editorial-page-metric-label">posts for the most-used tag</span>
+            </div>
+          </div>
+        </aside>
+      </section>
 
-      <div className="tags-alphabetical">
-        <h2 className="section-title">Alphabetical Index</h2>
-        {sortedLetters.map(letter => (
-          <div key={letter} className="letter-group">
-            <h3 className="letter-heading">{letter}</h3>
-            <div className="letter-tags">
-              {tagsByLetter.get(letter)!.map(([tag, count]) => (
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">All tags</p>
+          <h2 className="editorial-page-section-title">A weighted cloud with direct links.</h2>
+        </div>
+        <div className="tag-cloud">
+          <div className="tag-cloud-container">
+            {sortedTags.map(([tag, count]) => {
+              const maxCount = topTagCount || 1;
+              const minSize = 0.95;
+              const maxSize = 1.85;
+              const size = minSize + (count / maxCount) * (maxSize - minSize);
+
+              return (
                 <Link
                   key={tag}
                   href={`/tags/${encodeURIComponent(tag)}`}
-                  className="tag-link"
+                  className="tag-cloud-item"
+                  style={{ fontSize: `${size}rem` }}
+                  title={`${count} post${count !== 1 ? 's' : ''}`}
                 >
-                  {tag} <span className="tag-count">({count})</span>
+                  {tag}
                 </Link>
-              ))}
-            </div>
+              );
+            })}
           </div>
-        ))}
-      </div>
-    </div>
+        </div>
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Alphabetical</p>
+          <h2 className="editorial-page-section-title">Browse the same index by first letter.</h2>
+        </div>
+        <div className="tags-alphabetical">
+          {sortedLetters.map((letter) => (
+            <div key={letter} className="letter-group">
+              <h3 className="letter-heading">{letter}</h3>
+              <div className="letter-tags">
+                {tagsByLetter.get(letter)!.map(([tag, count]) => (
+                  <Link
+                    key={tag}
+                    href={`/tags/${encodeURIComponent(tag)}`}
+                    className="tag-link"
+                  >
+                    {tag} <span className="tag-count">({count})</span>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </EditorialPageFrame>
   );
 }


### PR DESCRIPTION
## Context

This branch reshapes the discovery surfaces for archive, month archive, tags, tag detail, and search while keeping the existing grouping, sorting, and search behavior intact. The work stays inside the editorial foundation already present on this branch and avoids touching shared shell or global styles.

## What changed

- **app/archive/page.tsx**: Reframed the archive index in the editorial shell and kept the year/month grouping and post links intact.
- **app/archives/[month]/page.tsx**: Rebuilt the month view as an editorial card grid while preserving month filtering, static params, and metadata.
- **app/tags/page.tsx**: Reworked the tag index into an editorial hub with a weighted cloud and alphabetical index.
- **app/tags/[tag]/page.tsx**: Redesigned the tag landing page as an editorial results view while keeping the tag filtering and newest-first order.
- **app/search/page.tsx**: Moved search into the editorial shell, kept the API-backed query flow, and replaced full-page reloads with router navigation.

## Test plan

- [x] `npm run build`
- [x] Verified the build generates `/archive`, `/archives/[month]`, `/tags`, `/tags/[tag]`, and `/search` routes

🤖 Generated with Claude Code