### PR TITLE
feat: improve discovery route hierarchy

### DIFF
--- a/app/archive/page.tsx
+++ b/app/archive/page.tsx
@@ -56,7 +56,7 @@ export default async function ArchivePage() {
           <p className="editorial-home-kicker">Archive</p>
           <h1 className="editorial-page-title">Archive</h1>
           <p className="editorial-page-copy">
-            Browse the full post history by year and month, with links preserved at both the month and individual post level.
+            Browse the full post history by year and month, with each month arranged like a compact table of contents rather than a flat index.
           </p>
           <div className="editorial-chip-row">
             <span className="editorial-chip">By year</span>
@@ -87,19 +87,16 @@ export default async function ArchivePage() {
         <section key={year} className="editorial-list-section">
           <div className="editorial-list-heading">
             <p className="editorial-home-section-label">Year {year}</p>
-            <h2 className="editorial-page-section-title">Monthly index for {year}.</h2>
+            <h2 className="editorial-page-section-title">Monthly index for {year}, with every post still available below each month.</h2>
           </div>
           <div className="months-grid">
             {postsByYear[year].map(({ monthLabel, monthHref, posts: monthPosts }) => (
-              <article key={`${year}-${monthLabel}`} className="editorial-post-card">
-                <div className="editorial-post-meta">
-                  <span>{monthLabel}</span>
-                  <span>{monthPosts.length} post{monthPosts.length !== 1 ? 's' : ''}</span>
-                </div>
-                <h3 className="month-heading">
+              <article key={`${year}-${monthLabel}`} className="editorial-home-card">
+                <p className="editorial-home-card-label">{monthLabel}</p>
+                <h3>
                   <Link href={monthHref}>{monthLabel}</Link>
-                  <span className="post-count">({monthPosts.length})</span>
                 </h3>
+                <p>{monthPosts.length} post{monthPosts.length !== 1 ? 's' : ''} in this month, linked by title below.</p>
                 <ul className="posts-list">
                   {monthPosts.map((post) => (
                     <li key={post.slug} className="archive-post">

--- a/app/archives/[month]/page.tsx
+++ b/app/archives/[month]/page.tsx
@@ -71,7 +71,7 @@ export default async function ArchivePage({ params }: ArchivePageProps) {
           <p className="editorial-home-kicker">Archive month</p>
           <h1 className="editorial-page-title">{monthName}</h1>
           <p className="editorial-page-copy">
-            Posts published in {monthName}, ordered newest first and linked back to the archive index.
+            Posts published in {monthName}, ordered newest first and framed as a single reading pass instead of a long list.
           </p>
           <div className="editorial-chip-row">
             <span className="editorial-chip">{monthPosts.length} posts</span>
@@ -104,30 +104,44 @@ export default async function ArchivePage({ params }: ArchivePageProps) {
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
           <p className="editorial-home-section-label">Posts</p>
-          <h2 className="editorial-page-section-title">Everything published during this month.</h2>
+          <h2 className="editorial-page-section-title">Everything published during this month, kept in one readable stack.</h2>
         </div>
-        <div className="editorial-post-grid">
-          {monthPosts.map((post) => (
-            <article key={post.slug} className="editorial-post-card">
-              <div className="editorial-post-meta">
-                <span>{longDateFormatter.format(post.date)}</span>
-                {post.readingTime && <span>{post.readingTime} min read</span>}
-              </div>
-              <h2>{post.title}</h2>
-              {post.summary && <p className="editorial-post-summary">{post.summary}</p>}
+        <article className="editorial-home-card">
+          <p className="editorial-home-card-label">Month index</p>
+          <h3>{monthName}</h3>
+          <p>
+            {monthPosts.length} post{monthPosts.length !== 1 ? 's' : ''} arranged newest first, with summaries and topic links left visible for scanning.
+          </p>
+          {monthPosts[0] ? (
+            <div>
+              <p className="editorial-home-card-label">Featured post</p>
+              <Link href={`/posts/${monthPosts[0].slug}`} className="editorial-home-card-link">
+                {monthPosts[0].title}
+              </Link>
+              {monthPosts[0].summary && <p className="editorial-post-summary">{monthPosts[0].summary}</p>}
               <div className="editorial-chip-row">
-                {post.tags.slice(0, 4).map((tag) => (
+                {monthPosts[0].tags.slice(0, 4).map((tag) => (
                   <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
                     {tag}
                   </Link>
                 ))}
               </div>
-              <Link href={`/posts/${post.slug}`} className="editorial-post-link">
-                Read post
-              </Link>
-            </article>
-          ))}
-        </div>
+            </div>
+          ) : null}
+          <ul className="posts-list">
+            {monthPosts.slice(1).map((post) => (
+              <li key={post.slug} className="archive-post">
+                <Link href={`/posts/${post.slug}`}>
+                  <time className="archive-post-date">{longDateFormatter.format(post.date)}</time>
+                  <span className="archive-post-title">{post.title}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+          <Link href="/archive" className="editorial-home-card-link">
+            Back to archive
+          </Link>
+        </article>
       </section>
     </EditorialPageFrame>
   );

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -92,7 +92,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
           <h1 className="editorial-page-title">{post.title}</h1>
           {post.summary && <p className="editorial-page-copy">{post.summary}</p>}
           <p className="editorial-post-summary">
-            Published {longDateFormatter.format(post.date)}{post.readingTime ? ` · ${post.readingTime} min read` : ''}
+            Published {longDateFormatter.format(post.date)}{post.readingTime ? ` · ${post.readingTime} min read` : ''} and filed with the post archive.
           </p>
           <div className="editorial-home-actions">
             <Link href="/posts" className="editorial-home-button editorial-home-button-secondary">
@@ -109,19 +109,19 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
           </div>
         </div>
         <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">Post details</p>
+          <p className="editorial-home-card-label">Reading frame</p>
           <div className="editorial-page-metric-list">
             <div>
               <span className="editorial-page-metric-value">{longDateFormatter.format(post.date)}</span>
-              <span className="editorial-page-metric-label">published date</span>
+              <span className="editorial-page-metric-label">publication date</span>
             </div>
             <div>
               <span className="editorial-page-metric-value">{post.readingTime ? `${post.readingTime} min` : 'Essay'}</span>
-              <span className="editorial-page-metric-label">reading time</span>
+              <span className="editorial-page-metric-label">reading length</span>
             </div>
             <div>
               <span className="editorial-page-metric-value">{monthYearFormatter.format(post.date)}</span>
-              <span className="editorial-page-metric-label">archive month</span>
+              <span className="editorial-page-metric-label">filed in</span>
             </div>
           </div>
           <div className="editorial-chip-row">

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -8,13 +8,15 @@ export const metadata: Metadata = {
   description: 'Essays, field notes, and technical writing on AI systems, memory, engineering practice, and adjacent work.',
 };
 
+type Posts = Awaited<ReturnType<typeof postService.getAllPosts>>;
+
 const formatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'short',
   day: 'numeric',
 });
 
-const countTags = (posts: Awaited<ReturnType<typeof postService.getAllPosts>>) => {
+const countTags = (posts: Posts) => {
   const counts = new Map<string, number>();
 
   posts.forEach((post) => {
@@ -28,11 +30,30 @@ const countTags = (posts: Awaited<ReturnType<typeof postService.getAllPosts>>) =
     .slice(0, 4);
 };
 
+const groupPostsByYear = (posts: Posts) => {
+  const groups = new Map<number, Posts>();
+
+  posts.forEach((post) => {
+    const year = post.date.getFullYear();
+    const yearPosts = groups.get(year) ?? [];
+    yearPosts.push(post);
+    groups.set(year, yearPosts);
+  });
+
+  return Array.from(groups.entries())
+    .sort((a, b) => b[0] - a[0])
+    .map(([year, yearPosts]) => ({
+      year,
+      posts: yearPosts,
+    }));
+};
+
 export default async function PostsPage() {
   const posts = await postService.getAllPosts();
   const featuredPost = posts[0];
   const topTags = countTags(posts);
-  const publicationYears = new Set(posts.map((post) => post.date.getFullYear())).size;
+  const postsByYear = groupPostsByYear(posts);
+  const publicationYears = postsByYear.length;
 
   return (
     <EditorialPageFrame currentPath="/posts">
@@ -41,7 +62,7 @@ export default async function PostsPage() {
           <p className="editorial-home-kicker">Writing archive</p>
           <h1 className="editorial-page-title">Posts</h1>
           <p className="editorial-page-copy">
-            Essays, field notes, and working-throughs on agent memory, AI systems, engineering practice, and the occasional economics detour.
+            Essays, field notes, and working-throughs on agent memory, AI systems, engineering practice, and the occasional economics detour, arranged so the newest work stays easy to find.
           </p>
           <div className="editorial-chip-row">
             {topTags.map(([tag, count]) => (
@@ -56,20 +77,18 @@ export default async function PostsPage() {
           <div className="editorial-page-metric-list">
             <div>
               <span className="editorial-page-metric-value">{posts.length}</span>
-              <span className="editorial-page-metric-label">published essays</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">
-                {featuredPost ? formatter.format(featuredPost.date) : 'n/a'}
-              </span>
-              <span className="editorial-page-metric-label">latest post</span>
+              <span className="editorial-page-metric-label">posts in the archive</span>
             </div>
             <div>
               <span className="editorial-page-metric-value">{publicationYears}</span>
-              <span className="editorial-page-metric-label">years of writing</span>
+              <span className="editorial-page-metric-label">years represented</span>
             </div>
           </div>
-          {featuredPost?.summary && <p className="editorial-post-summary">{featuredPost.summary}</p>}
+          {featuredPost && (
+            <p className="editorial-post-summary">
+              Latest: {featuredPost.title} on {formatter.format(featuredPost.date)}.
+            </p>
+          )}
           {featuredPost && (
             <Link href={`/posts/${featuredPost.slug}`} className="editorial-home-button editorial-home-button-secondary">
               Start with the latest essay
@@ -78,51 +97,75 @@ export default async function PostsPage() {
         </aside>
       </section>
 
-      <section className="editorial-home-proof-strip" aria-label="Posts summary">
-        <span>{posts.length} posts</span>
-        <span>/</span>
-        <span>essays + field notes</span>
-        <span>/</span>
-        <span>agent memory</span>
-        <span>/</span>
-        <span>systems + workflow</span>
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Featured reading</p>
+          <h2 className="editorial-page-section-title">Start with the latest essay, then move backward by year.</h2>
+        </div>
+        {featuredPost ? (
+          <article className="editorial-home-card">
+            <p className="editorial-home-card-label">{formatter.format(featuredPost.date)}</p>
+            <h3>
+              <Link href={`/posts/${featuredPost.slug}`}>{featuredPost.title}</Link>
+            </h3>
+            {featuredPost.summary && <p>{featuredPost.summary}</p>}
+            <div className="editorial-post-meta">
+              {featuredPost.tags[0] ? (
+                <Link href={`/tags/${encodeURIComponent(featuredPost.tags[0])}`} className="editorial-chip">
+                  <span>{featuredPost.tags[0]}</span>
+                </Link>
+              ) : (
+                <span className="editorial-chip">Essay</span>
+              )}
+              <span>{featuredPost.readingTime ? `${featuredPost.readingTime} min read` : 'Long-form note'}</span>
+            </div>
+            <div className="editorial-chip-row">
+              {featuredPost.tags.slice(0, 3).map((tag) => (
+                <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
+                  {tag}
+                </Link>
+              ))}
+            </div>
+            <Link href={`/posts/${featuredPost.slug}`} className="editorial-home-card-link">
+              Read the post
+            </Link>
+          </article>
+        ) : null}
       </section>
 
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Archive</p>
-          <h2 className="editorial-page-section-title">Recent writing, newest first, with tags and context left visible.</h2>
+          <p className="editorial-home-section-label">By year</p>
+          <h2 className="editorial-page-section-title">A compact index that keeps each year readable on mobile.</h2>
         </div>
 
-        <div className="editorial-post-grid">
-          {posts.map((post) => (
-            <article key={post.slug} className="editorial-post-card">
-              <div className="editorial-post-meta">
-                {post.tags[0] ? (
-                  <Link href={`/tags/${encodeURIComponent(post.tags[0])}`} className="editorial-chip">
-                    <span>{post.tags[0]}</span>
+        <div className="editorial-two-column">
+          {postsByYear.map(({ year, posts: yearPosts }) => (
+            <article key={year} className="editorial-home-card">
+              <p className="editorial-home-card-label">Year {year}</p>
+              <h3>{yearPosts.length} post{yearPosts.length !== 1 ? 's' : ''}</h3>
+              <p>Newest first, with each post left visible so the archive can be scanned without opening every page.</p>
+              {yearPosts[0] ? (
+                <div>
+                  <p className="editorial-home-card-label">Featured post</p>
+                  <Link href={`/posts/${yearPosts[0].slug}`} className="editorial-home-card-link">
+                    {yearPosts[0].title}
                   </Link>
-                ) : (
-                  <span className="editorial-chip">Essay</span>
-                )}
-                <span>{formatter.format(post.date)}</span>
-                {post.readingTime && <span>{post.readingTime} min read</span>}
-                <span>{post.tags.length} tags</span>
-              </div>
-              <h2>
-                <Link href={`/posts/${post.slug}`}>{post.title}</Link>
-              </h2>
-              {post.summary && <p className="editorial-post-summary">{post.summary}</p>}
-              <div className="editorial-chip-row">
-                {post.tags.slice(0, 3).map((tag) => (
-                  <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
-                    {tag}
-                  </Link>
+                  {yearPosts[0].summary && <p className="editorial-post-summary">{yearPosts[0].summary}</p>}
+                </div>
+              ) : null}
+              <ul className="posts-list">
+                {yearPosts.slice(1).map((post) => (
+                  <li key={post.slug} className="archive-post">
+                    <Link href={`/posts/${post.slug}`}>
+                      <time className="archive-post-date">
+                        {post.date.getDate().toString().padStart(2, '0')}
+                      </time>
+                      <span className="archive-post-title">{post.title}</span>
+                    </Link>
+                  </li>
                 ))}
-              </div>
-              <Link href={`/posts/${post.slug}`} className="editorial-post-link">
-                Read the post
-              </Link>
+              </ul>
             </article>
           ))}
         </div>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -17,11 +17,36 @@ function formatResultDate(date?: Date) {
   }).format(new Date(date));
 }
 
+const resultTypeOrder: SearchResult['type'][] = ['post', 'publication', 'talk', 'code-ai'];
+
+const groupResultsByType = (results: SearchResult[]) => {
+  const groups = new Map<SearchResult['type'], SearchResult[]>();
+
+  results.forEach((result) => {
+    const typeResults = groups.get(result.type) ?? [];
+    typeResults.push(result);
+    groups.set(result.type, typeResults);
+  });
+
+  return resultTypeOrder
+    .filter((type) => groups.has(type))
+    .map((type) => ({
+      type,
+      results: groups.get(type) ?? [],
+    }));
+};
+
 function SearchContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const query = searchParams.get('q') || '';
   const normalizedQuery = query.trim();
+  const typeLabels: Record<SearchResult['type'], string> = {
+    post: 'Blog post',
+    talk: 'Talk',
+    publication: 'Publication',
+    'code-ai': 'Code & tools',
+  };
 
   const [results, setResults] = useState<SearchResult[]>([]);
   const [loading, setLoading] = useState(false);
@@ -68,13 +93,7 @@ function SearchContent() {
 
     router.replace(`/search?q=${encodeURIComponent(nextQuery)}`);
   };
-
-  const typeLabels: Record<SearchResult['type'], string> = {
-    post: 'Blog post',
-    talk: 'Talk',
-    publication: 'Publication',
-    'code-ai': 'Code & tools',
-  };
+  const groupedResults = groupResultsByType(results);
 
   return (
     <EditorialPageFrame currentPath="/search" pageClassName="editorial-book-page">
@@ -83,7 +102,7 @@ function SearchContent() {
           <p className="editorial-home-kicker">Search</p>
           <h1 className="editorial-page-title">Search Results</h1>
           <p className="editorial-page-copy">
-            Search posts, talks, publications, and code notes without leaving the editorial index.
+            Search posts, talks, publications, and code notes without leaving the editorial index, with results grouped so the page reads in sections instead of one long feed.
           </p>
           <p className="editorial-post-summary">
             {normalizedQuery ? `Showing results for “${normalizedQuery}”.` : 'Search the archive by topic, title, or theme.'}
@@ -159,34 +178,66 @@ function SearchContent() {
               Found {results.length} result{results.length !== 1 ? 's' : ''} for “{normalizedQuery}”
             </p>
 
-            <div className="editorial-post-grid">
-              {results.map((result) => (
-                <Link
-                  key={`${result.type}-${result.title}`}
-                  href={result.url}
-                  className="editorial-post-card search-result-item"
-                >
-                  <div className="editorial-post-meta">
-                    <span>{typeLabels[result.type]}</span>
-                    {result.date && <span>{formatResultDate(result.date)}</span>}
+            {groupedResults.map(({ type, results: typeResults }) => {
+              const [featuredResult, ...moreResults] = typeResults;
+
+              return (
+                <section key={type} className="editorial-list-section">
+                  <div className="editorial-list-heading">
+                    <p className="editorial-home-section-label">{typeLabels[type]}</p>
+                    <h2 className="editorial-page-section-title">
+                      {typeResults.length} result{typeResults.length !== 1 ? 's' : ''} in this section.
+                    </h2>
                   </div>
 
-                  <h2>{result.title}</h2>
+                  {featuredResult ? (
+                    <article className="editorial-home-card">
+                      <p className="editorial-home-card-label">{typeLabels[featuredResult.type]}</p>
+                      <h3>
+                        <Link href={featuredResult.url}>{featuredResult.title}</Link>
+                      </h3>
+                      {featuredResult.description && <p>{featuredResult.description}</p>}
+                      <div className="editorial-post-meta">
+                        {featuredResult.date ? (
+                          <span>{formatResultDate(featuredResult.date)}</span>
+                        ) : (
+                          <span>{typeLabels[featuredResult.type]}</span>
+                        )}
+                        <span>{featuredResult.tags?.length ? `${featuredResult.tags.length} tags` : 'No tags listed'}</span>
+                      </div>
+                      <div className="editorial-chip-row">
+                        {featuredResult.tags?.slice(0, 3).map((tag) => (
+                          <span key={tag} className="editorial-chip">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                      <Link href={featuredResult.url} className="editorial-home-card-link">
+                        Open result
+                      </Link>
+                    </article>
+                  ) : null}
 
-                  {result.description && <p className="editorial-post-summary">{result.description}</p>}
-
-                  <div className="editorial-chip-row">
-                    {result.tags?.slice(0, 3).map((tag) => (
-                      <span key={tag} className="editorial-chip">
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-
-                  <span className="editorial-post-link">Open result</span>
-                </Link>
-              ))}
-            </div>
+                  {moreResults.length > 0 ? (
+                    <article className="editorial-home-card">
+                      <p className="editorial-home-card-label">More {typeLabels[type]}</p>
+                      <ul className="posts-list">
+                        {moreResults.map((result) => (
+                          <li key={`${result.type}-${result.title}`} className="archive-post">
+                            <Link href={result.url}>
+                              <time className="archive-post-date">
+                                {result.date ? formatResultDate(result.date) ?? typeLabels[result.type] : typeLabels[result.type]}
+                              </time>
+                              <span className="archive-post-title">{result.title}</span>
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    </article>
+                  ) : null}
+                </section>
+              );
+            })}
           </>
         )}
       </section>

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -16,6 +16,26 @@ const longDateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
 });
 
+type Posts = Awaited<ReturnType<typeof postService.getPostsByTag>>;
+
+const groupPostsByYear = (posts: Posts) => {
+  const groups = new Map<number, Posts>();
+
+  posts.forEach((post) => {
+    const year = post.date.getFullYear();
+    const yearPosts = groups.get(year) ?? [];
+    yearPosts.push(post);
+    groups.set(year, yearPosts);
+  });
+
+  return Array.from(groups.entries())
+    .sort((a, b) => b[0] - a[0])
+    .map(([year, yearPosts]) => ({
+      year,
+      posts: yearPosts,
+    }));
+};
+
 export async function generateMetadata({ params }: TagPageProps): Promise<Metadata> {
   const { tag: encodedTag } = await params;
   const tag = decodeURIComponent(encodedTag);
@@ -37,6 +57,8 @@ export default async function TagPage({ params }: TagPageProps) {
   const { tag: encodedTag } = await params;
   const tag = decodeURIComponent(encodedTag);
   const posts = await postService.getPostsByTag(tag);
+  const postsByYear = groupPostsByYear(posts);
+  const featuredPost = posts[0];
 
   if (posts.length === 0) {
     notFound();
@@ -49,7 +71,7 @@ export default async function TagPage({ params }: TagPageProps) {
           <p className="editorial-home-kicker">Tag archive</p>
           <h1 className="editorial-page-title">{tag}</h1>
           <p className="editorial-page-copy">
-            {posts.length} post{posts.length !== 1 ? 's' : ''} found for this topic, ordered newest first.
+            {posts.length} post{posts.length !== 1 ? 's' : ''} found for this topic, ordered newest first and arranged so the topic reads like a guided trail.
           </p>
           <div className="editorial-chip-row">
             <span className="editorial-chip">{posts.length} posts</span>
@@ -65,7 +87,7 @@ export default async function TagPage({ params }: TagPageProps) {
               <span className="editorial-page-metric-label">posts in this tag</span>
             </div>
             <div>
-              <span className="editorial-page-metric-value">{new Set(posts.map((post) => post.date.getFullYear())).size}</span>
+              <span className="editorial-page-metric-value">{postsByYear.length}</span>
               <span className="editorial-page-metric-label">years represented</span>
             </div>
             <div>
@@ -79,28 +101,66 @@ export default async function TagPage({ params }: TagPageProps) {
 
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Posts</p>
-          <h2 className="editorial-page-section-title">Everything indexed under {tag}.</h2>
+          <p className="editorial-home-section-label">Featured match</p>
+          <h2 className="editorial-page-section-title">Start with the newest post, then move through the year-by-year trail.</h2>
         </div>
-        <div className="editorial-post-grid">
-          {posts.map((post) => (
-            <article key={post.slug} className="editorial-post-card">
-              <div className="editorial-post-meta">
-                <span>{longDateFormatter.format(post.date)}</span>
-                <span>{post.readingTime ? `${post.readingTime} min read` : `${post.tags.length} tags`}</span>
-              </div>
-              <h2>{post.title}</h2>
-              {post.summary && <p className="editorial-post-summary">{post.summary}</p>}
-              <div className="editorial-chip-row">
-                {post.tags.map((postTag) => (
-                  <Link key={postTag} href={`/tags/${encodeURIComponent(postTag)}`} className="editorial-chip">
-                    {postTag}
+        {featuredPost ? (
+          <article className="editorial-home-card">
+            <p className="editorial-home-card-label">{longDateFormatter.format(featuredPost.date)}</p>
+            <h3>
+              <Link href={`/posts/${featuredPost.slug}`}>{featuredPost.title}</Link>
+            </h3>
+            {featuredPost.summary && <p>{featuredPost.summary}</p>}
+            <div className="editorial-post-meta">
+              <span>{featuredPost.readingTime ? `${featuredPost.readingTime} min read` : `${featuredPost.tags.length} tags`}</span>
+              <span>{featuredPost.tags.length} topic tag{featuredPost.tags.length !== 1 ? 's' : ''}</span>
+            </div>
+            <div className="editorial-chip-row">
+              {featuredPost.tags.map((postTag) => (
+                <Link key={postTag} href={`/tags/${encodeURIComponent(postTag)}`} className="editorial-chip">
+                  {postTag}
+                </Link>
+              ))}
+            </div>
+            <Link href={`/posts/${featuredPost.slug}`} className="editorial-home-card-link">
+              Read post
+            </Link>
+          </article>
+        ) : null}
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">By year</p>
+          <h2 className="editorial-page-section-title">A lighter index that keeps every tagged post visible on mobile.</h2>
+        </div>
+        <div className="editorial-two-column">
+          {postsByYear.map(({ year, posts: yearPosts }) => (
+            <article key={year} className="editorial-home-card">
+              <p className="editorial-home-card-label">Year {year}</p>
+              <h3>{yearPosts.length} post{yearPosts.length !== 1 ? 's' : ''}</h3>
+              <p>Newest first, with titles and summaries kept together so the topic stays scannable.</p>
+              {yearPosts[0] ? (
+                <div>
+                  <p className="editorial-home-card-label">Featured post</p>
+                  <Link href={`/posts/${yearPosts[0].slug}`} className="editorial-home-card-link">
+                    {yearPosts[0].title}
                   </Link>
+                  {yearPosts[0].summary && <p className="editorial-post-summary">{yearPosts[0].summary}</p>}
+                </div>
+              ) : null}
+              <ul className="posts-list">
+                {yearPosts.slice(1).map((post) => (
+                  <li key={post.slug} className="archive-post">
+                    <Link href={`/posts/${post.slug}`}>
+                      <time className="archive-post-date">
+                        {post.date.getDate().toString().padStart(2, '0')}
+                      </time>
+                      <span className="archive-post-title">{post.title}</span>
+                    </Link>
+                  </li>
                 ))}
-              </div>
-              <Link href={`/posts/${post.slug}`} className="editorial-post-link">
-                Read post
-              </Link>
+              </ul>
             </article>
           ))}
         </div>

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -40,7 +40,7 @@ export default async function TagsPage() {
           <p className="editorial-home-kicker">Topics</p>
           <h1 className="editorial-page-title">Tags</h1>
           <p className="editorial-page-copy">
-            Explore topics across {posts.length} posts, with links preserved to every tag-specific archive.
+            Explore topics across {posts.length} posts, with links preserved to every tag-specific archive and the broadest themes surfaced first.
           </p>
           <div className="editorial-chip-row">
             {topTags.map(([tag, count]) => (
@@ -71,7 +71,7 @@ export default async function TagsPage() {
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
           <p className="editorial-home-section-label">All tags</p>
-          <h2 className="editorial-page-section-title">A weighted cloud with direct links.</h2>
+          <h2 className="editorial-page-section-title">A weighted cloud for broad browsing.</h2>
         </div>
         <div className="tag-cloud">
           <div className="tag-cloud-container">
@@ -100,7 +100,7 @@ export default async function TagsPage() {
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
           <p className="editorial-home-section-label">Alphabetical</p>
-          <h2 className="editorial-page-section-title">Browse the same index by first letter.</h2>
+          <h2 className="editorial-page-section-title">The same index, re-sorted for precision.</h2>
         </div>
         <div className="tags-alphabetical">
           {sortedLetters.map((letter) => (


### PR DESCRIPTION
## Context

The combined preview for the discovery surfaces was still reading like a dense list, especially on `/posts` and the related archive and tag views. On mobile, the top stats rails and repeated card patterns made the pages feel flatter than the content warranted.

This branch keeps the same routes, slugs, tags, and search behavior, but reshapes the presentation so the archive reads in layers: a lead item first, then year or topic groupings, then compact supporting entries. The intent is to make the pages easier to scan without dropping any content or navigation paths.

## What changed

- **`app/posts/page.tsx`**: Reworked the posts index into a featured latest essay plus year-grouped sections with compact supporting entries, reducing the wall-of-cards effect on mobile.
- **`app/posts/[slug]/page.tsx`**: Tightened the reading frame copy and labels so the single-post view feels more editorial and less mechanically boxed.
- **`app/archive/page.tsx`**: Swapped month tiles to a lighter card treatment and clarified the archive copy for faster scanning.
- **`app/archives/[month]/page.tsx`**: Reframed the month page around one featured post with the rest kept in a readable stack.
- **`app/tags/page.tsx`**: Polished the topic index copy so the cloud and alphabetical browse modes read more intentionally.
- **`app/tags/[tag]/page.tsx`**: Grouped tagged posts by year with a featured entry to reduce repetitive density.
- **`app/search/page.tsx`**: Grouped results by type and split each section into a lead result plus compact follow-on items.

## Why this matters

These routes are the main discovery layer for the site. If they stay visually flat, the preview feels harder to browse even when the content is complete. This change gives the pages a clearer hierarchy and better mobile pacing, which makes the archive feel curated instead of exhaustive.

## Test plan

- [x] `npm ci` to restore local dependencies in the worktree
- [x] `npm run build`
- [x] Cleaned generated `.next` output back out of the worktree after validation

