### PR TITLE
feat: preserve code/tools continuity during redesign

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,22 +1,43 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { postService } from '@/services/PostService';
+import { unifiedSearchService } from '@/app/services/UnifiedSearchService';
 
-export async function GET(request: NextRequest) {
-  const searchParams = request.nextUrl.searchParams;
-  const query = searchParams.get('q');
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const query = url.searchParams.get('q')?.trim() || '';
 
   if (!query) {
-    return NextResponse.json({ posts: [] });
+    return NextResponse.json(
+      { results: [], posts: [] },
+      { headers: { 'Cache-Control': 'no-store' } }
+    );
   }
 
   try {
-    const posts = await postService.searchPosts(query);
-    return NextResponse.json({ posts });
+    const results = await unifiedSearchService.search(query);
+    return NextResponse.json(
+      {
+        results,
+        posts: results.filter((result) => result.type === 'post'),
+      },
+      { headers: { 'Cache-Control': 'no-store' } }
+    );
   } catch (error) {
     console.error('Search error:', error);
+    const posts = await postService.searchPosts(query);
     return NextResponse.json(
-      { error: 'Failed to search posts' },
-      { status: 500 }
+      {
+        results: posts.map((post) => ({
+          type: 'post' as const,
+          title: post.title,
+          description: post.summary,
+          url: `/posts/${post.slug}`,
+          date: post.date,
+          tags: post.tags,
+        })),
+        posts,
+      },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } }
     );
   }
 }

--- a/app/code-ai/[id]/page.tsx
+++ b/app/code-ai/[id]/page.tsx
@@ -1,17 +1,17 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
-import { gistItems, gistCategories, WorkshopItem } from '../../config/workshopGists';
+import { workshopConfig } from '../../config/workshopConfig';
+import { getSiteUrl } from '../../utils/siteUrl';
+import { getCodeToolsItemById, getCodeToolsStaticParams, getCodeToolsUrl } from '../../utils/codeTools';
 
 export async function generateStaticParams() {
-  return gistItems.map((item) => ({
-    id: item.id,
-  }));
+  return getCodeToolsStaticParams();
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
   const { id } = await params;
-  const item = gistItems.find(i => i.id === id);
+  const item = getCodeToolsItemById(id);
   
   if (!item) {
     return {
@@ -22,10 +22,14 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   return {
     title: `${item.title} | Code & Tools | Economic Notes`,
     description: item.description,
+    alternates: {
+      canonical: `${getSiteUrl()}${getCodeToolsUrl(id)}`,
+    },
     openGraph: {
       title: item.title,
       description: item.description,
       type: 'article',
+      url: `${getSiteUrl()}${getCodeToolsUrl(id)}`,
       publishedTime: item.date ? new Date(item.date).toISOString() : undefined,
       tags: item.tags,
     },
@@ -34,13 +38,13 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
 
 export default async function CodeAIDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const item = gistItems.find(i => i.id === id);
+  const item = getCodeToolsItemById(id);
   
   if (!item) {
     notFound();
   }
 
-  const categoryConfig = gistCategories.find(cat => cat.id === item.category);
+  const categoryConfig = workshopConfig.categories.find(cat => cat.id === item.category);
 
   return (
     <article className="code-ai-detail">

--- a/app/code-ai/page.tsx
+++ b/app/code-ai/page.tsx
@@ -5,8 +5,8 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
-import { workshopConfig, WorkshopItem } from '../config/workshopConfig';
-import { gistItems } from '../config/workshopGists';
+import { workshopConfig, type WorkshopItem } from '../config/workshopConfig';
+import { getCodeToolsItems } from '../utils/codeTools';
 
 // Map common language aliases to Prism language names
 const languageMap: Record<string, string> = {
@@ -73,18 +73,10 @@ export default function CodeAIPage() {
 
   const { title, subtitle, categories } = workshopConfig;
 
-  // Combine manual items with fetched gist items
-  const allItems = [...workshopConfig.items, ...gistItems];
-
-  // Sort all items by date, most recent first
-  const sortedItems = allItems.sort((a, b) => {
-    const dateA = a.date ? new Date(a.date).getTime() : 0;
-    const dateB = b.date ? new Date(b.date).getTime() : 0;
-    return dateB - dateA; // Most recent first
-  });
+  const allItems = getCodeToolsItems();
 
   // Filter items based on category and search
-  const filteredItems = sortedItems.filter((item: WorkshopItem) => {
+  const filteredItems = allItems.filter((item: WorkshopItem) => {
     const matchesCategory = selectedCategory === 'all' || item.category === selectedCategory;
     const matchesSearch = searchQuery === '' ||
       item.title.toLowerCase().includes(searchQuery.toLowerCase()) ||

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,7 +1,8 @@
 import { MetadataRoute } from 'next';
+import { getSiteUrl } from './utils/siteUrl';
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://economicsnotes.com';
+  const baseUrl = getSiteUrl();
   
   return {
     rules: {

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,30 +1,44 @@
 import { NextResponse } from 'next/server';
 import { postService } from '../../services/PostService';
+import { getSiteUrl } from '../utils/siteUrl';
+
+const escapeXml = (value: string): string => {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+};
 
 export async function GET() {
-  const posts = await postService.getAllPosts();
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://econoben.dev';
+  const siteUrl = getSiteUrl();
+  const posts = await postService.getAllPosts().catch((error) => {
+    console.error('RSS generation error:', error);
+    return [];
+  });
+  const latestPostDate = posts[0]?.date ? new Date(posts[0].date) : new Date();
   
   const rss = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
-    <title>Economic Notes</title>
-    <description>Exploring Economics, Technology, and Life</description>
+    <title>${escapeXml('Economic Notes')}</title>
+    <description>${escapeXml('Exploring Economics, Technology, and Life')}</description>
     <link>${siteUrl}</link>
     <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml" />
     <language>en-us</language>
-    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <lastBuildDate>${latestPostDate.toUTCString()}</lastBuildDate>
     <generator>Next.js</generator>
-    <managingEditor>benjamin.labaschin@gmail.com (Benjamin Labaschin)</managingEditor>
-    <webMaster>benjamin.labaschin@gmail.com (Benjamin Labaschin)</webMaster>
+    <managingEditor>${escapeXml('benjamin.labaschin@gmail.com (Benjamin Labaschin)')}</managingEditor>
+    <webMaster>${escapeXml('benjamin.labaschin@gmail.com (Benjamin Labaschin)')}</webMaster>
     ${posts.slice(0, 20).map((post: any) => `
     <item>
       <title><![CDATA[${post.title}]]></title>
-      <description><![CDATA[${post.summary || post.content.substring(0, 200) + '...'}]]></description>
+      <description><![CDATA[${post.summary || `${post.content.substring(0, 200)}...`}]]></description>
       <link>${siteUrl}/posts/${post.slug}</link>
       <guid isPermaLink="true">${siteUrl}/posts/${post.slug}</guid>
       <pubDate>${post.date.toUTCString()}</pubDate>
-      ${post.tags.map((tag: string) => `<category>${tag}</category>`).join('\n      ')}
+      ${post.tags.map((tag: string) => `<category>${escapeXml(tag)}</category>`).join('\n      ')}
       <content:encoded><![CDATA[${post.content}]]></content:encoded>
     </item>`).join('')}
   </channel>

--- a/app/services/UnifiedSearchService.ts
+++ b/app/services/UnifiedSearchService.ts
@@ -181,6 +181,7 @@ class UnifiedSearchService {
 
     const searchTerm = query.toLowerCase().trim();
     const suggestions = new Set<string>();
+    const codeToolsItems = getCodeToolsItems();
 
     // Get suggestions from post titles and tags
     const posts = await postService.getAllPosts();

--- a/app/services/UnifiedSearchService.ts
+++ b/app/services/UnifiedSearchService.ts
@@ -1,5 +1,5 @@
 import { postService } from '../../services/PostService';
-import { gistItems } from '../../config/workshopGists';
+import { getCodeToolsItems, getCodeToolsUrl } from '../utils/codeTools';
 
 export interface SearchResult {
   type: 'post' | 'talk' | 'publication' | 'code-ai';
@@ -135,8 +135,10 @@ class UnifiedSearchService {
       }
     });
 
-    // Search Code & Tools (workshop) items
-    gistItems.forEach((item: any) => {
+    const codeToolsItems = getCodeToolsItems();
+
+    // Search Code & Tools items
+    codeToolsItems.forEach((item: any) => {
       if (
         item.title.toLowerCase().includes(searchTerm) ||
         item.description.toLowerCase().includes(searchTerm) ||
@@ -146,7 +148,7 @@ class UnifiedSearchService {
           type: 'code-ai',
           title: item.title,
           description: item.description,
-          url: `/code-ai/${item.slug}`,
+          url: getCodeToolsUrl(item.id),
           date: item.date ? new Date(item.date) : undefined,
           tags: item.tags,
           category: item.category,
@@ -193,8 +195,8 @@ class UnifiedSearchService {
       });
     });
 
-    // Get suggestions from gist items
-    gistItems.forEach((item: any) => {
+    // Get suggestions from code tools items
+    codeToolsItems.forEach((item: any) => {
       if (item.title.toLowerCase().includes(searchTerm)) {
         suggestions.add(item.title);
       }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,9 +1,10 @@
 import { MetadataRoute } from 'next';
 import { postService } from '../services/PostService';
-import { gistItems } from '../config/workshopGists';
+import { getCodeToolsItems, getCodeToolsLatestDate, getCodeToolsUrl } from './utils/codeTools';
+import { getSiteUrl } from './utils/siteUrl';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://economicsnotes.com';
+  const baseUrl = getSiteUrl();
   
   // Get all posts
   const posts = await postService.getAllPosts();
@@ -24,7 +25,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
     {
       url: `${baseUrl}/code-ai`,
-      lastModified: new Date(),
+      lastModified: getCodeToolsLatestDate(),
       changeFrequency: 'weekly',
       priority: 0.8,
     },
@@ -63,8 +64,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }));
 
   // Code & Tools (workshop) pages
-  const codeAiPages: MetadataRoute.Sitemap = gistItems.map((item: any) => ({
-    url: `${baseUrl}/code-ai/${item.slug}`,
+  const codeAiPages: MetadataRoute.Sitemap = getCodeToolsItems().map((item: any) => ({
+    url: `${baseUrl}${getCodeToolsUrl(item.id)}`,
     lastModified: item.date ? new Date(item.date) : new Date(),
     changeFrequency: 'monthly',
     priority: 0.6,

--- a/app/utils/codeTools.ts
+++ b/app/utils/codeTools.ts
@@ -1,0 +1,46 @@
+import { workshopConfig, type WorkshopItem } from '../config/workshopConfig';
+import { gistItems } from '../config/workshopGists';
+
+export type CodeToolsItem = WorkshopItem;
+
+const codeToolsItems: CodeToolsItem[] = [...workshopConfig.items, ...gistItems];
+
+export const codeToolsCategories = workshopConfig.categories;
+
+export const getCodeToolsItems = (): CodeToolsItem[] => {
+  return [...codeToolsItems].sort((a, b) => {
+    const dateA = a.date ? new Date(a.date).getTime() : 0;
+    const dateB = b.date ? new Date(b.date).getTime() : 0;
+    return dateB - dateA;
+  });
+};
+
+export const getCodeToolsItemById = (id: string): CodeToolsItem | undefined => {
+  return codeToolsItems.find((item) => item.id === id);
+};
+
+export const getCodeToolsStaticParams = (): Array<{ id: string }> => {
+  return codeToolsItems.map((item) => ({ id: item.id }));
+};
+
+export const getCodeToolsLatestDate = (): Date => {
+  const latest = codeToolsItems.reduce((currentLatest, item) => {
+    const itemDate = item.date ? new Date(item.date) : null;
+
+    if (!itemDate) {
+      return currentLatest;
+    }
+
+    if (!currentLatest || itemDate.getTime() > currentLatest.getTime()) {
+      return itemDate;
+    }
+
+    return currentLatest;
+  }, null as Date | null);
+
+  return latest ?? new Date();
+};
+
+export const getCodeToolsUrl = (id: string): string => {
+  return `/code-ai/${encodeURIComponent(id)}`;
+};

--- a/app/utils/siteUrl.ts
+++ b/app/utils/siteUrl.ts
@@ -1,0 +1,9 @@
+const DEFAULT_SITE_URL = 'https://econoben.dev';
+
+export const getSiteUrl = (): string => {
+  return (process.env.NEXT_PUBLIC_SITE_URL || DEFAULT_SITE_URL).replace(/\/$/, '');
+};
+
+export const getAbsoluteUrl = (path: string): string => {
+  return `${getSiteUrl()}${path.startsWith('/') ? path : `/${path}`}`;
+};

--- a/tests/continuity-smoke.mjs
+++ b/tests/continuity-smoke.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const repoRoot = resolve(new URL('..', import.meta.url).pathname);
+const read = (relativePath) => readFileSync(resolve(repoRoot, relativePath), 'utf8');
+
+const codeToolsSource = read('app/utils/codeTools.ts');
+const siteUrlSource = read('app/utils/siteUrl.ts');
+const detailPageSource = read('app/code-ai/[id]/page.tsx');
+const searchRouteSource = read('app/api/search/route.ts');
+const sitemapSource = read('app/sitemap.ts');
+const rssSource = read('app/rss.xml/route.ts');
+const robotsSource = read('app/robots.ts');
+
+assert.match(codeToolsSource, /getCodeToolsItems/);
+assert.match(codeToolsSource, /getCodeToolsStaticParams/);
+assert.match(codeToolsSource, /getCodeToolsItemById/);
+assert.match(codeToolsSource, /getCodeToolsUrl/);
+
+assert.match(siteUrlSource, /DEFAULT_SITE_URL/);
+assert.match(siteUrlSource, /getAbsoluteUrl/);
+
+assert.match(detailPageSource, /getCodeToolsStaticParams/);
+assert.match(detailPageSource, /getCodeToolsItemById/);
+assert.match(detailPageSource, /alternates:/);
+assert.match(detailPageSource, /canonical:/);
+assert.match(detailPageSource, /getSiteUrl/);
+
+assert.match(searchRouteSource, /unifiedSearchService/);
+assert.match(searchRouteSource, /results:/);
+assert.match(searchRouteSource, /Cache-Control': 'no-store'/);
+
+assert.match(sitemapSource, /getCodeToolsItems/);
+assert.match(sitemapSource, /getCodeToolsLatestDate/);
+assert.match(sitemapSource, /getCodeToolsUrl/);
+assert.match(sitemapSource, /getSiteUrl/);
+
+assert.match(rssSource, /escapeXml/);
+assert.match(rssSource, /latestPostDate/);
+assert.match(rssSource, /getSiteUrl/);
+
+assert.match(robotsSource, /getSiteUrl/);
+
+console.log('continuity smoke checks passed');


### PR DESCRIPTION
## Context

The redesign work is already carving out the new shell and layout, but the site still needs its feature-backed surfaces to stay usable while that work continues. In this slice, the main risk is that the Code & Tools collection, search, and metadata endpoints drift apart: the index page already renders both workshop items and gists, but detail routing, sitemap entries, and search results were still assuming gist-only URLs.

This PR keeps those continuity surfaces aligned without touching the visual shell. It promotes the full Code & Tools item set into a shared index, makes the detail route resolve all item IDs, and routes search through the unified result service so code tools remain discoverable alongside posts.

## What changed

- **Code & Tools routing**: Added shared helpers for item lookup, static params, and stable `/code-ai/<id>` URLs so both workshop items and gists resolve through the same continuity path.
- **Search API**: Switched `/api/search` to the unified search service, added a `results` payload for the search page, and kept a `posts` compatibility field while returning `no-store` responses.
- **Metadata endpoints**: Updated `sitemap.xml`, `robots.txt`, and `rss.xml` to use a shared site URL helper, include the full Code & Tools index, and harden RSS XML escaping/error handling.
- **Continuity check**: Added a lightweight source-level smoke test under `tests/` that asserts the route and helper wiring stays intact.

## Why this matters

Without this work, the redesigned shell could ship while the remaining feature-backed surfaces silently lose discoverability or break deep links. That would be a real regression for search, indexing, and the Code & Tools collection during the migration window.

This keeps the non-visual surfaces coherent while the redesign continues, and it gives us a narrow set of guards that will catch future drift in search, sitemap, robots, and detail-page routing.

## Test plan

- [x] `node tests/continuity-smoke.mjs`
- [x] `npm run build`
- [x] `npm ci` to install missing local dependencies in the worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)
