### PR TITLE
feat: create integrated site preview stack

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -47,9 +47,25 @@ export default function AboutPage() {
           <p className="editorial-page-copy">
             I work at the intersection of AI systems, technical writing, and research. This site is where those threads meet: essays, talks, reports, and the forthcoming book on agent memory.
           </p>
+          <div className="editorial-chip-row">
+            <span className="editorial-chip">AI systems</span>
+            <span className="editorial-chip">Writing</span>
+            <span className="editorial-chip">Research</span>
+            <span className="editorial-chip">Speaking</span>
+          </div>
         </div>
         <aside className="editorial-page-aside editorial-about-photo-card">
           <img src="/assets/atlas_and_I.jpg" alt="Ben Labaschin with Atlas" />
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">systems</span>
+              <span className="editorial-page-metric-label">AI platforms and memory</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">public</span>
+              <span className="editorial-page-metric-label">writing, talks, and reports</span>
+            </div>
+          </div>
         </aside>
       </section>
 

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,22 +1,43 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { postService } from '@/services/PostService';
+import { unifiedSearchService } from '@/app/services/UnifiedSearchService';
 
-export async function GET(request: NextRequest) {
-  const searchParams = request.nextUrl.searchParams;
-  const query = searchParams.get('q');
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const query = url.searchParams.get('q')?.trim() || '';
 
   if (!query) {
-    return NextResponse.json({ posts: [] });
+    return NextResponse.json(
+      { results: [], posts: [] },
+      { headers: { 'Cache-Control': 'no-store' } }
+    );
   }
 
   try {
-    const posts = await postService.searchPosts(query);
-    return NextResponse.json({ posts });
+    const results = await unifiedSearchService.search(query);
+    return NextResponse.json(
+      {
+        results,
+        posts: results.filter((result) => result.type === 'post'),
+      },
+      { headers: { 'Cache-Control': 'no-store' } }
+    );
   } catch (error) {
     console.error('Search error:', error);
+    const posts = await postService.searchPosts(query);
     return NextResponse.json(
-      { error: 'Failed to search posts' },
-      { status: 500 }
+      {
+        results: posts.map((post) => ({
+          type: 'post' as const,
+          title: post.title,
+          description: post.summary,
+          url: `/posts/${post.slug}`,
+          date: post.date,
+          tags: post.tags,
+        })),
+        posts,
+      },
+      { status: 500, headers: { 'Cache-Control': 'no-store' } }
     );
   }
 }

--- a/app/archive/page.tsx
+++ b/app/archive/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
+import { EditorialPageFrame } from '../components/EditorialPageFrame';
 import { postService } from '../services/PostService';
 
 export const metadata: Metadata = {
@@ -9,33 +10,30 @@ export const metadata: Metadata = {
 
 export default async function ArchivePage() {
   const posts = await postService.getAllPosts();
-  
-  // Group posts by year and month
   const postsByYearMonth = posts.reduce((acc, post) => {
     const year = post.date.getFullYear();
     const month = post.date.getMonth();
-    const key = `${year}-${month}`;
-    
-    if (!acc[key]) {
-      acc[key] = {
+    const monthKey = `${year}-${String(month + 1).padStart(2, '0')}`;
+
+    if (!acc[monthKey]) {
+      acc[monthKey] = {
         year,
         month,
-        monthName: post.date.toLocaleDateString('en-US', { month: 'long' }),
-        posts: []
+        monthLabel: post.date.toLocaleDateString('en-US', { month: 'long' }),
+        monthHref: `/archives/${monthKey}`,
+        posts: [],
       };
     }
-    
-    acc[key].posts.push(post);
-    return acc;
-  }, {} as Record<string, { year: number; month: number; monthName: string; posts: typeof posts }>);
 
-  // Sort by year and month
+    acc[monthKey].posts.push(post);
+    return acc;
+  }, {} as Record<string, { year: number; month: number; monthLabel: string; monthHref: string; posts: typeof posts }>);
+
   const sortedEntries = Object.values(postsByYearMonth).sort((a, b) => {
     if (a.year !== b.year) return b.year - a.year;
     return b.month - a.month;
   });
 
-  // Group by year for display
   const postsByYear = sortedEntries.reduce((acc, entry) => {
     if (!acc[entry.year]) {
       acc[entry.year] = [];
@@ -45,73 +43,67 @@ export default async function ArchivePage() {
   }, {} as Record<number, typeof sortedEntries>);
 
   const years = Object.keys(postsByYear).map(Number).sort((a, b) => b - a);
+  const uniqueTags = new Set(posts.flatMap((post) => post.tags)).size;
 
   return (
-    <div className="archive-page">
-      <div className="page-header">
-        <h1 className="page-title">Archive</h1>
-        <p className="page-subtitle">
-          {posts.length} posts across {years.length} years
-        </p>
-      </div>
-
-      <div className="archive-content">
-        {years.map(year => (
-          <section key={year} className="archive-year">
-            <h2 className="year-heading">{year}</h2>
-            
-            <div className="months-grid">
-              {postsByYear[year].map(({ monthName, posts: monthPosts }) => (
-                <div key={`${year}-${monthName}`} className="month-section">
-                  <h3 className="month-heading">
-                    {monthName} 
-                    <span className="post-count">({monthPosts.length})</span>
-                  </h3>
-                  
-                  <ul className="posts-list">
-                    {monthPosts.map(post => (
-                      <li key={post.slug} className="archive-post">
-                        <Link href={`/posts/${post.slug}`}>
-                          <time className="archive-post-date">
-                            {post.date.getDate().toString().padStart(2, '0')}
-                          </time>
-                          <span className="archive-post-title">{post.title}</span>
-                        </Link>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </div>
-          </section>
-        ))}
-      </div>
-
-      <div className="archive-stats">
-        <h2 className="stats-heading">Post Statistics</h2>
-        <div className="stats-grid">
-          <div className="stat-card">
-            <div className="stat-value">{posts.length}</div>
-            <div className="stat-label">Total Posts</div>
-          </div>
-          <div className="stat-card">
-            <div className="stat-value">{years.length}</div>
-            <div className="stat-label">Years Active</div>
-          </div>
-          <div className="stat-card">
-            <div className="stat-value">
-              {Math.round(posts.length / years.length)}
-            </div>
-            <div className="stat-label">Posts per Year</div>
-          </div>
-          <div className="stat-card">
-            <div className="stat-value">
-              {new Set(posts.flatMap(p => p.tags)).size}
-            </div>
-            <div className="stat-label">Unique Tags</div>
-          </div>
+    <EditorialPageFrame currentPath="/archive" pageClassName="editorial-book-page">
+      <section className="editorial-page-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">Archive</p>
+          <h1 className="editorial-page-title">Archive</h1>
+          <p className="editorial-page-copy">
+            Browse the full post history by year and month, with links preserved at both the month and individual post level.
+          </p>
         </div>
-      </div>
-    </div>
+        <aside className="editorial-page-aside">
+          <p className="editorial-home-card-label">Archive at a glance</p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">{posts.length}</span>
+              <span className="editorial-page-metric-label">total posts</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">{years.length}</span>
+              <span className="editorial-page-metric-label">years represented</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">{uniqueTags}</span>
+              <span className="editorial-page-metric-label">unique tags across the archive</span>
+            </div>
+          </div>
+        </aside>
+      </section>
+
+      {years.map((year) => (
+        <section key={year} className="editorial-list-section">
+          <div className="editorial-list-heading">
+            <p className="editorial-home-section-label">Year {year}</p>
+            <h2 className="editorial-page-section-title">Monthly index for {year}.</h2>
+          </div>
+          <div className="months-grid">
+            {postsByYear[year].map(({ monthLabel, monthHref, posts: monthPosts }) => (
+              <div key={`${year}-${monthLabel}`} className="month-section">
+                <h3 className="month-heading">
+                  <Link href={monthHref}>{monthLabel}</Link>
+                  <span className="post-count">({monthPosts.length})</span>
+                </h3>
+                <ul className="posts-list">
+                  {monthPosts.map((post) => (
+                    <li key={post.slug} className="archive-post">
+                      <Link href={`/posts/${post.slug}`}>
+                        <time className="archive-post-date">
+                          {post.date.getDate().toString().padStart(2, '0')}
+                        </time>
+                        <span className="archive-post-title">{post.title}</span>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </EditorialPageFrame>
   );
 }

--- a/app/archives/[month]/page.tsx
+++ b/app/archives/[month]/page.tsx
@@ -1,6 +1,8 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { EditorialPageFrame } from '../../components/EditorialPageFrame';
 import { postService } from '../../services/PostService';
-import BlogCard from '../../components/BlogCard';
 
 interface ArchivePageProps {
   params: Promise<{
@@ -10,89 +12,120 @@ interface ArchivePageProps {
 
 export default async function ArchivePage({ params }: ArchivePageProps) {
   const { month } = await params;
-  
-  // Parse month parameter (expected format: YYYY-MM)
   const [year, monthNum] = month.split('-');
-  
+
   if (!year || !monthNum || isNaN(parseInt(year)) || isNaN(parseInt(monthNum))) {
     notFound();
   }
-  
+
   const allPosts = await postService.getAllPosts();
-  
-  // Filter posts by month
-  const monthPosts = allPosts.filter(post => {
+  const monthPosts = allPosts.filter((post) => {
     const postDate = new Date(post.date);
     const postYear = postDate.getFullYear().toString();
     const postMonth = (postDate.getMonth() + 1).toString().padStart(2, '0');
-    
+
     return postYear === year && postMonth === monthNum;
   });
-  
+
   if (monthPosts.length === 0) {
     notFound();
   }
-  
+
   const monthName = new Date(parseInt(year), parseInt(monthNum) - 1).toLocaleDateString('en-US', {
     year: 'numeric',
-    month: 'long'
+    month: 'long',
   });
-  
+
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-8">Posts from {monthName}</h1>
-      
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {monthPosts.map((post) => (
-          <BlogCard 
-            key={post.slug} 
-            slug={post.slug}
-            title={post.title}
-            date={post.date}
-            tags={post.tags}
-            excerpt={post.summary || ''}
-            readingTime={post.readingTime}
-            coverImage={post.coverImage}
-          />
-        ))}
-      </div>
-    </div>
+    <EditorialPageFrame currentPath="/archive" pageClassName="editorial-book-page">
+      <section className="editorial-page-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">Archive month</p>
+          <h1 className="editorial-page-title">{monthName}</h1>
+          <p className="editorial-page-copy">
+            Posts published in {monthName}, ordered newest first and linked back to the archive index.
+          </p>
+        </div>
+        <aside className="editorial-page-aside">
+          <p className="editorial-home-card-label">Month at a glance</p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">{monthPosts.length}</span>
+              <span className="editorial-page-metric-label">posts in this month</span>
+            </div>
+            <div>
+              <Link href="/archive" className="editorial-post-link">
+                Back to archive
+              </Link>
+            </div>
+          </div>
+        </aside>
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Posts</p>
+          <h2 className="editorial-page-section-title">Everything published during this month.</h2>
+        </div>
+        <div className="editorial-post-grid">
+          {monthPosts.map((post) => (
+            <article key={post.slug} className="editorial-post-card">
+              <div className="editorial-post-meta">
+                <span>{post.date.toLocaleDateString('en-US', { month: 'long' })}</span>
+                <span>{post.date.getFullYear()}</span>
+              </div>
+              <h2>{post.title}</h2>
+              {post.summary && <p className="editorial-post-summary">{post.summary}</p>}
+              <div className="editorial-chip-row">
+                {post.tags.slice(0, 4).map((tag) => (
+                  <span key={tag} className="editorial-chip">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+              <Link href={`/posts/${post.slug}`} className="editorial-post-link">
+                Read post
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+    </EditorialPageFrame>
   );
 }
 
 export async function generateStaticParams() {
   const allPosts = await postService.getAllPosts();
-  
-  // Get unique months from all posts
+
   const months = new Set<string>();
-  
-  allPosts.forEach(post => {
+
+  allPosts.forEach((post) => {
     const postDate = new Date(post.date);
     const year = postDate.getFullYear();
     const month = (postDate.getMonth() + 1).toString().padStart(2, '0');
     months.add(`${year}-${month}`);
   });
-  
-  return Array.from(months).map(month => ({
+
+  return Array.from(months).map((month) => ({
     month,
   }));
 }
 
-export async function generateMetadata({ params }: ArchivePageProps) {
+export async function generateMetadata({ params }: ArchivePageProps): Promise<Metadata> {
   const { month } = await params;
   const [year, monthNum] = month.split('-');
-  
+
   if (!year || !monthNum) {
     return {
       title: 'Archive Not Found',
     };
   }
-  
+
   const monthName = new Date(parseInt(year), parseInt(monthNum) - 1).toLocaleDateString('en-US', {
     year: 'numeric',
-    month: 'long'
+    month: 'long',
   });
-  
+
   return {
     title: `Posts from ${monthName} - Economic Notes`,
     description: `Browse all blog posts from ${monthName}`,

--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -4,48 +4,74 @@ import { EditorialPageFrame } from '../components/EditorialPageFrame';
 export default function BookPage() {
   return (
     <EditorialPageFrame currentPath="/book">
-        <section className="editorial-book-hero">
-          <div>
-            <p className="editorial-home-kicker">Forthcoming O&apos;Reilly book</p>
-            <h1>Agent Memory</h1>
-            <p className="editorial-home-subtitle">
-              A practical guide to how AI systems should remember, retrieve, compress, and act on information in production.
-            </p>
-            <div className="editorial-home-actions">
-              <a href="mailto:benjaminlabaschindev@gmail.com?subject=Agent%20Memory%20updates" className="editorial-home-button editorial-home-button-primary">
-                Get updates
-              </a>
-              <Link href="/publications" className="editorial-home-button editorial-home-button-secondary">
-                See related work
-              </Link>
+      <section className="editorial-book-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">Forthcoming O&apos;Reilly book</p>
+          <h1 className="editorial-page-title">Agent Memory</h1>
+          <p className="editorial-page-copy">
+            A practical guide to how AI systems should remember, retrieve, compress, and act on information in production.
+          </p>
+          <div className="editorial-chip-row">
+            <span className="editorial-chip">Memory</span>
+            <span className="editorial-chip">Retrieval</span>
+            <span className="editorial-chip">Compression</span>
+            <span className="editorial-chip">Action</span>
+          </div>
+          <div className="editorial-home-actions">
+            <a href="mailto:benjaminlabaschindev@gmail.com?subject=Agent%20Memory%20updates" className="editorial-home-button editorial-home-button-primary">
+              Get updates
+            </a>
+            <Link href="/publications" className="editorial-home-button editorial-home-button-secondary">
+              See related work
+            </Link>
+          </div>
+        </div>
+
+        <aside className="editorial-home-book-card">
+          <p className="editorial-home-card-label">Working direction</p>
+          <h2>Why it belongs here</h2>
+          <p>
+            One domain, one body of work, one list. The book should strengthen the platform, not split it into a second identity.
+          </p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">one</span>
+              <span className="editorial-page-metric-label">coherent public arc</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">O&apos;Reilly</span>
+              <span className="editorial-page-metric-label">publisher and home base</span>
             </div>
           </div>
+        </aside>
+      </section>
 
-          <aside className="editorial-home-book-card">
-            <p className="editorial-home-card-label">Working direction</p>
-            <h2>Why it belongs here</h2>
-            <p>
-              One domain, one body of work, one list. The book should strengthen the platform, not split it into a second identity.
-            </p>
-          </aside>
-        </section>
+      <section className="editorial-home-proof-strip" aria-label="Book summary">
+        <span>Memory systems</span>
+        <span>/</span>
+        <span>retrieval design</span>
+        <span>/</span>
+        <span>compression strategies</span>
+        <span>/</span>
+        <span>production AI</span>
+      </section>
 
-        <section className="editorial-home-grid">
-          <article className="editorial-home-card">
-            <p className="editorial-home-card-label">What belongs here</p>
-            <h3>Context, audience, and updates.</h3>
-            <p>
-              Explain why the book matters, who it is for, and why readers should follow the project now instead of waiting for launch week.
-            </p>
-          </article>
-          <article className="editorial-home-card">
-            <p className="editorial-home-card-label">How it connects</p>
-            <h3>The reports, talks, and book should read as one arc.</h3>
-            <p>
-              This page should point back to the O&apos;Reilly reports, talks, and essays so the book feels like the next step in the same public body of work.
-            </p>
-          </article>
-        </section>
+      <section className="editorial-home-grid">
+        <article className="editorial-home-card">
+          <p className="editorial-home-card-label">What belongs here</p>
+          <h3>Context, audience, and updates.</h3>
+          <p>
+            Explain why the book matters, who it is for, and why readers should follow the project now instead of waiting for launch week.
+          </p>
+        </article>
+        <article className="editorial-home-card">
+          <p className="editorial-home-card-label">How it connects</p>
+          <h3>The reports, talks, and book should read as one arc.</h3>
+          <p>
+            This page should point back to the O&apos;Reilly reports, talks, and essays so the book feels like the next step in the same public body of work.
+          </p>
+        </article>
+      </section>
     </EditorialPageFrame>
   );
 }

--- a/app/code-ai/[id]/page.tsx
+++ b/app/code-ai/[id]/page.tsx
@@ -1,17 +1,17 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
-import { gistItems, gistCategories, WorkshopItem } from '../../config/workshopGists';
+import { workshopConfig } from '../../config/workshopConfig';
+import { getSiteUrl } from '../../utils/siteUrl';
+import { getCodeToolsItemById, getCodeToolsStaticParams, getCodeToolsUrl } from '../../utils/codeTools';
 
 export async function generateStaticParams() {
-  return gistItems.map((item) => ({
-    id: item.id,
-  }));
+  return getCodeToolsStaticParams();
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
   const { id } = await params;
-  const item = gistItems.find(i => i.id === id);
+  const item = getCodeToolsItemById(id);
   
   if (!item) {
     return {
@@ -22,10 +22,14 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   return {
     title: `${item.title} | Code & Tools | Economic Notes`,
     description: item.description,
+    alternates: {
+      canonical: `${getSiteUrl()}${getCodeToolsUrl(id)}`,
+    },
     openGraph: {
       title: item.title,
       description: item.description,
       type: 'article',
+      url: `${getSiteUrl()}${getCodeToolsUrl(id)}`,
       publishedTime: item.date ? new Date(item.date).toISOString() : undefined,
       tags: item.tags,
     },
@@ -34,13 +38,13 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
 
 export default async function CodeAIDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const item = gistItems.find(i => i.id === id);
+  const item = getCodeToolsItemById(id);
   
   if (!item) {
     notFound();
   }
 
-  const categoryConfig = gistCategories.find(cat => cat.id === item.category);
+  const categoryConfig = workshopConfig.categories.find(cat => cat.id === item.category);
 
   return (
     <article className="code-ai-detail">

--- a/app/code-ai/page.tsx
+++ b/app/code-ai/page.tsx
@@ -5,8 +5,8 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
-import { workshopConfig, WorkshopItem } from '../config/workshopConfig';
-import { gistItems } from '../config/workshopGists';
+import { workshopConfig, type WorkshopItem } from '../config/workshopConfig';
+import { getCodeToolsItems } from '../utils/codeTools';
 
 // Map common language aliases to Prism language names
 const languageMap: Record<string, string> = {
@@ -73,18 +73,10 @@ export default function CodeAIPage() {
 
   const { title, subtitle, categories } = workshopConfig;
 
-  // Combine manual items with fetched gist items
-  const allItems = [...workshopConfig.items, ...gistItems];
-
-  // Sort all items by date, most recent first
-  const sortedItems = allItems.sort((a, b) => {
-    const dateA = a.date ? new Date(a.date).getTime() : 0;
-    const dateB = b.date ? new Date(b.date).getTime() : 0;
-    return dateB - dateA; // Most recent first
-  });
+  const allItems = getCodeToolsItems();
 
   // Filter items based on category and search
-  const filteredItems = sortedItems.filter((item: WorkshopItem) => {
+  const filteredItems = allItems.filter((item: WorkshopItem) => {
     const matchesCategory = selectedCategory === 'all' || item.category === selectedCategory;
     const matchesSearch = searchQuery === '' ||
       item.title.toLowerCase().includes(searchQuery.toLowerCase()) ||

--- a/app/components/MainContent.tsx
+++ b/app/components/MainContent.tsx
@@ -1,41 +1,40 @@
 'use client';
 
-import React from 'react';
+import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { EditorialPageFrame } from './EditorialPageFrame';
-
-interface Post {
-  slug: string;
-  title: string;
-  date: Date;
-  tags: string[];
-  summary?: string;
-  content: string;
-  readingTime?: number;
-}
+import type { Post } from '../services/PostService';
 
 interface MainContentProps {
   posts: Post[];
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 interface DefaultHomeContentProps {
   posts: Post[];
 }
 
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
 const getExcerpt = (content: string, summary?: string): string => {
   if (summary && summary.trim()) {
     return summary.length <= 150 ? summary : summary.substring(0, 147) + '...';
   }
 
-  const firstParagraph = content.split('\n\n')[0];
+  const firstParagraph = content.split('\n\n')[0] || '';
   if (firstParagraph.length <= 150) {
     return firstParagraph;
   }
   return firstParagraph.substring(0, 147) + '...';
 };
 
-const DefaultHomeContent: React.FC<DefaultHomeContentProps> = ({ posts }) => {
+const getPrimaryTag = (post: Post): string => post.tags[0] ?? 'Essay';
+
+const DefaultHomeContent = ({ posts }: DefaultHomeContentProps) => {
   if (!posts || posts.length === 0) {
     return (
       <div className="home-loading">
@@ -46,103 +45,102 @@ const DefaultHomeContent: React.FC<DefaultHomeContentProps> = ({ posts }) => {
   }
 
   const newestPost = posts[0];
-  const secondaryPost = posts[1] ?? newestPost;
-  const tertiaryPost = posts[2] ?? secondaryPost;
+  const featuredPosts = posts.slice(0, 3);
   const newestExcerpt = getExcerpt(newestPost.content, newestPost.summary);
 
   return (
     <EditorialPageFrame currentPath="/" pageClassName="editorial-home-page">
-        <section className="editorial-home-hero">
-          <div className="editorial-home-hero-copy">
-            <p className="editorial-home-kicker">Technical editorial platform</p>
-            <h1>Writing about how AI systems remember, fail, and scale.</h1>
-            <p className="editorial-home-subtitle">
-              A public platform for essays, talks, O&apos;Reilly reports, and the forthcoming book on agent memory.
-            </p>
-            <div className="editorial-home-actions">
-              <Link href="/book" className="editorial-home-button editorial-home-button-primary">
-                Follow the book
-              </Link>
-              <Link href={`/posts/${newestPost.slug}`} className="editorial-home-button editorial-home-button-secondary">
-                Browse selected writing
-              </Link>
-            </div>
-          </div>
-
-          <aside className="editorial-home-book-card">
-            <p className="editorial-home-card-label">Book in progress</p>
-            <h2>Agent Memory</h2>
-            <p>
-              A forthcoming O&apos;Reilly book on how modern AI systems structure retrieval, memory, and long-running context.
-            </p>
-            <div className="editorial-home-book-meta">
-              <span>Q1 2027</span>
-              <span>O&apos;Reilly</span>
-              <span>newsletter-led launch</span>
-            </div>
-            <Link href="/book" className="editorial-home-button editorial-home-button-accent">
-              Read updates
+      <section className="editorial-home-hero">
+        <div className="editorial-home-hero-copy">
+          <p className="editorial-home-kicker">Writing archive</p>
+          <h1>Writing about how AI systems remember, fail, and scale.</h1>
+          <p className="editorial-home-subtitle">
+            A public platform for essays, talks, O&apos;Reilly reports, and the forthcoming book on agent memory.
+          </p>
+          <div className="editorial-home-actions">
+            <Link href={`/posts/${newestPost.slug}`} className="editorial-home-button editorial-home-button-primary">
+              Read the latest post
             </Link>
-          </aside>
-        </section>
-
-        <section className="editorial-home-proof-strip" aria-label="Proof of work">
-          <span>Principal ML Engineer</span>
-          <span>/</span>
-          <span>O&apos;Reilly reports</span>
-          <span>/</span>
-          <span>ODSC + Agents in Production talks</span>
-          <span>/</span>
-          <span>forthcoming book</span>
-        </section>
-
-        <section className="editorial-home-section">
-          <p className="editorial-home-section-label">Selected work</p>
-          <h2>A homepage that curates, instead of dumping a feed.</h2>
-          <div className="editorial-home-grid">
-            <article className="editorial-home-card">
-              <p className="editorial-home-card-label">Essay</p>
-              <h3>The strongest writing gets space to breathe.</h3>
-              <p>
-                Feature one important post or report with enough room for an opinion, not just a thumbnail and a date.
-              </p>
-              <Link href={`/posts/${newestPost.slug}`} className="editorial-home-card-link">
-                {newestPost.title}
-              </Link>
-              <p className="editorial-home-card-footnote">{newestExcerpt}</p>
-            </article>
-
-            <article className="editorial-home-card">
-              <p className="editorial-home-card-label">Talks + proof</p>
-              <h3>Pull authority forward. Don&apos;t hide it in subpages.</h3>
-              <p>
-                Talks, reports, and current work should reinforce the same story visitors infer from the hero.
-              </p>
-              <div className="editorial-home-proof-links">
-                <Link href="/talks">See talks</Link>
-                <Link href="/publications">See publications</Link>
-              </div>
-            </article>
+            <Link href="/posts" className="editorial-home-button editorial-home-button-secondary">
+              Browse the archive
+            </Link>
           </div>
-        </section>
+        </div>
 
-        <section className="editorial-home-cta-band">
-          <div>
-            <p className="editorial-home-card-label">Newsletter + book</p>
-            <h3>A lightweight conversion layer. Present, not pushy.</h3>
-            <p>
-              Make the next action obvious: follow the book, subscribe for updates, or browse the strongest writing and talks.
-            </p>
+        <aside className="editorial-home-book-card">
+          <p className="editorial-home-card-label">Latest post</p>
+          <h2>{newestPost.title}</h2>
+          <p>{newestExcerpt}</p>
+          <div className="editorial-home-book-meta">
+            <span>{dateFormatter.format(newestPost.date)}</span>
+            <span>{newestPost.readingTime ? `${newestPost.readingTime} min read` : 'Read now'}</span>
+            <span>{getPrimaryTag(newestPost)}</span>
           </div>
-          <Link href="/book" className="editorial-home-button editorial-home-button-primary">
-            Start the list
+          <Link href={`/posts/${newestPost.slug}`} className="editorial-home-button editorial-home-button-accent">
+            Open the essay
           </Link>
-        </section>
+        </aside>
+      </section>
+
+      <section className="editorial-home-proof-strip" aria-label="Proof of work">
+        <span>{posts.length} published posts</span>
+        <span>/</span>
+        <span>Principal ML Engineer</span>
+        <span>/</span>
+        <span>O&apos;Reilly reports</span>
+        <span>/</span>
+        <span>forthcoming book</span>
+      </section>
+
+      <section className="editorial-home-section">
+        <p className="editorial-home-section-label">Selected work</p>
+        <h2>Recent posts with enough room to decide what to read next.</h2>
+        <div className="editorial-home-grid">
+          {featuredPosts.map((post) => {
+            const excerpt = getExcerpt(post.content, post.summary);
+            return (
+              <article key={post.slug} className="editorial-home-card">
+                <p className="editorial-home-card-label">{getPrimaryTag(post)}</p>
+                <h3>
+                  <Link href={`/posts/${post.slug}`} className="editorial-home-card-link">
+                    {post.title}
+                  </Link>
+                </h3>
+                <p>{excerpt}</p>
+                <div className="editorial-home-book-meta">
+                  <span>{dateFormatter.format(post.date)}</span>
+                  <span>{post.readingTime ? `${post.readingTime} min read` : 'Essay'}</span>
+                </div>
+                <div className="editorial-chip-row">
+                  {post.tags.slice(0, 3).map((tag) => (
+                    <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
+                      {tag}
+                    </Link>
+                  ))}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="editorial-home-cta-band">
+        <div>
+          <p className="editorial-home-card-label">Newsletter + book</p>
+          <h3>A lightweight conversion layer, not a hard sell.</h3>
+          <p>
+            Follow the book, browse the archive, or move into talks and publications if you want the broader context.
+          </p>
+        </div>
+        <Link href="/book" className="editorial-home-button editorial-home-button-primary">
+          Read book updates
+        </Link>
+      </section>
     </EditorialPageFrame>
   );
 };
 
-export const MainContent: React.FC<MainContentProps> = ({ posts, children }) => {
+export const MainContent = ({ posts, children }: MainContentProps) => {
   if (!children) {
     return <DefaultHomeContent posts={posts} />;
   }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
+import { EditorialPageFrame } from '../../components/EditorialPageFrame';
 import { postService } from '../../services/PostService';
 import MarkdownRenderer from '../../components/MarkdownRenderer';
 import AudioPlayer from '../../components/AudioPlayer';
@@ -16,7 +17,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
   const { slug } = await params;
   const post = await postService.getPostBySlug(slug);
-  
+
   if (!post) {
     return {
       title: 'Post Not Found | Economic Notes',
@@ -24,7 +25,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   }
 
   // Generate OG image URL
-  const imageUrl = post.coverImage 
+  const imageUrl = post.coverImage
     ? `https://econoben.dev${post.coverImage}`
     : (() => {
         const ogImageParams = new URLSearchParams({
@@ -75,35 +76,64 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
     });
   };
 
-  // Check if audio exists for this post
+  const primaryTag = post.tags[0];
   const audioUrl = audioManifest[slug as keyof typeof audioManifest];
 
   return (
-    <div className="post-detail">
-      <div className="blog-header">
-        <h1 className="blog-title">{post.title}</h1>
-        <div className="blog-meta">
-          {formatDate(post.date)}
-          {post.tags.map(tag => (
-            <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`}>
-              <span className="blog-tag">{tag}</span>
+    <EditorialPageFrame currentPath="/posts">
+      <section className="editorial-page-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">{primaryTag}</p>
+          <h1 className="editorial-page-title">{post.title}</h1>
+          {post.summary && <p className="editorial-page-copy">{post.summary}</p>}
+          <div className="editorial-home-actions">
+            <Link href="/posts" className="editorial-home-button editorial-home-button-secondary">
+              Back to posts
             </Link>
-          ))}
+            {primaryTag ? (
+              <Link href={`/tags/${encodeURIComponent(primaryTag)}`} className="editorial-home-button editorial-home-button-primary">
+                Browse this topic
+              </Link>
+            ) : null}
+          </div>
         </div>
-      </div>
+        <aside className="editorial-page-aside">
+          <p className="editorial-home-card-label">Post details</p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">{formatDate(post.date)}</span>
+              <span className="editorial-page-metric-label">published date</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">{post.readingTime ? `${post.readingTime} min` : 'Essay'}</span>
+              <span className="editorial-page-metric-label">reading time</span>
+            </div>
+          </div>
+          <div className="editorial-chip-row">
+            {post.tags.length > 0
+              ? post.tags.map((tag) => (
+                  <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
+                    {tag}
+                  </Link>
+                ))
+              : <span className="editorial-chip">Essay</span>}
+          </div>
+        </aside>
+      </section>
 
-      {/* Audio Player - only show if audio file exists */}
-      {audioUrl && (
-        <AudioPlayer
-          audioUrl={audioUrl}
-          title="Listen to this post"
-          className="post-audio-player"
-        />
-      )}
+      <section className="editorial-list-section">
+        {audioUrl && (
+          <AudioPlayer
+            audioUrl={audioUrl}
+            title="Listen to this post"
+            className="post-audio-player"
+          />
+        )}
 
-      <div className="blog-content">
-        <MarkdownRenderer content={post.content} />
-      </div>
-    </div>
+        <div className="blog-content">
+          <MarkdownRenderer content={post.content} />
+        </div>
+      </section>
+    </EditorialPageFrame>
   );
 }

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -8,13 +8,16 @@ export const metadata: Metadata = {
   description: 'Essays on AI systems, engineering, memory, and adjacent technical work.',
 };
 
+const formatter = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+});
+
+const getPrimaryTag = (tags: string[]): string => tags[0] ?? 'Essay';
+
 export default async function PostsPage() {
   const posts = await postService.getAllPosts();
-  const formatter = new Intl.DateTimeFormat('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
   const featuredPost = posts[0];
 
   return (
@@ -48,7 +51,7 @@ export default async function PostsPage() {
       </section>
 
       <section className="editorial-home-proof-strip" aria-label="Posts summary">
-        <span>long-form essays</span>
+        <span>{posts.length} posts</span>
         <span>/</span>
         <span>systems + infrastructure</span>
         <span>/</span>
@@ -64,26 +67,35 @@ export default async function PostsPage() {
         </div>
 
         <div className="editorial-post-grid">
-        {posts.map((post) => (
-          <article key={post.slug} className="editorial-post-card">
-            <div className="editorial-post-meta">
-              <span>{post.tags[0] ?? 'Essay'}</span>
-              <span>{formatter.format(post.date)}</span>
-            </div>
-            <h2>{post.title}</h2>
-            {post.summary && <p className="editorial-post-summary">{post.summary}</p>}
-            <div className="editorial-chip-row">
-              {post.tags.slice(0, 3).map((tag) => (
-                <span key={tag} className="editorial-chip">
-                  {tag}
-                </span>
-              ))}
-            </div>
-            <Link href={`/posts/${post.slug}`} className="editorial-post-link">
-              Read the post
-            </Link>
-          </article>
-        ))}
+          {posts.map((post) => (
+            <article key={post.slug} className="editorial-post-card">
+              <div className="editorial-post-meta">
+                {post.tags[0] ? (
+                  <Link href={`/tags/${encodeURIComponent(post.tags[0])}`} className="editorial-chip">
+                    <span>{post.tags[0]}</span>
+                  </Link>
+                ) : (
+                  <span className="editorial-chip">Essay</span>
+                )}
+                <span>{formatter.format(post.date)}</span>
+                {post.readingTime && <span>{post.readingTime} min read</span>}
+              </div>
+              <h2>
+                <Link href={`/posts/${post.slug}`}>{post.title}</Link>
+              </h2>
+              {post.summary && <p className="editorial-post-summary">{post.summary}</p>}
+              <div className="editorial-chip-row">
+                {post.tags.slice(0, 3).map((tag) => (
+                  <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
+                    {tag}
+                  </Link>
+                ))}
+              </div>
+              <Link href={`/posts/${post.slug}`} className="editorial-post-link">
+                Read the post
+              </Link>
+            </article>
+          ))}
         </div>
       </section>
     </EditorialPageFrame>

--- a/app/publications/page.tsx
+++ b/app/publications/page.tsx
@@ -12,6 +12,7 @@ export default function PublicationsPage() {
   const sortedPublications = [...publications].sort((a, b) => b.year - a.year);
   const featuredPublications = sortedPublications.filter(pub => pub.featured);
   const otherPublications = sortedPublications.filter(pub => !pub.featured);
+  const latestPublication = sortedPublications[0];
 
   return (
     <EditorialPageFrame currentPath="/publications">
@@ -22,6 +23,12 @@ export default function PublicationsPage() {
           <p className="editorial-page-copy">
             O&apos;Reilly work, formal research, and longer-form pieces that anchor the writing and talks elsewhere on the site.
           </p>
+          <div className="editorial-chip-row">
+            <span className="editorial-chip">O&apos;Reilly</span>
+            <span className="editorial-chip">Research</span>
+            <span className="editorial-chip">Reports</span>
+            <span className="editorial-chip">Long-form writing</span>
+          </div>
         </div>
         <aside className="editorial-page-aside">
           <p className="editorial-home-card-label">What&apos;s here</p>
@@ -31,10 +38,17 @@ export default function PublicationsPage() {
               <span className="editorial-page-metric-label">major publications</span>
             </div>
             <div>
-              <span className="editorial-page-metric-value">2025</span>
+              <span className="editorial-page-metric-value">{latestPublication?.year ?? 'n/a'}</span>
               <span className="editorial-page-metric-label">latest release year</span>
             </div>
+            <div>
+              <span className="editorial-page-metric-value">{featuredPublications.length}</span>
+              <span className="editorial-page-metric-label">featured entries</span>
+            </div>
           </div>
+          <p className="editorial-post-summary">
+            Featured work appears first so the newest or most central pieces are easy to find.
+          </p>
         </aside>
       </section>
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,7 +1,8 @@
 import { MetadataRoute } from 'next';
+import { getSiteUrl } from './utils/siteUrl';
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://economicsnotes.com';
+  const baseUrl = getSiteUrl();
   
   return {
     rules: {

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,30 +1,44 @@
 import { NextResponse } from 'next/server';
 import { postService } from '../../services/PostService';
+import { getSiteUrl } from '../utils/siteUrl';
+
+const escapeXml = (value: string): string => {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+};
 
 export async function GET() {
-  const posts = await postService.getAllPosts();
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://econoben.dev';
+  const siteUrl = getSiteUrl();
+  const posts = await postService.getAllPosts().catch((error) => {
+    console.error('RSS generation error:', error);
+    return [];
+  });
+  const latestPostDate = posts[0]?.date ? new Date(posts[0].date) : new Date();
   
   const rss = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
-    <title>Economic Notes</title>
-    <description>Exploring Economics, Technology, and Life</description>
+    <title>${escapeXml('Economic Notes')}</title>
+    <description>${escapeXml('Exploring Economics, Technology, and Life')}</description>
     <link>${siteUrl}</link>
     <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml" />
     <language>en-us</language>
-    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <lastBuildDate>${latestPostDate.toUTCString()}</lastBuildDate>
     <generator>Next.js</generator>
-    <managingEditor>benjamin.labaschin@gmail.com (Benjamin Labaschin)</managingEditor>
-    <webMaster>benjamin.labaschin@gmail.com (Benjamin Labaschin)</webMaster>
+    <managingEditor>${escapeXml('benjamin.labaschin@gmail.com (Benjamin Labaschin)')}</managingEditor>
+    <webMaster>${escapeXml('benjamin.labaschin@gmail.com (Benjamin Labaschin)')}</webMaster>
     ${posts.slice(0, 20).map((post: any) => `
     <item>
       <title><![CDATA[${post.title}]]></title>
-      <description><![CDATA[${post.summary || post.content.substring(0, 200) + '...'}]]></description>
+      <description><![CDATA[${post.summary || `${post.content.substring(0, 200)}...`}]]></description>
       <link>${siteUrl}/posts/${post.slug}</link>
       <guid isPermaLink="true">${siteUrl}/posts/${post.slug}</guid>
       <pubDate>${post.date.toUTCString()}</pubDate>
-      ${post.tags.map((tag: string) => `<category>${tag}</category>`).join('\n      ')}
+      ${post.tags.map((tag: string) => `<category>${escapeXml(tag)}</category>`).join('\n      ')}
       <content:encoded><![CDATA[${post.content}]]></content:encoded>
     </item>`).join('')}
   </channel>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,148 +1,180 @@
 'use client';
 
-import { useState, useEffect, Suspense } from 'react';
-import { useSearchParams } from 'next/navigation';
+import type { FormEvent } from 'react';
+import { Suspense, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { SearchResult } from '../services/UnifiedSearchService';
+import { EditorialPageFrame } from '../components/EditorialPageFrame';
+import type { SearchResult } from '../services/UnifiedSearchService';
+
+function formatResultDate(date?: Date) {
+  if (!date) return null;
+
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(new Date(date));
+}
 
 function SearchContent() {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const query = searchParams.get('q') || '';
-  
+
   const [results, setResults] = useState<SearchResult[]>([]);
   const [loading, setLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState(query);
 
   useEffect(() => {
-    if (query) {
-      performSearch(query);
-    }
-  }, [query]);
+    setSearchQuery(query);
 
-  const performSearch = async (searchTerm: string) => {
-    if (!searchTerm.trim()) {
-      setResults([]);
+    const performSearch = async (searchTerm: string) => {
+      if (!searchTerm.trim()) {
+        setResults([]);
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const response = await fetch(`/api/search?q=${encodeURIComponent(searchTerm)}`);
+        const data = await response.json();
+        setResults(data.results || []);
+      } catch (error) {
+        console.error('Search error:', error);
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (query) {
+      void performSearch(query);
       return;
     }
 
-    setLoading(true);
-    try {
-      const response = await fetch(`/api/search?q=${encodeURIComponent(searchTerm)}`);
-      const data = await response.json();
-      setResults(data.results || []);
-    } catch (error) {
-      console.error('Search error:', error);
-      setResults([]);
-    } finally {
-      setLoading(false);
-    }
-  };
+    setResults([]);
+  }, [query]);
 
-  const handleSearch = (e: React.FormEvent) => {
+  const handleSearch = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (searchQuery.trim()) {
-      window.location.href = `/search?q=${encodeURIComponent(searchQuery)}`;
+
+    const nextQuery = searchQuery.trim();
+    if (!nextQuery) {
+      router.replace('/search');
+      return;
     }
+
+    router.replace(`/search?q=${encodeURIComponent(nextQuery)}`);
   };
 
   const typeLabels: Record<string, string> = {
-    post: 'Blog Post',
+    post: 'Blog post',
     talk: 'Talk',
     publication: 'Publication',
     archive: 'Archive',
-    'code-ai': 'Code & Tools'
-  };
-
-  const typeColors: Record<string, string> = {
-    post: 'bg-blue-100 text-blue-800',
-    talk: 'bg-green-100 text-green-800',
-    publication: 'bg-purple-100 text-purple-800',
-    archive: 'bg-gray-100 text-gray-800',
-    'code-ai': 'bg-orange-100 text-orange-800'
+    'code-ai': 'Code & tools',
   };
 
   return (
-    <div className="search-results-page">
-      <div className="page-header">
-        <h1 className="page-title">Search Results</h1>
-      </div>
-
-      <form onSubmit={handleSearch} className="search-input-container">
-        <input
-          type="text"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          placeholder="Search posts, talks, publications..."
-          className="search-input-large"
-          autoFocus
-        />
-      </form>
-
-      {loading ? (
-        <div className="search-loading">
-          <div className="loading-spinner"></div>
-          <p>Searching...</p>
-        </div>
-      ) : query && results.length === 0 ? (
-        <div className="no-results">
-          <p>No results found for "{query}"</p>
-          <p className="text-sm text-gray-600 mt-2">
-            Try different keywords or check your spelling
+    <EditorialPageFrame currentPath="/search" pageClassName="editorial-book-page">
+      <section className="editorial-page-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">Search</p>
+          <h1 className="editorial-page-title">Search Results</h1>
+          <p className="editorial-page-copy">
+            Search posts, talks, publications, and code notes without leaving the editorial index.
           </p>
         </div>
-      ) : results.length > 0 ? (
-        <div className="search-results-container">
-          <p className="results-count">
-            Found {results.length} result{results.length !== 1 ? 's' : ''} for "{query}"
-          </p>
-          
-          {results.map((result) => (
-            <Link 
-              key={`${result.type}-${result.title}`}
-              href={result.url}
-              className="search-result-item"
-            >
-              <div className="search-result-content">
-                
-                <div className="search-result-details">
-                  <span className={`search-result-type ${typeColors[result.type]}`}>
-                    {typeLabels[result.type]}
-                  </span>
-                  
-                  <h2 className="search-result-title">{result.title}</h2>
-                  
-                  <p className="search-result-description">
-                    {result.description}
-                  </p>
-                  
-                  <div className="search-result-meta">
-                    {result.date && (
-                      <time>
-                        {new Date(result.date).toLocaleDateString('en-US', {
-                          year: 'numeric',
-                          month: 'long',
-                          day: 'numeric'
-                        })}
-                      </time>
-                    )}
-                    
-                    {result.tags && result.tags.length > 0 && (
-                      <div className="search-result-tags">
-                        {result.tags.slice(0, 3).map((tag: string) => (
-                          <span key={tag} className="tag-small">
-                            {tag}
-                          </span>
-                        ))}
-                      </div>
-                    )}
+        <aside className="editorial-page-aside">
+          <p className="editorial-home-card-label">Search status</p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">{results.length}</span>
+              <span className="editorial-page-metric-label">results on the current query</span>
+            </div>
+            <div>
+              <Link href="/archive" className="editorial-post-link">
+                Browse archive
+              </Link>
+            </div>
+          </div>
+        </aside>
+      </section>
+
+      <section className="editorial-list-section">
+        <form onSubmit={handleSearch} className="search-input-container">
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search posts, talks, publications..."
+            className="search-input-large"
+            autoFocus
+          />
+        </form>
+
+        {!query ? (
+          <div className="editorial-page-aside">
+            <p className="editorial-home-card-label">Try searching for</p>
+            <div className="editorial-chip-row">
+              {['memory', 'retrieval', 'economics', 'forecasting'].map((term) => (
+                <Link key={term} href={`/search?q=${encodeURIComponent(term)}`} className="editorial-chip">
+                  {term}
+                </Link>
+              ))}
+            </div>
+          </div>
+        ) : loading ? (
+          <div className="search-loading">
+            <div className="loading-spinner"></div>
+            <p>Searching...</p>
+          </div>
+        ) : results.length === 0 ? (
+          <div className="no-results">
+            <p>No results found for "{query}"</p>
+            <p className="text-sm text-gray-600 mt-2">
+              Try different keywords or check your spelling
+            </p>
+          </div>
+        ) : (
+          <>
+            <p className="results-count">
+              Found {results.length} result{results.length !== 1 ? 's' : ''} for "{query}"
+            </p>
+
+            <div className="editorial-post-grid">
+              {results.map((result) => (
+                <Link
+                  key={`${result.type}-${result.title}`}
+                  href={result.url}
+                  className="editorial-post-card search-result-item"
+                >
+                  <div className="editorial-post-meta">
+                    <span>{typeLabels[result.type]}</span>
+                    {formatResultDate(result.date) && <span>{formatResultDate(result.date)}</span>}
                   </div>
-                </div>
-              </div>
-            </Link>
-          ))}
-        </div>
-      ) : null}
-    </div>
+
+                  <h2>{result.title}</h2>
+
+                  {result.description && <p className="editorial-post-summary">{result.description}</p>}
+
+                  <div className="editorial-chip-row">
+                    {result.tags?.slice(0, 3).map((tag) => (
+                      <span key={tag} className="editorial-chip">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+
+                  <span className="editorial-post-link">Open result</span>
+                </Link>
+              ))}
+            </div>
+          </>
+        )}
+      </section>
+    </EditorialPageFrame>
   );
 }
 

--- a/app/services/UnifiedSearchService.ts
+++ b/app/services/UnifiedSearchService.ts
@@ -181,6 +181,7 @@ class UnifiedSearchService {
 
     const searchTerm = query.toLowerCase().trim();
     const suggestions = new Set<string>();
+    const codeToolsItems = getCodeToolsItems();
 
     // Get suggestions from post titles and tags
     const posts = await postService.getAllPosts();

--- a/app/services/UnifiedSearchService.ts
+++ b/app/services/UnifiedSearchService.ts
@@ -1,5 +1,5 @@
 import { postService } from '../../services/PostService';
-import { gistItems } from '../../config/workshopGists';
+import { getCodeToolsItems, getCodeToolsUrl } from '../utils/codeTools';
 
 export interface SearchResult {
   type: 'post' | 'talk' | 'publication' | 'code-ai';
@@ -135,8 +135,10 @@ class UnifiedSearchService {
       }
     });
 
-    // Search Code & Tools (workshop) items
-    gistItems.forEach((item: any) => {
+    const codeToolsItems = getCodeToolsItems();
+
+    // Search Code & Tools items
+    codeToolsItems.forEach((item: any) => {
       if (
         item.title.toLowerCase().includes(searchTerm) ||
         item.description.toLowerCase().includes(searchTerm) ||
@@ -146,7 +148,7 @@ class UnifiedSearchService {
           type: 'code-ai',
           title: item.title,
           description: item.description,
-          url: `/code-ai/${item.slug}`,
+          url: getCodeToolsUrl(item.id),
           date: item.date ? new Date(item.date) : undefined,
           tags: item.tags,
           category: item.category,
@@ -193,8 +195,8 @@ class UnifiedSearchService {
       });
     });
 
-    // Get suggestions from gist items
-    gistItems.forEach((item: any) => {
+    // Get suggestions from code tools items
+    codeToolsItems.forEach((item: any) => {
       if (item.title.toLowerCase().includes(searchTerm)) {
         suggestions.add(item.title);
       }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,9 +1,10 @@
 import { MetadataRoute } from 'next';
 import { postService } from '../services/PostService';
-import { gistItems } from '../config/workshopGists';
+import { getCodeToolsItems, getCodeToolsLatestDate, getCodeToolsUrl } from './utils/codeTools';
+import { getSiteUrl } from './utils/siteUrl';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://economicsnotes.com';
+  const baseUrl = getSiteUrl();
   
   // Get all posts
   const posts = await postService.getAllPosts();
@@ -24,7 +25,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
     {
       url: `${baseUrl}/code-ai`,
-      lastModified: new Date(),
+      lastModified: getCodeToolsLatestDate(),
       changeFrequency: 'weekly',
       priority: 0.8,
     },
@@ -63,8 +64,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }));
 
   // Code & Tools (workshop) pages
-  const codeAiPages: MetadataRoute.Sitemap = gistItems.map((item: any) => ({
-    url: `${baseUrl}/code-ai/${item.slug}`,
+  const codeAiPages: MetadataRoute.Sitemap = getCodeToolsItems().map((item: any) => ({
+    url: `${baseUrl}${getCodeToolsUrl(item.id)}`,
     lastModified: item.date ? new Date(item.date) : new Date(),
     changeFrequency: 'monthly',
     priority: 0.6,

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -1,17 +1,19 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
-import { postService } from '../../../services/PostService';
 import { notFound } from 'next/navigation';
-import { Metadata } from 'next';
+import { EditorialPageFrame } from '../../components/EditorialPageFrame';
+import { postService } from '../../../services/PostService';
 
 interface TagPageProps {
-  params: {
+  params: Promise<{
     tag: string;
-  };
+  }>;
 }
 
-export async function generateMetadata({ params }: { params: Promise<{ tag: string }> }): Promise<Metadata> {
+export async function generateMetadata({ params }: TagPageProps): Promise<Metadata> {
   const { tag: encodedTag } = await params;
   const tag = decodeURIComponent(encodedTag);
+
   return {
     title: `${tag} | Economic Notes`,
     description: `Browse all posts tagged with "${tag}".`,
@@ -25,50 +27,73 @@ export async function generateStaticParams() {
   }));
 }
 
-export default async function TagPage({ params }: { params: Promise<{ tag: string }> }) {
+export default async function TagPage({ params }: TagPageProps) {
   const { tag: encodedTag } = await params;
   const tag = decodeURIComponent(encodedTag);
   const posts = await postService.getPostsByTag(tag);
-  
+
   if (posts.length === 0) {
     notFound();
   }
 
   return (
-    <div className="tag-page">
-      <div className="page-header">
-        <h1 className="page-title">Posts tagged with "{tag}"</h1>
-        <p className="page-subtitle">{posts.length} post{posts.length !== 1 ? 's' : ''} found</p>
-      </div>
-      
-      <div className="posts-grid">
-        {posts.map((post: any) => (
-          <article key={post.slug} className="blog-card">
-            <Link href={`/posts/${post.slug}`}>
-              <div className="blog-card-content">
-                <h2 className="blog-card-title">{post.title}</h2>
-                <time className="blog-card-date">
-                  {post.date.toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric'
-                  })}
-                </time>
-                {post.summary && (
-                  <p className="blog-card-summary">{post.summary}</p>
-                )}
-                <div className="blog-card-tags">
-                  {post.tags.map((t: string) => (
-                    <span key={t} className={`tag ${t === tag ? 'tag-active' : ''}`}>
-                      {t}
-                    </span>
-                  ))}
-                </div>
+    <EditorialPageFrame currentPath="/tags" pageClassName="editorial-book-page">
+      <section className="editorial-page-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">Tag archive</p>
+          <h1 className="editorial-page-title">{tag}</h1>
+          <p className="editorial-page-copy">
+            {posts.length} post{posts.length !== 1 ? 's' : ''} found for this topic, ordered newest first.
+          </p>
+        </div>
+        <aside className="editorial-page-aside">
+          <p className="editorial-home-card-label">Browse links</p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">{posts.length}</span>
+              <span className="editorial-page-metric-label">posts in this tag</span>
+            </div>
+            <div>
+              <Link href="/tags" className="editorial-post-link">
+                Back to tags
+              </Link>
+            </div>
+          </div>
+        </aside>
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Posts</p>
+          <h2 className="editorial-page-section-title">Everything indexed under {tag}.</h2>
+        </div>
+        <div className="editorial-post-grid">
+          {posts.map((post) => (
+            <article key={post.slug} className="editorial-post-card">
+              <div className="editorial-post-meta">
+                <span>{post.date.toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}</span>
+                <span>{post.tags.length} tags</span>
               </div>
-            </Link>
-          </article>
-        ))}
-      </div>
-    </div>
+              <h2>{post.title}</h2>
+              {post.summary && <p className="editorial-post-summary">{post.summary}</p>}
+              <div className="editorial-chip-row">
+                {post.tags.map((postTag) => (
+                  <span key={postTag} className="editorial-chip">
+                    {postTag}
+                  </span>
+                ))}
+              </div>
+              <Link href={`/posts/${post.slug}`} className="editorial-post-link">
+                Read post
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+    </EditorialPageFrame>
   );
 }

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -1,5 +1,6 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
+import { EditorialPageFrame } from '../components/EditorialPageFrame';
 import { postService } from '../services/PostService';
 
 export const metadata: Metadata = {
@@ -9,21 +10,17 @@ export const metadata: Metadata = {
 
 export default async function TagsPage() {
   const posts = await postService.getAllPosts();
-  
-  // Extract all unique tags with counts
+
   const tagCounts = new Map<string, number>();
-  posts.forEach(post => {
-    post.tags.forEach(tag => {
+  posts.forEach((post) => {
+    post.tags.forEach((tag) => {
       tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
     });
   });
 
-  // Convert to array and sort by count
-  const sortedTags = Array.from(tagCounts.entries())
-    .sort((a, b) => b[1] - a[1]);
-
-  // Group tags by first letter
+  const sortedTags = Array.from(tagCounts.entries()).sort((a, b) => b[1] - a[1]);
   const tagsByLetter = new Map<string, Array<[string, number]>>();
+
   sortedTags.forEach(([tag, count]) => {
     const firstLetter = tag[0].toUpperCase();
     if (!tagsByLetter.has(firstLetter)) {
@@ -32,62 +29,87 @@ export default async function TagsPage() {
     tagsByLetter.get(firstLetter)!.push([tag, count]);
   });
 
-  // Sort letters
   const sortedLetters = Array.from(tagsByLetter.keys()).sort();
+  const topTagCount = sortedTags[0]?.[1] || 0;
 
   return (
-    <div className="tags-page">
-      <div className="page-header">
-        <h1 className="page-title">Tags</h1>
-        <p className="page-subtitle">
-          Explore topics across {posts.length} posts
-        </p>
-      </div>
-
-      <div className="tag-cloud">
-        <h2 className="section-title">All Tags</h2>
-        <div className="tag-cloud-container">
-          {sortedTags.map(([tag, count]) => {
-            // Calculate relative size based on count
-            const maxCount = sortedTags[0][1];
-            const minSize = 0.9;
-            const maxSize = 1.8;
-            const size = minSize + (count / maxCount) * (maxSize - minSize);
-            
-            return (
-              <Link
-                key={tag}
-                href={`/tags/${encodeURIComponent(tag)}`}
-                className="tag-cloud-item"
-                style={{ fontSize: `${size}rem` }}
-                title={`${count} post${count !== 1 ? 's' : ''}`}
-              >
-                {tag}
-              </Link>
-            );
-          })}
+    <EditorialPageFrame currentPath="/tags" pageClassName="editorial-book-page">
+      <section className="editorial-page-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">Topics</p>
+          <h1 className="editorial-page-title">Tags</h1>
+          <p className="editorial-page-copy">
+            Explore topics across {posts.length} posts, with links preserved to every tag-specific archive.
+          </p>
         </div>
-      </div>
+        <aside className="editorial-page-aside">
+          <p className="editorial-home-card-label">Tag index</p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">{sortedTags.length}</span>
+              <span className="editorial-page-metric-label">unique tags</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">{topTagCount}</span>
+              <span className="editorial-page-metric-label">posts for the most-used tag</span>
+            </div>
+          </div>
+        </aside>
+      </section>
 
-      <div className="tags-alphabetical">
-        <h2 className="section-title">Alphabetical Index</h2>
-        {sortedLetters.map(letter => (
-          <div key={letter} className="letter-group">
-            <h3 className="letter-heading">{letter}</h3>
-            <div className="letter-tags">
-              {tagsByLetter.get(letter)!.map(([tag, count]) => (
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">All tags</p>
+          <h2 className="editorial-page-section-title">A weighted cloud with direct links.</h2>
+        </div>
+        <div className="tag-cloud">
+          <div className="tag-cloud-container">
+            {sortedTags.map(([tag, count]) => {
+              const maxCount = topTagCount || 1;
+              const minSize = 0.95;
+              const maxSize = 1.85;
+              const size = minSize + (count / maxCount) * (maxSize - minSize);
+
+              return (
                 <Link
                   key={tag}
                   href={`/tags/${encodeURIComponent(tag)}`}
-                  className="tag-link"
+                  className="tag-cloud-item"
+                  style={{ fontSize: `${size}rem` }}
+                  title={`${count} post${count !== 1 ? 's' : ''}`}
                 >
-                  {tag} <span className="tag-count">({count})</span>
+                  {tag}
                 </Link>
-              ))}
-            </div>
+              );
+            })}
           </div>
-        ))}
-      </div>
-    </div>
+        </div>
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Alphabetical</p>
+          <h2 className="editorial-page-section-title">Browse the same index by first letter.</h2>
+        </div>
+        <div className="tags-alphabetical">
+          {sortedLetters.map((letter) => (
+            <div key={letter} className="letter-group">
+              <h3 className="letter-heading">{letter}</h3>
+              <div className="letter-tags">
+                {tagsByLetter.get(letter)!.map(([tag, count]) => (
+                  <Link
+                    key={tag}
+                    href={`/tags/${encodeURIComponent(tag)}`}
+                    className="tag-link"
+                  >
+                    {tag} <span className="tag-count">({count})</span>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </EditorialPageFrame>
   );
 }

--- a/app/talks/page.tsx
+++ b/app/talks/page.tsx
@@ -18,6 +18,7 @@ export default function TalksPage() {
   const talks = [...talksConfig.talks].sort(
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
   );
+  const latestTalk = talks[0];
 
   return (
     <EditorialPageFrame currentPath="/talks">
@@ -28,19 +29,28 @@ export default function TalksPage() {
           <p className="editorial-page-copy">
             A running record of talks, podcasts, and community appearances on memory systems, AI engineering, and production workflows.
           </p>
+          <div className="editorial-chip-row">
+            <span className="editorial-chip">Podcasts</span>
+            <span className="editorial-chip">Conferences</span>
+            <span className="editorial-chip">Streams</span>
+            <span className="editorial-chip">Transcripts</span>
+          </div>
         </div>
         <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">Speaking themes</p>
+          <p className="editorial-home-card-label">At a glance</p>
           <div className="editorial-page-metric-list">
             <div>
-              <span className="editorial-page-metric-value">memory</span>
-              <span className="editorial-page-metric-label">agent systems and retrieval</span>
+              <span className="editorial-page-metric-value">{talks.length}</span>
+              <span className="editorial-page-metric-label">recorded appearances</span>
             </div>
             <div>
-              <span className="editorial-page-metric-value">production</span>
-              <span className="editorial-page-metric-label">real deployment and operations</span>
+              <span className="editorial-page-metric-value">{latestTalk ? formatDate(latestTalk.date) : 'n/a'}</span>
+              <span className="editorial-page-metric-label">latest appearance</span>
             </div>
           </div>
+          <p className="editorial-post-summary">
+            Newest entries appear first, with watch and read links preserved where they exist.
+          </p>
         </aside>
       </section>
 
@@ -57,7 +67,7 @@ export default function TalksPage() {
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
           <p className="editorial-home-section-label">Appearances</p>
-          <h2 className="editorial-page-section-title">Selected talks and recordings.</h2>
+          <h2 className="editorial-page-section-title">Selected talks and recordings, newest first.</h2>
         </div>
         <div className="editorial-talk-grid">
           {talks.map((talk) => {

--- a/app/utils/codeTools.ts
+++ b/app/utils/codeTools.ts
@@ -1,0 +1,46 @@
+import { workshopConfig, type WorkshopItem } from '../config/workshopConfig';
+import { gistItems } from '../config/workshopGists';
+
+export type CodeToolsItem = WorkshopItem;
+
+const codeToolsItems: CodeToolsItem[] = [...workshopConfig.items, ...gistItems];
+
+export const codeToolsCategories = workshopConfig.categories;
+
+export const getCodeToolsItems = (): CodeToolsItem[] => {
+  return [...codeToolsItems].sort((a, b) => {
+    const dateA = a.date ? new Date(a.date).getTime() : 0;
+    const dateB = b.date ? new Date(b.date).getTime() : 0;
+    return dateB - dateA;
+  });
+};
+
+export const getCodeToolsItemById = (id: string): CodeToolsItem | undefined => {
+  return codeToolsItems.find((item) => item.id === id);
+};
+
+export const getCodeToolsStaticParams = (): Array<{ id: string }> => {
+  return codeToolsItems.map((item) => ({ id: item.id }));
+};
+
+export const getCodeToolsLatestDate = (): Date => {
+  const latest = codeToolsItems.reduce((currentLatest, item) => {
+    const itemDate = item.date ? new Date(item.date) : null;
+
+    if (!itemDate) {
+      return currentLatest;
+    }
+
+    if (!currentLatest || itemDate.getTime() > currentLatest.getTime()) {
+      return itemDate;
+    }
+
+    return currentLatest;
+  }, null as Date | null);
+
+  return latest ?? new Date();
+};
+
+export const getCodeToolsUrl = (id: string): string => {
+  return `/code-ai/${encodeURIComponent(id)}`;
+};

--- a/app/utils/siteUrl.ts
+++ b/app/utils/siteUrl.ts
@@ -1,0 +1,9 @@
+const DEFAULT_SITE_URL = 'https://econoben.dev';
+
+export const getSiteUrl = (): string => {
+  return (process.env.NEXT_PUBLIC_SITE_URL || DEFAULT_SITE_URL).replace(/\/$/, '');
+};
+
+export const getAbsoluteUrl = (path: string): string => {
+  return `${getSiteUrl()}${path.startsWith('/') ? path : `/${path}`}`;
+};

--- a/tests/continuity-smoke.mjs
+++ b/tests/continuity-smoke.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const repoRoot = resolve(new URL('..', import.meta.url).pathname);
+const read = (relativePath) => readFileSync(resolve(repoRoot, relativePath), 'utf8');
+
+const codeToolsSource = read('app/utils/codeTools.ts');
+const siteUrlSource = read('app/utils/siteUrl.ts');
+const detailPageSource = read('app/code-ai/[id]/page.tsx');
+const searchRouteSource = read('app/api/search/route.ts');
+const sitemapSource = read('app/sitemap.ts');
+const rssSource = read('app/rss.xml/route.ts');
+const robotsSource = read('app/robots.ts');
+
+assert.match(codeToolsSource, /getCodeToolsItems/);
+assert.match(codeToolsSource, /getCodeToolsStaticParams/);
+assert.match(codeToolsSource, /getCodeToolsItemById/);
+assert.match(codeToolsSource, /getCodeToolsUrl/);
+
+assert.match(siteUrlSource, /DEFAULT_SITE_URL/);
+assert.match(siteUrlSource, /getAbsoluteUrl/);
+
+assert.match(detailPageSource, /getCodeToolsStaticParams/);
+assert.match(detailPageSource, /getCodeToolsItemById/);
+assert.match(detailPageSource, /alternates:/);
+assert.match(detailPageSource, /canonical:/);
+assert.match(detailPageSource, /getSiteUrl/);
+
+assert.match(searchRouteSource, /unifiedSearchService/);
+assert.match(searchRouteSource, /results:/);
+assert.match(searchRouteSource, /Cache-Control': 'no-store'/);
+
+assert.match(sitemapSource, /getCodeToolsItems/);
+assert.match(sitemapSource, /getCodeToolsLatestDate/);
+assert.match(sitemapSource, /getCodeToolsUrl/);
+assert.match(sitemapSource, /getSiteUrl/);
+
+assert.match(rssSource, /escapeXml/);
+assert.match(rssSource, /latestPostDate/);
+assert.match(rssSource, /getSiteUrl/);
+
+assert.match(robotsSource, /getSiteUrl/);
+
+console.log('continuity smoke checks passed');


### PR DESCRIPTION
## Context

The redesign is currently split across a foundation PR and four child PRs. That is the right execution model for parallel work, but it makes it hard to review the actual combined experience because no single branch contains the full stacked site.

This branch is the integration preview for the current stack. It cherry-picks the active structured-page, posts, discovery, and continuity-system slices onto the current foundation branch so the site can be reviewed as one combined experience without merging anything into `main`.

This PR is not a replacement for the child PRs. It is a review surface and a base for the next polish wave, where the work shifts from continuity into shared visual fidelity, language, and subpage refinement.

## What changed

- **stacked preview branch**: Combined the active redesign slices from PRs #3, #4, #5, and #6 onto the current foundation branch.
- **review surface**: Made the full redesign visible in one branch for browser review and future polish work.
- **execution flow**: Preserved the no-merge review model by targeting this PR at `feat/site-continuity-foundation`, not `main`.

## Why this matters

Without a combined preview branch, every discussion about the site has to mentally merge multiple draft PRs. This branch makes the real composite state visible so the next wave can target what the site actually feels like rather than what each isolated slice looks like.

## Test plan

- [x] `npm ci`
- [x] `npm run build`
- [ ] Manual browser review on the integrated branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
