### PR TITLE
feat: polish code tools surfaces

### DIFF
--- a/app/code-ai/[id]/page.tsx
+++ b/app/code-ai/[id]/page.tsx
@@ -1,9 +1,22 @@
+import Link from 'next/link';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import Link from 'next/link';
-import { workshopConfig } from '../../config/workshopConfig';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { getSiteUrl } from '../../utils/siteUrl';
-import { getCodeToolsItemById, getCodeToolsStaticParams, getCodeToolsUrl } from '../../utils/codeTools';
+import {
+  formatCodeToolsDate,
+  getCodeToolsCategoryMeta,
+  getCodeToolsItemById,
+  getCodeToolsItemLineCount,
+  getCodeToolsLanguageLabel,
+  getCodeToolsRelatedItems,
+  getCodeToolsStaticParams,
+  getCodeToolsUrl,
+  normalizeCodeToolsLanguage,
+} from '../../utils/codeTools';
 
 export async function generateStaticParams() {
   return getCodeToolsStaticParams();
@@ -12,24 +25,26 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
   const { id } = await params;
   const item = getCodeToolsItemById(id);
-  
+
   if (!item) {
     return {
       title: 'Not Found | Economic Notes',
     };
   }
 
+  const canonicalUrl = `${getSiteUrl()}${getCodeToolsUrl(id)}`;
+
   return {
     title: `${item.title} | Code & Tools | Economic Notes`,
     description: item.description,
     alternates: {
-      canonical: `${getSiteUrl()}${getCodeToolsUrl(id)}`,
+      canonical: canonicalUrl,
     },
     openGraph: {
       title: item.title,
       description: item.description,
       type: 'article',
-      url: `${getSiteUrl()}${getCodeToolsUrl(id)}`,
+      url: canonicalUrl,
       publishedTime: item.date ? new Date(item.date).toISOString() : undefined,
       tags: item.tags,
     },
@@ -39,35 +54,50 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
 export default async function CodeAIDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const item = getCodeToolsItemById(id);
-  
+
   if (!item) {
     notFound();
   }
 
-  const categoryConfig = workshopConfig.categories.find(cat => cat.id === item.category);
+  const categoryConfig = getCodeToolsCategoryMeta(item.category);
+  const relatedItems = getCodeToolsRelatedItems(item, 3);
+  const lineCount = getCodeToolsItemLineCount(item);
+  const dateLabel = item.date ? formatCodeToolsDate(item.date, { year: 'numeric', month: 'long', day: 'numeric' }) : 'No date';
 
   return (
-    <article className="code-ai-detail">
-      <div className="code-ai-detail-header">
+    <article
+      className="code-ai-detail"
+      style={{
+        display: 'grid',
+        gap: '1.5rem',
+        maxWidth: '1120px',
+        margin: '0 auto',
+      }}
+    >
+      <div className="code-ai-detail-header" style={{ display: 'grid', gap: '1rem' }}>
         <div className="breadcrumb">
           <Link href="/code-ai">← Back to Code & Tools</Link>
         </div>
 
-        <div className="code-ai-detail-meta">
+        <div
+          className="code-ai-detail-meta"
+          style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem', alignItems: 'center' }}
+        >
           <span className="code-ai-detail-category">
             {categoryConfig?.icon} {categoryConfig?.label || item.category}
           </span>
-          <time className="code-ai-detail-date">
-            {item.date ? new Date(item.date).toLocaleDateString('en-US', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric'
-            }) : 'No date'}
-          </time>
+          <time className="code-ai-detail-date">{dateLabel}</time>
+          <span className="code-ai-detail-date">{getCodeToolsLanguageLabel(item.language)}</span>
+          {item.filename && <span className="code-ai-detail-date">{item.filename}</span>}
+          <span className="code-ai-detail-date">{lineCount} lines</span>
         </div>
 
-        <h1 className="code-ai-detail-title">{item.title}</h1>
-        <p className="code-ai-detail-description">{item.description}</p>
+        <div style={{ maxWidth: '70ch' }}>
+          <h1 className="code-ai-detail-title" style={{ marginBottom: '0.5rem' }}>
+            {item.title}
+          </h1>
+          <p className="code-ai-detail-description">{item.description}</p>
+        </div>
 
         <div className="code-ai-detail-tags">
           {item.tags.map((tag) => (
@@ -79,45 +109,127 @@ export default async function CodeAIDetailPage({ params }: { params: Promise<{ i
 
         <div className="code-ai-detail-actions">
           {item.gistUrl && (
-            <a 
+            <a
               href={item.gistUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="action-button github-button"
             >
               <svg className="icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
-                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
               </svg>
               View on GitHub
             </a>
           )}
+          <Link href="/code-ai" className="action-button">
+            Browse all snippets
+          </Link>
         </div>
       </div>
 
-      <div className="code-ai-detail-content">
-        <pre className="code-block">
-          <code className={`language-${item.language || 'bash'}`}>
-            {item.content}
-          </code>
-        </pre>
-      </div>
-
-      <div className="code-ai-detail-footer">
-        <p className="footer-note">
-          This snippet is part of the Code & Tools collection. 
-          {item.gistUrl && (
-            <>
-              {' '}You can also{' '}
-              <a 
-                href={item.gistUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                star or fork it on GitHub
-              </a>.
-            </>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'minmax(0, 1.6fr) minmax(280px, 0.9fr)',
+          gap: '1.25rem',
+          alignItems: 'start',
+        }}
+      >
+        <section style={{ display: 'grid', gap: '1rem' }}>
+          {item.writeup && (
+            <div className="item-writeup" style={{ padding: '1.1rem 1.15rem', borderRadius: '16px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.writeup}</ReactMarkdown>
+            </div>
           )}
-        </p>
+
+          <div className="code-block">
+            <div className="code-header">
+              <div className="code-filename">{getCodeToolsLanguageLabel(item.language)}</div>
+              <div className="code-actions">
+                <span className="code-action" style={{ pointerEvents: 'none' }}>
+                  {lineCount} lines
+                </span>
+              </div>
+            </div>
+            <div className="code-container">
+              <SyntaxHighlighter
+                language={normalizeCodeToolsLanguage(item.language)}
+                style={oneDark}
+                showLineNumbers
+                wrapLines
+                lineNumberStyle={{
+                  minWidth: '3em',
+                  paddingRight: '1em',
+                  textAlign: 'right',
+                  userSelect: 'none',
+                  opacity: 0.5,
+                }}
+                customStyle={{
+                  margin: 0,
+                  padding: '1rem',
+                  fontSize: '0.9rem',
+                  lineHeight: '1.7',
+                  borderRadius: '0 0 8px 8px',
+                  background: '#282c34',
+                }}
+                codeTagProps={{
+                  style: {
+                    fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace",
+                  },
+                }}
+              >
+                {item.content}
+              </SyntaxHighlighter>
+            </div>
+          </div>
+        </section>
+
+        <aside style={{ display: 'grid', gap: '1rem' }}>
+          <section style={{ padding: '1rem 1.1rem', borderRadius: '16px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
+            <h2 style={{ marginTop: 0, marginBottom: '0.75rem', fontSize: '1rem' }}>At a glance</h2>
+            <div style={{ display: 'grid', gap: '0.7rem' }}>
+              <div>
+                <div style={{ fontSize: '0.76rem', textTransform: 'uppercase', letterSpacing: '0.12em', opacity: 0.7 }}>Category</div>
+                <div style={{ marginTop: '0.2rem' }}>{categoryConfig?.label || item.category}</div>
+              </div>
+              <div>
+                <div style={{ fontSize: '0.76rem', textTransform: 'uppercase', letterSpacing: '0.12em', opacity: 0.7 }}>Language</div>
+                <div style={{ marginTop: '0.2rem' }}>{getCodeToolsLanguageLabel(item.language)}</div>
+              </div>
+              <div>
+                <div style={{ fontSize: '0.76rem', textTransform: 'uppercase', letterSpacing: '0.12em', opacity: 0.7 }}>Source</div>
+                <div style={{ marginTop: '0.2rem' }}>{item.filename || 'Inline snippet'}</div>
+              </div>
+              <div>
+                <div style={{ fontSize: '0.76rem', textTransform: 'uppercase', letterSpacing: '0.12em', opacity: 0.7 }}>Tags</div>
+                <div style={{ marginTop: '0.2rem' }}>{item.tags.length}</div>
+              </div>
+            </div>
+          </section>
+
+          {relatedItems.length > 0 && (
+            <section style={{ padding: '1rem 1.1rem', borderRadius: '16px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
+              <h2 style={{ marginTop: 0, marginBottom: '0.75rem', fontSize: '1rem' }}>Related snippets</h2>
+              <div style={{ display: 'grid', gap: '0.75rem' }}>
+                {relatedItems.map((relatedItem) => (
+                  <article key={relatedItem.id} style={{ paddingBottom: '0.75rem', borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+                    <h3 style={{ margin: 0, fontSize: '0.98rem' }}>
+                      <Link href={getCodeToolsUrl(relatedItem.id)}>{relatedItem.title}</Link>
+                    </h3>
+                    <p style={{ margin: '0.35rem 0 0', opacity: 0.78 }}>{relatedItem.description}</p>
+                  </article>
+                ))}
+              </div>
+            </section>
+          )}
+
+          <section style={{ padding: '1rem 1.1rem', borderRadius: '16px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
+            <h2 style={{ marginTop: 0, marginBottom: '0.75rem', fontSize: '1rem' }}>Collection note</h2>
+            <p style={{ margin: 0, opacity: 0.82 }}>
+              This snippet lives in the Code & Tools library alongside the rest of the collection, so the route structure stays stable even as the presentation gets more editorial.
+            </p>
+          </section>
+        </aside>
       </div>
     </article>
   );

--- a/app/code-ai/page.tsx
+++ b/app/code-ai/page.tsx
@@ -1,92 +1,53 @@
 'use client';
 
 import React, { useState } from 'react';
+import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { workshopConfig, type WorkshopItem } from '../config/workshopConfig';
-import { getCodeToolsItems } from '../utils/codeTools';
+import {
+  formatCodeToolsDate,
+  getCodeToolsCategoryCounts,
+  getCodeToolsFeaturedItems,
+  getCodeToolsItemLineCount,
+  getCodeToolsItems,
+  getCodeToolsLanguageLabel,
+  getCodeToolsUrl,
+  normalizeCodeToolsLanguage,
+} from '../utils/codeTools';
 
-// Map common language aliases to Prism language names
-const languageMap: Record<string, string> = {
-  'js': 'javascript',
-  'ts': 'typescript',
-  'py': 'python',
-  'rb': 'ruby',
-  'sh': 'bash',
-  'shell': 'bash',
-  'zsh': 'bash',
-  'yml': 'yaml',
-  'dockerfile': 'docker',
-  'text': 'plaintext',
-  'txt': 'plaintext',
-  'code': 'plaintext',
-  'toml': 'toml',
-  'gitconfig': 'ini',
-  'ini': 'ini',
-  'conf': 'ini',
-  'cfg': 'ini',
-};
-
-// Get a display-friendly language name
-const getDisplayLanguage = (lang: string | undefined): string => {
-  const lowered = lang?.toLowerCase() || 'text';
-  const normalized = languageMap[lowered] || lowered;
-  const displayNames: Record<string, string> = {
-    'javascript': 'JavaScript',
-    'typescript': 'TypeScript',
-    'python': 'Python',
-    'bash': 'Bash',
-    'shell': 'Shell',
-    'json': 'JSON',
-    'yaml': 'YAML',
-    'markdown': 'Markdown',
-    'css': 'CSS',
-    'html': 'HTML',
-    'sql': 'SQL',
-    'go': 'Go',
-    'rust': 'Rust',
-    'java': 'Java',
-    'csharp': 'C#',
-    'cpp': 'C++',
-    'c': 'C',
-    'ruby': 'Ruby',
-    'php': 'PHP',
-    'swift': 'Swift',
-    'kotlin': 'Kotlin',
-    'docker': 'Dockerfile',
-    'plaintext': 'Text',
-    'toml': 'TOML',
-  };
-  return displayNames[normalized] || normalized.charAt(0).toUpperCase() + normalized.slice(1);
-};
-
-/**
- * Code & Tools component with compact, navigable layout for code snippets and AI insights
- */
 export default function CodeAIPage() {
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
   const [viewMode, setViewMode] = useState<'compact' | 'full'>('compact');
+  const [copyStates, setCopyStates] = useState<Record<string, string>>({});
 
   const { title, subtitle, categories } = workshopConfig;
-
   const allItems = getCodeToolsItems();
+  const categoryCounts = getCodeToolsCategoryCounts(allItems);
+  const featuredItems = getCodeToolsFeaturedItems(allItems);
+  const latestItem = allItems[0];
+  const activeCategoryCount = categories.filter(
+    (category) => category.id !== 'all' && (categoryCounts[category.id] ?? 0) > 0,
+  ).length;
 
-  // Filter items based on category and search
   const filteredItems = allItems.filter((item: WorkshopItem) => {
+    const query = searchQuery.toLowerCase();
     const matchesCategory = selectedCategory === 'all' || item.category === selectedCategory;
-    const matchesSearch = searchQuery === '' ||
-      item.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      item.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      item.tags.some((tag: string) => tag.toLowerCase().includes(searchQuery.toLowerCase()));
+    const matchesSearch =
+      query === '' ||
+      item.title.toLowerCase().includes(query) ||
+      item.description.toLowerCase().includes(query) ||
+      item.tags.some((tag: string) => tag.toLowerCase().includes(query));
 
     return matchesCategory && matchesSearch;
   });
 
-  // Group items by category for hierarchical display, maintaining date order
+  const selectedCategoryLabel = categories.find((category) => category.id === selectedCategory)?.label ?? 'All';
+
   const groupedItems = filteredItems.reduce((acc, item) => {
     if (!acc[item.category]) {
       acc[item.category] = [];
@@ -95,53 +56,60 @@ export default function CodeAIPage() {
     return acc;
   }, {} as Record<string, WorkshopItem[]>);
 
-  // Toggle item expansion
   const toggleExpanded = (itemId: string) => {
-    const newExpanded = new Set(expandedItems);
-    if (newExpanded.has(itemId)) {
-      newExpanded.delete(itemId);
+    const nextExpanded = new Set(expandedItems);
+    if (nextExpanded.has(itemId)) {
+      nextExpanded.delete(itemId);
     } else {
-      newExpanded.add(itemId);
+      nextExpanded.add(itemId);
     }
-    setExpandedItems(newExpanded);
+    setExpandedItems(nextExpanded);
   };
 
-  // Track copy button states per item
-  const [copyStates, setCopyStates] = useState<Record<string, string>>({});
-
-  // Copy to clipboard with feedback
   const copyToClipboard = (content: string, itemId: string) => {
     navigator.clipboard.writeText(content);
-    setCopyStates(prev => ({ ...prev, [itemId]: 'Copied!' }));
+    setCopyStates((prev) => ({ ...prev, [itemId]: 'Copied!' }));
     setTimeout(() => {
-      setCopyStates(prev => ({ ...prev, [itemId]: 'Copy' }));
+      setCopyStates((prev) => ({ ...prev, [itemId]: 'Copy' }));
     }, 2000);
-  };
-
-  // Get normalized language for syntax highlighter
-  const getNormalizedLanguage = (lang: string | undefined): string => {
-    if (!lang) return 'text';
-    return languageMap[lang.toLowerCase()] || lang.toLowerCase();
-  };
-
-  // Format date for display
-  const formatDate = (date: Date | string | undefined) => {
-    if (!date) return '';
-    const d = new Date(date);
-    return d.toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric'
-    });
   };
 
   return (
     <div className="code-ai-container">
       <div className="code-ai-header">
-        <h1>{title}</h1>
-        <p className="code-ai-subtitle">
-          {subtitle}
+        <p style={{ margin: 0, textTransform: 'uppercase', letterSpacing: '0.16em', fontSize: '0.72rem', opacity: 0.72 }}>
+          Reference library
         </p>
+        <h1>{title}</h1>
+        <p className="code-ai-subtitle">{subtitle}</p>
+
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+            gap: '0.85rem',
+            marginTop: '1.25rem',
+          }}
+        >
+          <div style={{ padding: '1rem 1.1rem', borderRadius: '14px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
+            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.14em', opacity: 0.7 }}>Snippets</div>
+            <div style={{ fontSize: '1.35rem', fontWeight: 700, marginTop: '0.35rem' }}>{allItems.length}</div>
+          </div>
+          <div style={{ padding: '1rem 1.1rem', borderRadius: '14px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
+            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.14em', opacity: 0.7 }}>Active categories</div>
+            <div style={{ fontSize: '1.35rem', fontWeight: 700, marginTop: '0.35rem' }}>{activeCategoryCount}</div>
+          </div>
+          <div style={{ padding: '1rem 1.1rem', borderRadius: '14px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
+            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.14em', opacity: 0.7 }}>Featured</div>
+            <div style={{ fontSize: '1.35rem', fontWeight: 700, marginTop: '0.35rem' }}>{featuredItems.length}</div>
+          </div>
+          <div style={{ padding: '1rem 1.1rem', borderRadius: '14px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
+            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.14em', opacity: 0.7 }}>Latest</div>
+            <div style={{ fontSize: '1rem', fontWeight: 700, marginTop: '0.35rem' }}>
+              {latestItem ? formatCodeToolsDate(latestItem.date, { month: 'short', day: 'numeric', year: 'numeric' }) : 'No items yet'}
+            </div>
+          </div>
+        </div>
       </div>
 
       <div className="code-ai-controls">
@@ -150,7 +118,7 @@ export default function CodeAIPage() {
             type="text"
             placeholder="Search snippets..."
             value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            onChange={(event) => setSearchQuery(event.target.value)}
             className="code-ai-search-input"
           />
         </div>
@@ -160,6 +128,7 @@ export default function CodeAIPage() {
             className={`view-toggle-btn ${viewMode === 'compact' ? 'active' : ''}`}
             onClick={() => setViewMode('compact')}
             title="Compact view"
+            type="button"
           >
             ☰
           </button>
@@ -167,27 +136,77 @@ export default function CodeAIPage() {
             className={`view-toggle-btn ${viewMode === 'full' ? 'active' : ''}`}
             onClick={() => setViewMode('full')}
             title="Full view"
+            type="button"
           >
             ⊞
           </button>
         </div>
       </div>
 
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '0.75rem',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: '1rem',
+        }}
+      >
+        <div style={{ opacity: 0.84 }}>
+          Showing <strong>{filteredItems.length}</strong> of <strong>{allItems.length}</strong> items in <strong>{selectedCategoryLabel}</strong>
+          {searchQuery ? <> for <strong>“{searchQuery}”</strong></> : null}
+        </div>
+        <div style={{ opacity: 0.72 }}>
+          Browse the compact list for quick scanning, or open an item to read the note and copy the code.
+        </div>
+      </div>
+
+      {featuredItems.length > 0 && (
+        <section style={{ marginBottom: '1.5rem' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '1rem', marginBottom: '0.75rem' }}>
+            <h2 style={{ margin: 0, fontSize: '1.05rem' }}>Featured picks</h2>
+            <span style={{ opacity: 0.7, fontSize: '0.92rem' }}>Handpicked snippets that show the collection at its best.</span>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '0.85rem' }}>
+            {featuredItems.slice(0, 3).map((item) => (
+              <article key={item.id} style={{ padding: '1rem 1.1rem', borderRadius: '16px', border: '1px solid rgba(255,255,255,0.08)', background: 'rgba(255,255,255,0.035)' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.75rem', alignItems: 'start' }}>
+                  <div>
+                    <h3 style={{ margin: 0, fontSize: '1rem' }}>
+                      <Link href={getCodeToolsUrl(item.id)}>{item.title}</Link>
+                    </h3>
+                    <p style={{ margin: '0.45rem 0 0', opacity: 0.8 }}>{item.description}</p>
+                  </div>
+                  {item.date && (
+                    <span className="date-badge" style={{ whiteSpace: 'nowrap' }}>
+                      {formatCodeToolsDate(item.date, { month: 'short', day: 'numeric' })}
+                    </span>
+                  )}
+                </div>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginTop: '0.85rem', opacity: 0.85 }}>
+                  <span className="language-badge">{getCodeToolsLanguageLabel(item.language)}</span>
+                  <span className="date-badge">{getCodeToolsItemLineCount(item)} lines</span>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      )}
+
       <div className="code-ai-layout">
-        {/* Sidebar Navigation */}
         <aside className="code-ai-sidebar">
           <h3>Categories</h3>
           <nav className="code-ai-nav">
-            {categories.map(category => {
-              const count = category.id === 'all'
-                ? allItems.length
-                : allItems.filter(item => item.category === category.id).length;
+            {categories.map((category) => {
+              const count = category.id === 'all' ? allItems.length : categoryCounts[category.id] ?? 0;
 
               return (
                 <button
                   key={category.id}
                   className={`code-ai-nav-item ${selectedCategory === category.id ? 'active' : ''}`}
                   onClick={() => setSelectedCategory(category.id)}
+                  type="button"
                 >
                   <span className="nav-icon">{category.icon}</span>
                   <span className="nav-label">{category.label}</span>
@@ -198,134 +217,171 @@ export default function CodeAIPage() {
           </nav>
         </aside>
 
-        {/* Main Content Area */}
         <main className="code-ai-main">
           {viewMode === 'compact' ? (
-            // Compact List View
             <div className="code-ai-list">
               {Object.entries(groupedItems)
                 .sort(([, itemsA], [, itemsB]) => {
-                  // Sort categories by most recent item date
                   const latestA = itemsA[0]?.date ? new Date(itemsA[0].date).getTime() : 0;
                   const latestB = itemsB[0]?.date ? new Date(itemsB[0].date).getTime() : 0;
                   return latestB - latestA;
                 })
                 .map(([category, categoryItems]) => (
-                <div key={category} className="code-ai-category-group">
-                  <h3 className="category-group-title">
-                    {categories.find(c => c.id === category)?.label || category}
-                  </h3>
-                  {categoryItems.map(item => (
-                    <div key={item.id} className="code-ai-item-compact">
-                      <div className="item-header" onClick={() => toggleExpanded(item.id)}>
-                        <div className="item-title-row">
-                          <span className="expand-icon">
-                            {expandedItems.has(item.id) ? '▼' : '▶'}
-                          </span>
-                          <h4>{item.title}</h4>
-                          <div className="item-badges">
-                            {item.date && (
-                              <span className="date-badge">
-                                {formatDate(item.date)}
-                              </span>
-                            )}
-                            <span className={`language-badge ${item.language}`}>
-                              {item.language}
+                  <div key={category} className="code-ai-category-group">
+                    <h3 className="category-group-title">
+                      {categories.find((categoryConfig) => categoryConfig.id === category)?.label || category}
+                      <span style={{ marginLeft: '0.5rem', opacity: 0.65, fontSize: '0.9rem' }}>
+                        ({categoryItems.length})
+                      </span>
+                    </h3>
+                    {categoryItems.map((item) => (
+                      <div key={item.id} className="code-ai-item-compact">
+                        <div className="item-header" onClick={() => toggleExpanded(item.id)}>
+                          <div className="item-title-row">
+                            <span className="expand-icon">
+                              {expandedItems.has(item.id) ? '▼' : '▶'}
                             </span>
-                          </div>
-                        </div>
-                        <p className="item-description">{item.description}</p>
-                      </div>
-
-                      {expandedItems.has(item.id) && (
-                        <div className="item-expanded">
-                          {item.writeup && (
-                            <div className="item-writeup">
-                              <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.writeup}</ReactMarkdown>
+                            <h4 style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+                              <Link href={getCodeToolsUrl(item.id)} onClick={(event) => event.stopPropagation()}>
+                                {item.title}
+                              </Link>
+                              {item.featured && (
+                                <span className="date-badge" style={{ background: 'rgba(255, 193, 7, 0.18)' }}>
+                                  Featured
+                                </span>
+                              )}
+                            </h4>
+                            <div className="item-badges">
+                              {item.date && (
+                                <span className="date-badge">
+                                  {formatCodeToolsDate(item.date)}
+                                </span>
+                              )}
+                              <span className={`language-badge ${normalizeCodeToolsLanguage(item.language)}`}>
+                                {getCodeToolsLanguageLabel(item.language)}
+                              </span>
+                              {item.filename && (
+                                <span className="date-badge" title="Source filename">
+                                  {item.filename}
+                                </span>
+                              )}
                             </div>
-                          )}
-                          <div className="code-block">
-                            <div className="code-header">
-                              <div className="code-filename">{getDisplayLanguage(item.language)}</div>
-                              <div className="code-actions">
-                                {item.gistUrl && (
-                                  <a
-                                    href={item.gistUrl}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="code-action gist-link"
-                                    title="View on GitHub"
+                          </div>
+                          <p className="item-description">{item.description}</p>
+                        </div>
+
+                        {expandedItems.has(item.id) && (
+                          <div className="item-expanded">
+                            {item.writeup && (
+                              <div className="item-writeup">
+                                <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.writeup}</ReactMarkdown>
+                              </div>
+                            )}
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.6rem', margin: '0 0 0.9rem', opacity: 0.9 }}>
+                              <Link href={getCodeToolsUrl(item.id)} style={{ textDecoration: 'none', fontWeight: 600 }}>
+                                Open detail page
+                              </Link>
+                              <span>•</span>
+                              <span>{getCodeToolsItemLineCount(item)} lines</span>
+                              <span>•</span>
+                              <span>{item.tags.length} tags</span>
+                            </div>
+                            <div className="code-block">
+                              <div className="code-header">
+                                <div className="code-filename">{getCodeToolsLanguageLabel(item.language)}</div>
+                                <div className="code-actions">
+                                  {item.gistUrl && (
+                                    <a
+                                      href={item.gistUrl}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="code-action gist-link"
+                                      title="View on GitHub"
+                                    >
+                                      <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+                                        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+                                      </svg>
+                                      Gist
+                                    </a>
+                                  )}
+                                  <button
+                                    className="code-action"
+                                    onClick={() => copyToClipboard(item.content, item.id)}
+                                    type="button"
                                   >
-                                    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-                                      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
-                                    </svg>
-                                    Gist
-                                  </a>
-                                )}
-                                <button
-                                  className="code-action"
-                                  onClick={() => copyToClipboard(item.content, item.id)}
+                                    {copyStates[item.id] || 'Copy'}
+                                  </button>
+                                </div>
+                              </div>
+                              <div className="code-container">
+                                <SyntaxHighlighter
+                                  language={normalizeCodeToolsLanguage(item.language)}
+                                  style={oneDark}
+                                  showLineNumbers
+                                  wrapLines
+                                  lineNumberStyle={{
+                                    minWidth: '3em',
+                                    paddingRight: '1em',
+                                    textAlign: 'right',
+                                    userSelect: 'none',
+                                    opacity: 0.5,
+                                  }}
+                                  customStyle={{
+                                    margin: 0,
+                                    padding: '1rem',
+                                    fontSize: '0.875rem',
+                                    lineHeight: '1.6',
+                                    borderRadius: '0 0 8px 8px',
+                                    background: '#282c34',
+                                  }}
+                                  codeTagProps={{
+                                    style: {
+                                      fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace",
+                                    },
+                                  }}
                                 >
-                                  {copyStates[item.id] || 'Copy'}
-                                </button>
+                                  {item.content}
+                                </SyntaxHighlighter>
                               </div>
                             </div>
-                            <div className="code-container">
-                              <SyntaxHighlighter
-                                language={getNormalizedLanguage(item.language)}
-                                style={oneDark}
-                                showLineNumbers
-                                wrapLines
-                                lineNumberStyle={{
-                                  minWidth: '3em',
-                                  paddingRight: '1em',
-                                  textAlign: 'right',
-                                  userSelect: 'none',
-                                  opacity: 0.5,
-                                }}
-                                customStyle={{
-                                  margin: 0,
-                                  padding: '1rem',
-                                  fontSize: '0.875rem',
-                                  lineHeight: '1.6',
-                                  borderRadius: '0 0 8px 8px',
-                                  background: '#282c34',
-                                }}
-                                codeTagProps={{
-                                  style: {
-                                    fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace",
-                                  }
-                                }}
-                              >
-                                {item.content}
-                              </SyntaxHighlighter>
+                            <div className="item-footer">
+                              <div className="item-tags">
+                                {item.tags.map((tag: string) => (
+                                  <span key={tag} className="tag">
+                                    #{tag}
+                                  </span>
+                                ))}
+                              </div>
                             </div>
                           </div>
-                          <div className="item-footer">
-                            <div className="item-tags">
-                              {item.tags.map((tag: string) => (
-                                <span key={tag} className="tag">#{tag}</span>
-                              ))}
-                            </div>
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              ))}
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ))}
             </div>
           ) : (
-            // Full Card View (original grid layout)
             <div className="code-ai-grid">
-              {filteredItems.map(item => (
+              {filteredItems.map((item) => (
                 <div key={item.id} className="code-ai-card">
                   <div className="code-ai-card-header">
-                    <h3>{item.title}</h3>
+                    <h3>
+                      <Link href={getCodeToolsUrl(item.id)}>{item.title}</Link>
+                    </h3>
                     <div className="code-ai-card-badges">
+                      {item.featured && (
+                        <span className="code-ai-date" style={{ background: 'rgba(255, 193, 7, 0.18)' }}>
+                          Featured
+                        </span>
+                      )}
                       {item.date && (
                         <span className="code-ai-date">
-                          {formatDate(item.date)}
+                          {formatCodeToolsDate(item.date)}
+                        </span>
+                      )}
+                      {item.filename && (
+                        <span className="code-ai-date">
+                          {item.filename}
                         </span>
                       )}
                     </div>
@@ -341,7 +397,7 @@ export default function CodeAIPage() {
 
                   <div className="code-block">
                     <div className="code-header">
-                      <div className="code-filename">{getDisplayLanguage(item.language)}</div>
+                      <div className="code-filename">{getCodeToolsLanguageLabel(item.language)}</div>
                       <div className="code-actions">
                         {item.gistUrl && (
                           <a
@@ -352,7 +408,7 @@ export default function CodeAIPage() {
                             title="View on GitHub"
                           >
                             <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-                              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+                              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
                             </svg>
                             Gist
                           </a>
@@ -360,6 +416,7 @@ export default function CodeAIPage() {
                         <button
                           className="code-action"
                           onClick={() => copyToClipboard(item.content, item.id)}
+                          type="button"
                         >
                           {copyStates[item.id] || 'Copy'}
                         </button>
@@ -367,7 +424,7 @@ export default function CodeAIPage() {
                     </div>
                     <div className="code-container">
                       <SyntaxHighlighter
-                        language={getNormalizedLanguage(item.language)}
+                        language={normalizeCodeToolsLanguage(item.language)}
                         style={oneDark}
                         showLineNumbers
                         wrapLines
@@ -389,7 +446,7 @@ export default function CodeAIPage() {
                         codeTagProps={{
                           style: {
                             fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace",
-                          }
+                          },
                         }}
                       >
                         {item.content}
@@ -405,6 +462,9 @@ export default function CodeAIPage() {
                         </span>
                       ))}
                     </div>
+                    <Link href={getCodeToolsUrl(item.id)} className="code-ai-card-link">
+                      Read detail
+                    </Link>
                   </div>
                 </div>
               ))}
@@ -412,8 +472,11 @@ export default function CodeAIPage() {
           )}
 
           {filteredItems.length === 0 && (
-            <div className="code-ai-empty">
-              <p>No snippets found matching your criteria.</p>
+            <div className="code-ai-empty" style={{ padding: '2rem 1.5rem' }}>
+              <p style={{ margin: 0, fontSize: '1.05rem' }}>No snippets match the current filter.</p>
+              <p style={{ marginTop: '0.5rem', opacity: 0.75 }}>
+                Try a different category, clear the search, or switch to full view to browse the whole collection.
+              </p>
             </div>
           )}
         </main>

--- a/app/utils/codeTools.ts
+++ b/app/utils/codeTools.ts
@@ -7,6 +7,129 @@ const codeToolsItems: CodeToolsItem[] = [...workshopConfig.items, ...gistItems];
 
 export const codeToolsCategories = workshopConfig.categories;
 
+const languageMap: Record<string, string> = {
+  js: 'javascript',
+  ts: 'typescript',
+  py: 'python',
+  rb: 'ruby',
+  sh: 'bash',
+  shell: 'bash',
+  zsh: 'bash',
+  yml: 'yaml',
+  dockerfile: 'docker',
+  text: 'plaintext',
+  txt: 'plaintext',
+  code: 'plaintext',
+  toml: 'toml',
+  gitconfig: 'ini',
+  ini: 'ini',
+  conf: 'ini',
+  cfg: 'ini',
+};
+
+const displayLanguageNames: Record<string, string> = {
+  javascript: 'JavaScript',
+  typescript: 'TypeScript',
+  python: 'Python',
+  bash: 'Bash',
+  shell: 'Shell',
+  json: 'JSON',
+  yaml: 'YAML',
+  markdown: 'Markdown',
+  css: 'CSS',
+  html: 'HTML',
+  sql: 'SQL',
+  go: 'Go',
+  rust: 'Rust',
+  java: 'Java',
+  csharp: 'C#',
+  cpp: 'C++',
+  c: 'C',
+  ruby: 'Ruby',
+  php: 'PHP',
+  swift: 'Swift',
+  kotlin: 'Kotlin',
+  docker: 'Dockerfile',
+  plaintext: 'Text',
+  toml: 'TOML',
+  ini: 'INI',
+};
+
+export const normalizeCodeToolsLanguage = (lang?: string): string => {
+  if (!lang) {
+    return 'plaintext';
+  }
+
+  const lowered = lang.toLowerCase();
+  return languageMap[lowered] || lowered;
+};
+
+export const getCodeToolsLanguageLabel = (lang?: string): string => {
+  const normalized = normalizeCodeToolsLanguage(lang);
+  return displayLanguageNames[normalized] || normalized.charAt(0).toUpperCase() + normalized.slice(1);
+};
+
+export const formatCodeToolsDate = (date: Date | string | undefined, options?: Intl.DateTimeFormatOptions): string => {
+  if (!date) {
+    return '';
+  }
+
+  return new Date(date).toLocaleDateString(
+    'en-US',
+    options ?? {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    },
+  );
+};
+
+export const getCodeToolsCategoryMeta = (categoryId: string) => {
+  return codeToolsCategories.find((category) => category.id === categoryId);
+};
+
+export const getCodeToolsCategoryCounts = (items: CodeToolsItem[] = codeToolsItems): Record<string, number> => {
+  return items.reduce<Record<string, number>>((counts, item) => {
+    counts[item.category] = (counts[item.category] ?? 0) + 1;
+    return counts;
+  }, {});
+};
+
+export const getCodeToolsFeaturedItems = (items: CodeToolsItem[] = codeToolsItems): CodeToolsItem[] => {
+  return [...items]
+    .filter((item) => item.featured)
+    .sort((a, b) => {
+      const dateA = a.date ? new Date(a.date).getTime() : 0;
+      const dateB = b.date ? new Date(b.date).getTime() : 0;
+      return dateB - dateA;
+    });
+};
+
+export const getCodeToolsItemLineCount = (item: CodeToolsItem): number => {
+  return item.content.split(/\r?\n/).length;
+};
+
+export const getCodeToolsRelatedItems = (item: CodeToolsItem, limit = 3): CodeToolsItem[] => {
+  const itemTags = new Set(item.tags.map((tag) => tag.toLowerCase()));
+
+  return codeToolsItems
+    .filter((candidate) => candidate.id !== item.id)
+    .map((candidate) => {
+      const sharedTags = candidate.tags.filter((tag) => itemTags.has(tag.toLowerCase())).length;
+      const categoryMatch = candidate.category === item.category ? 3 : 0;
+      const featuredBonus = candidate.featured ? 1 : 0;
+      const recency = candidate.date ? new Date(candidate.date).getTime() : 0;
+
+      return {
+        candidate,
+        score: sharedTags * 4 + categoryMatch + featuredBonus + recency / 1e15,
+      };
+    })
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(({ candidate }) => candidate);
+};
+
 export const getCodeToolsItems = (): CodeToolsItem[] => {
   return [...codeToolsItems].sort((a, b) => {
     const dateA = a.date ? new Date(a.date).getTime() : 0;


### PR DESCRIPTION
## Context

The Code & Tools area already had complete coverage, but it still read like a utility dump rather than a finished part of the site. The list view did not give readers much editorial framing, and the detail pages were mostly raw code blocks with minimal narrative structure.

This work keeps the full item set and routing intact while improving presentation and navigation. The goal is to make the collection feel like a deliberate reference library inside the site, not a holdover from an internal tool.

## What changed

- **`app/code-ai/page.tsx`**: Added a more editorial header, summary stats, featured-item callouts, richer item metadata, and direct links into detail pages while preserving compact/full browsing and every existing item.
- **`app/code-ai/[id]/page.tsx`**: Reworked the detail route into a fuller article layout with metadata, writeup presentation, a syntax-highlighted code view, and related-item suggestions.
- **`app/utils/codeTools.ts`**: Added shared formatting and lookup helpers for categories, dates, language labels, featured items, line counts, and related-item discovery so both routes stay consistent.

## Why this matters

Without this pass, the Code & Tools section feels like a staging area. With the new framing and detail-page structure, it behaves more like a finished library that is easier to scan, easier to browse, and easier to share.

The routing and content inventory are unchanged, so the main risk is purely presentational. That keeps the change low-risk while improving the perceived quality of the site.

## Test plan

- [x] `npm ci`
- [x] `npm run build -- --no-lint`
- [x] Verified the `/code-ai` and `/code-ai/[id]` routes still render in the production build output

