### PR TITLE
polish: tighten site copy across key pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -3,7 +3,7 @@ import { EditorialPageFrame } from '../components/EditorialPageFrame';
 
 export const metadata: Metadata = {
   title: 'About | Ben Labaschin',
-  description: 'Background, current work, and the through-line across Ben Labaschin’s writing, talks, and engineering work.',
+  description: "Background, current work, and the through-line across Ben Labaschin's writing, talks, and engineering work.",
 };
 
 const experience = [
@@ -31,7 +31,7 @@ const experience = [
 ];
 
 const proofPoints = [
-  'O’Reilly reports on AI agents and memory systems',
+  "O'Reilly reports on AI agents and memory systems",
   'AEA Papers and Proceedings publication on firm-level exposure to GPTs',
   'Conference and community talks on memory, validation, and production AI systems',
   'Hands-on platform work spanning LLM APIs, analytics infrastructure, and deployment',
@@ -45,7 +45,7 @@ export default function AboutPage() {
           <p className="editorial-home-kicker">About</p>
           <h1 className="editorial-page-title">Ben Labaschin</h1>
           <p className="editorial-page-copy">
-            I work at the intersection of AI systems, technical writing, and research. This site is where those threads meet: essays, talks, reports, and the forthcoming book on agent memory.
+            I work where AI systems, technical writing, and research meet. This site is the public record of that work: essays, talks, reports, and the forthcoming book on agent memory.
           </p>
           <div className="editorial-chip-row">
             <span className="editorial-chip">AI systems</span>
@@ -74,7 +74,7 @@ export default function AboutPage() {
         <span>/</span>
         <span>writer and speaker</span>
         <span>/</span>
-        <span>AI systems + memory</span>
+        <span>AI systems and memory</span>
         <span>/</span>
         <span>economics background</span>
       </section>
@@ -82,21 +82,21 @@ export default function AboutPage() {
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
           <p className="editorial-home-section-label">Current focus</p>
-          <h2 className="editorial-page-section-title">The through-line is practical AI systems that actually work.</h2>
+          <h2 className="editorial-page-section-title">The through-line is practical AI systems that keep working after the demo.</h2>
         </div>
         <div className="editorial-two-column">
           <article className="editorial-home-card">
             <p className="editorial-home-card-label">What I spend time on</p>
             <h3>Production AI, memory, retrieval, and the messy middle.</h3>
             <p>
-              Most of my work sits between research ideas and the engineering realities of enterprise systems: memory management, async LLM infrastructure, evaluation, developer workflows, and the trade-offs that appear once systems leave the demo stage.
+              Most of my work sits between research ideas and the engineering realities of enterprise systems: memory management, async LLM infrastructure, evaluation, developer workflows, and the trade-offs that show up once systems leave the demo stage.
             </p>
           </article>
           <article className="editorial-home-card">
             <p className="editorial-home-card-label">What this site is for</p>
-            <h3>A public platform, not just a resume.</h3>
+            <h3>A public record, not just a resume.</h3>
             <p>
-              I still keep the professional signal here, but the point of the site is to make the writing, talks, reports, and upcoming book feel like one coherent body of work.
+              The site keeps the professional signal, but its job is to make the writing, talks, reports, and upcoming book read as one coherent body of work.
             </p>
             <a href="/benjamin_labaschin_resume.pdf" download className="editorial-post-link">
               Download resume
@@ -122,7 +122,7 @@ export default function AboutPage() {
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
           <p className="editorial-home-section-label">Experience</p>
-          <h2 className="editorial-page-section-title">A shorter version of the operating history.</h2>
+          <h2 className="editorial-page-section-title">A concise view of the operating history.</h2>
         </div>
         <div className="editorial-timeline">
           {experience.map((item) => (

--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -19,7 +19,7 @@ export default function BookPage() {
           </div>
           <div className="editorial-home-actions">
             <a href="mailto:benjaminlabaschindev@gmail.com?subject=Agent%20Memory%20updates" className="editorial-home-button editorial-home-button-primary">
-              Get updates
+              Get book updates
             </a>
             <Link href="/publications" className="editorial-home-button editorial-home-button-secondary">
               See related work
@@ -31,7 +31,7 @@ export default function BookPage() {
           <p className="editorial-home-card-label">Working direction</p>
           <h2>Why it belongs here</h2>
           <p>
-            One domain, one body of work, one list. The book should strengthen the platform, not split it into a second identity.
+            One domain, one body of work, one list. The book should reinforce the site&apos;s technical arc, not split it into a second identity.
           </p>
           <div className="editorial-page-metric-list">
             <div>
@@ -59,16 +59,16 @@ export default function BookPage() {
       <section className="editorial-home-grid">
         <article className="editorial-home-card">
           <p className="editorial-home-card-label">What belongs here</p>
-          <h3>Context, audience, and updates.</h3>
+          <h3>Context, audience, and ongoing updates.</h3>
           <p>
-            Explain why the book matters, who it is for, and why readers should follow the project now instead of waiting for launch week.
+            This page should make the book legible before launch: what problem it solves, who it is for, and why it belongs in the same public arc as the essays and talks.
           </p>
         </article>
         <article className="editorial-home-card">
           <p className="editorial-home-card-label">How it connects</p>
           <h3>The reports, talks, and book should read as one arc.</h3>
           <p>
-            This page should point back to the O&apos;Reilly reports, talks, and essays so the book feels like the next step in the same public body of work.
+            Use this page to point back to the O&apos;Reilly reports, talks, and essays so the book reads as the next step in the same body of work.
           </p>
         </article>
       </section>

--- a/app/components/MainContent.tsx
+++ b/app/components/MainContent.tsx
@@ -39,7 +39,7 @@ const DefaultHomeContent = ({ posts }: DefaultHomeContentProps) => {
     return (
       <div className="home-loading">
         <div className="loading-spinner"></div>
-        <p>Loading amazing content...</p>
+        <p>Preparing the latest writing.</p>
       </div>
     );
   }
@@ -52,14 +52,14 @@ const DefaultHomeContent = ({ posts }: DefaultHomeContentProps) => {
     <EditorialPageFrame currentPath="/" pageClassName="editorial-home-page">
       <section className="editorial-home-hero">
         <div className="editorial-home-hero-copy">
-          <p className="editorial-home-kicker">Writing archive</p>
-          <h1>Writing about how AI systems remember, fail, and scale.</h1>
+          <p className="editorial-home-kicker">Technical writing archive</p>
+          <h1>Writing about how AI systems remember, fail, and scale in production.</h1>
           <p className="editorial-home-subtitle">
-            A public platform for essays, talks, O&apos;Reilly reports, and the forthcoming book on agent memory.
+            A public body of work on AI systems, agent memory, and the engineering decisions that separate demos from durable products.
           </p>
           <div className="editorial-home-actions">
             <Link href={`/posts/${newestPost.slug}`} className="editorial-home-button editorial-home-button-primary">
-              Read the latest post
+              Read the newest essay
             </Link>
             <Link href="/posts" className="editorial-home-button editorial-home-button-secondary">
               Browse the archive
@@ -68,7 +68,7 @@ const DefaultHomeContent = ({ posts }: DefaultHomeContentProps) => {
         </div>
 
         <aside className="editorial-home-book-card">
-          <p className="editorial-home-card-label">Latest post</p>
+          <p className="editorial-home-card-label">Newest essay</p>
           <h2>{newestPost.title}</h2>
           <p>{newestExcerpt}</p>
           <div className="editorial-home-book-meta">
@@ -77,7 +77,7 @@ const DefaultHomeContent = ({ posts }: DefaultHomeContentProps) => {
             <span>{getPrimaryTag(newestPost)}</span>
           </div>
           <Link href={`/posts/${newestPost.slug}`} className="editorial-home-button editorial-home-button-accent">
-            Open the essay
+            Read the full piece
           </Link>
         </aside>
       </section>
@@ -89,12 +89,12 @@ const DefaultHomeContent = ({ posts }: DefaultHomeContentProps) => {
         <span>/</span>
         <span>O&apos;Reilly reports</span>
         <span>/</span>
-        <span>forthcoming book</span>
+        <span>forthcoming book on agent memory</span>
       </section>
 
       <section className="editorial-home-section">
-        <p className="editorial-home-section-label">Selected work</p>
-        <h2>Recent posts with enough room to decide what to read next.</h2>
+        <p className="editorial-home-section-label">Selected writing</p>
+        <h2>Recent essays with enough context to know where to go next.</h2>
         <div className="editorial-home-grid">
           {featuredPosts.map((post) => {
             const excerpt = getExcerpt(post.content, post.summary);
@@ -126,14 +126,14 @@ const DefaultHomeContent = ({ posts }: DefaultHomeContentProps) => {
 
       <section className="editorial-home-cta-band">
         <div>
-          <p className="editorial-home-card-label">Newsletter + book</p>
-          <h3>A lightweight conversion layer, not a hard sell.</h3>
+          <p className="editorial-home-card-label">Book notes + archive</p>
+          <h3>Follow the longer arc without losing the thread.</h3>
           <p>
-            Follow the book, browse the archive, or move into talks and publications if you want the broader context.
+            Start with the book notes, then move through the archive, talks, and publications if you want the broader technical context.
           </p>
         </div>
         <Link href="/book" className="editorial-home-button editorial-home-button-primary">
-          Read book updates
+          Follow the book
         </Link>
       </section>
     </EditorialPageFrame>

--- a/app/publications/page.tsx
+++ b/app/publications/page.tsx
@@ -4,7 +4,7 @@ import { publicationsConfig, Publication } from '../config/publicationsConfig';
 
 export const metadata: Metadata = {
   title: 'Publications | Ben Labaschin',
-  description: 'Reports, research, and long-form publications across AI systems and economics.',
+  description: "Reports, research, and long-form publications that anchor the site's technical and economic writing.",
 };
 
 export default function PublicationsPage() {
@@ -21,7 +21,7 @@ export default function PublicationsPage() {
           <p className="editorial-home-kicker">Public record</p>
           <h1 className="editorial-page-title">Publications</h1>
           <p className="editorial-page-copy">
-            O&apos;Reilly work, formal research, and longer-form pieces that anchor the writing and talks elsewhere on the site.
+            The technical record behind the site: O&apos;Reilly work, formal research, and longer-form pieces that ground the essays and talks.
           </p>
           <div className="editorial-chip-row">
             <span className="editorial-chip">O&apos;Reilly</span>
@@ -47,7 +47,7 @@ export default function PublicationsPage() {
             </div>
           </div>
           <p className="editorial-post-summary">
-            Featured work appears first so the newest or most central pieces are easy to find.
+            Featured work appears first so the most important pieces are easy to find before you dig into the archive.
           </p>
         </aside>
       </section>
@@ -56,7 +56,7 @@ export default function PublicationsPage() {
         <section className="editorial-list-section">
           <div className="editorial-list-heading">
             <p className="editorial-home-section-label">Featured</p>
-            <h2 className="editorial-page-section-title">The work most likely to orient a first-time reader.</h2>
+            <h2 className="editorial-page-section-title">The work that best frames the site&apos;s technical point of view.</h2>
           </div>
           <div className="editorial-publication-grid">
             {featuredPublications.map((pub) => (
@@ -70,7 +70,7 @@ export default function PublicationsPage() {
         <section className="editorial-list-section">
           <div className="editorial-list-heading">
             <p className="editorial-home-section-label">Archive</p>
-            <h2 className="editorial-page-section-title">Background reports and earlier writing.</h2>
+            <h2 className="editorial-page-section-title">Background reports and earlier writing, kept for completeness.</h2>
           </div>
           <div className="editorial-publication-grid">
             {otherPublications.map((pub) => (
@@ -103,7 +103,15 @@ function PublicationCard({ publication, featured = false }: {
   })();
 
   const actionHref = publication.url || publication.pdfUrl || (publication.doi ? `https://doi.org/${publication.doi}` : undefined);
-  const actionLabel = publication.url ? 'View publication' : publication.pdfUrl ? 'Open PDF' : publication.doi ? 'View DOI' : undefined;
+  const actionLabel = publication.url
+    ? publication.venue === "O'Reilly Media"
+      ? 'Read the report'
+      : 'Read online'
+    : publication.pdfUrl
+      ? 'Open PDF'
+      : publication.doi
+        ? 'View DOI record'
+        : undefined;
 
   return (
     <article

--- a/app/talks/page.tsx
+++ b/app/talks/page.tsx
@@ -4,7 +4,7 @@ import { talksConfig } from '../config/talksConfig';
 
 export const metadata: Metadata = {
   title: 'Talks | Ben Labaschin',
-  description: 'Conference talks, podcasts, and public talks on AI systems, memory, and engineering.',
+  description: 'Conference talks, podcasts, and recorded appearances on AI systems, memory, and engineering.',
 };
 
 const formatDate = (dateStr: string) =>
@@ -27,7 +27,7 @@ export default function TalksPage() {
           <p className="editorial-home-kicker">Speaking</p>
           <h1 className="editorial-page-title">Talks</h1>
           <p className="editorial-page-copy">
-            A running record of talks, podcasts, and community appearances on memory systems, AI engineering, and production workflows.
+            Talks, podcast conversations, and community appearances on memory systems, AI engineering, and the realities of production workflows.
           </p>
           <div className="editorial-chip-row">
             <span className="editorial-chip">Podcasts</span>
@@ -49,7 +49,7 @@ export default function TalksPage() {
             </div>
           </div>
           <p className="editorial-post-summary">
-            Newest entries appear first, with watch and read links preserved where they exist.
+            Newest entries appear first, with watch, listen, and read links preserved where they exist.
           </p>
         </aside>
       </section>
@@ -67,7 +67,7 @@ export default function TalksPage() {
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
           <p className="editorial-home-section-label">Appearances</p>
-          <h2 className="editorial-page-section-title">Selected talks and recordings, newest first.</h2>
+          <h2 className="editorial-page-section-title">Selected talks and recordings, organized newest first.</h2>
         </div>
         <div className="editorial-talk-grid">
           {talks.map((talk) => {
@@ -100,7 +100,7 @@ export default function TalksPage() {
                       rel="noopener noreferrer"
                       className="editorial-post-link"
                     >
-                      {talk.spotifyUrl ? 'Listen' : 'Watch'}
+                      {talk.spotifyUrl ? 'Listen to recording' : 'Watch recording'}
                     </a>
                   )}
                   {talk.transcriptUrl && (


### PR DESCRIPTION
## Context

This slice tightens the language on the homepage and the top-level About, Book, Publications, and Talks pages so the site reads more like a finished technical author platform than a placeholder portfolio. The structural work and route coverage already exist; this pass is about narrative positioning, hierarchy, and CTA phrasing.

The current copy was functional, but several lines still sounded instructional or provisional. That made the site feel less authoritative than the content behind it. This PR reframes the existing pages without changing links, routes, or shared layout.

## What changed

- **app/components/MainContent.tsx**: Rewrote the homepage hero, proof strip, selected-work section, and CTA band copy to sound more editorial and production-focused.
- **app/about/page.tsx**: Tightened the bio, proof points, and section headings to present the site as a public record of technical writing and systems work.
- **app/book/page.tsx**: Refined the book page language and CTA phrasing so the forthcoming O'Reilly project feels like part of the same public arc.
- **app/publications/page.tsx**: Repositioned publications as the technical record behind the site and sharpened the featured/archive framing.
- **app/talks/page.tsx**: Adjusted the speaking page description and supporting copy to better match the rest of the site voice.

## Why this matters

The site already has the right content structure. This change makes the language match the level of the work: clearer hierarchy, less placeholder phrasing, and CTAs that invite reading instead of feeling like form fill prompts.

## Test plan

- [x] `npm ci`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
