### PR TITLE
feat: assemble refined site review preview

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -75,6 +75,11 @@ export default function AboutPage() {
               <p className="editorial-home-card-label">{item.label}</p>
               <h3>{item.title}</h3>
               <p>{item.summary}</p>
+              {item.label === 'What this site is for' && (
+                <a href="/benjamin_labaschin_resume.pdf" download className="editorial-post-link">
+                  Download resume
+                </a>
+              )}
             </article>
           ))}
         </div>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -30,11 +30,19 @@ const experience = [
   },
 ];
 
-const proofPoints = [
-  "O'Reilly reports on AI agents and memory systems",
-  'AEA Papers and Proceedings publication on firm-level exposure to GPTs',
-  'Conference and community talks on memory, validation, and production AI systems',
-  'Hands-on platform work spanning LLM APIs, analytics infrastructure, and deployment',
+const currentFocus = [
+  {
+    label: 'What I spend time on',
+    title: 'Production AI, memory, retrieval, and the messy middle.',
+    summary:
+      'Most of my current work sits between research ideas and the engineering realities of enterprise systems: memory management, async LLM infrastructure, evaluation, developer workflows, and the trade-offs that show up once systems leave the demo stage.',
+  },
+  {
+    label: 'What this site is for',
+    title: 'A public record, not just a resume.',
+    summary:
+      'The site keeps the professional signal, but its job is to make the writing, talks, reports, and upcoming book read as one coherent body of work.',
+  },
 ];
 
 export default function AboutPage() {
@@ -54,6 +62,39 @@ export default function AboutPage() {
             <span className="editorial-chip">Speaking</span>
           </div>
         </div>
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Current focus</p>
+          <h2 className="editorial-page-section-title">The through-line is practical AI systems that keep working after the demo.</h2>
+        </div>
+        <div className="editorial-two-column">
+          {currentFocus.map((item) => (
+            <article key={item.label} className="editorial-home-card">
+              <p className="editorial-home-card-label">{item.label}</p>
+              <h3>{item.title}</h3>
+              <p>{item.summary}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="editorial-home-proof-strip" aria-label="About summary">
+        <span>Principal ML Engineer</span>
+        <span>/</span>
+        <span>writer and speaker</span>
+        <span>/</span>
+        <span>AI systems and memory</span>
+        <span>/</span>
+        <span>economics background</span>
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">At a glance</p>
+          <h2 className="editorial-page-section-title">A small visual pause before the work history.</h2>
+        </div>
         <aside className="editorial-page-aside editorial-about-photo-card">
           <img src="/assets/atlas_and_I.jpg" alt="Ben Labaschin with Atlas" />
           <div className="editorial-page-metric-list">
@@ -69,60 +110,10 @@ export default function AboutPage() {
         </aside>
       </section>
 
-      <section className="editorial-home-proof-strip" aria-label="About summary">
-        <span>Principal ML Engineer</span>
-        <span>/</span>
-        <span>writer and speaker</span>
-        <span>/</span>
-        <span>AI systems and memory</span>
-        <span>/</span>
-        <span>economics background</span>
-      </section>
-
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Current focus</p>
-          <h2 className="editorial-page-section-title">The through-line is practical AI systems that keep working after the demo.</h2>
-        </div>
-        <div className="editorial-two-column">
-          <article className="editorial-home-card">
-            <p className="editorial-home-card-label">What I spend time on</p>
-            <h3>Production AI, memory, retrieval, and the messy middle.</h3>
-            <p>
-              Most of my work sits between research ideas and the engineering realities of enterprise systems: memory management, async LLM infrastructure, evaluation, developer workflows, and the trade-offs that show up once systems leave the demo stage.
-            </p>
-          </article>
-          <article className="editorial-home-card">
-            <p className="editorial-home-card-label">What this site is for</p>
-            <h3>A public record, not just a resume.</h3>
-            <p>
-              The site keeps the professional signal, but its job is to make the writing, talks, reports, and upcoming book read as one coherent body of work.
-            </p>
-            <a href="/benjamin_labaschin_resume.pdf" download className="editorial-post-link">
-              Download resume
-            </a>
-          </article>
-        </div>
-      </section>
-
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Proof</p>
-          <h2 className="editorial-page-section-title">The strongest signals to put in front of a new visitor.</h2>
-        </div>
-        <div className="editorial-proof-list">
-          {proofPoints.map((item) => (
-            <div key={item} className="editorial-proof-item">
-              {item}
-            </div>
-          ))}
-        </div>
-      </section>
-
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
           <p className="editorial-home-section-label">Experience</p>
-          <h2 className="editorial-page-section-title">A concise view of the operating history.</h2>
+          <h2 className="editorial-page-section-title">A concise view of the operating history behind the public work.</h2>
         </div>
         <div className="editorial-timeline">
           {experience.map((item) => (

--- a/app/archive/page.tsx
+++ b/app/archive/page.tsx
@@ -56,7 +56,7 @@ export default async function ArchivePage() {
           <p className="editorial-home-kicker">Archive</p>
           <h1 className="editorial-page-title">Archive</h1>
           <p className="editorial-page-copy">
-            Browse the full post history by year and month, with links preserved at both the month and individual post level.
+            Browse the full post history by year and month, with each month arranged like a compact table of contents rather than a flat index.
           </p>
           <div className="editorial-chip-row">
             <span className="editorial-chip">By year</span>
@@ -87,19 +87,16 @@ export default async function ArchivePage() {
         <section key={year} className="editorial-list-section">
           <div className="editorial-list-heading">
             <p className="editorial-home-section-label">Year {year}</p>
-            <h2 className="editorial-page-section-title">Monthly index for {year}.</h2>
+            <h2 className="editorial-page-section-title">Monthly index for {year}, with every post still available below each month.</h2>
           </div>
           <div className="months-grid">
             {postsByYear[year].map(({ monthLabel, monthHref, posts: monthPosts }) => (
-              <article key={`${year}-${monthLabel}`} className="editorial-post-card">
-                <div className="editorial-post-meta">
-                  <span>{monthLabel}</span>
-                  <span>{monthPosts.length} post{monthPosts.length !== 1 ? 's' : ''}</span>
-                </div>
-                <h3 className="month-heading">
+              <article key={`${year}-${monthLabel}`} className="editorial-home-card">
+                <p className="editorial-home-card-label">{monthLabel}</p>
+                <h3>
                   <Link href={monthHref}>{monthLabel}</Link>
-                  <span className="post-count">({monthPosts.length})</span>
                 </h3>
+                <p>{monthPosts.length} post{monthPosts.length !== 1 ? 's' : ''} in this month, linked by title below.</p>
                 <ul className="posts-list">
                   {monthPosts.map((post) => (
                     <li key={post.slug} className="archive-post">

--- a/app/archives/[month]/page.tsx
+++ b/app/archives/[month]/page.tsx
@@ -71,7 +71,7 @@ export default async function ArchivePage({ params }: ArchivePageProps) {
           <p className="editorial-home-kicker">Archive month</p>
           <h1 className="editorial-page-title">{monthName}</h1>
           <p className="editorial-page-copy">
-            Posts published in {monthName}, ordered newest first and linked back to the archive index.
+            Posts published in {monthName}, ordered newest first and framed as a single reading pass instead of a long list.
           </p>
           <div className="editorial-chip-row">
             <span className="editorial-chip">{monthPosts.length} posts</span>
@@ -104,30 +104,44 @@ export default async function ArchivePage({ params }: ArchivePageProps) {
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
           <p className="editorial-home-section-label">Posts</p>
-          <h2 className="editorial-page-section-title">Everything published during this month.</h2>
+          <h2 className="editorial-page-section-title">Everything published during this month, kept in one readable stack.</h2>
         </div>
-        <div className="editorial-post-grid">
-          {monthPosts.map((post) => (
-            <article key={post.slug} className="editorial-post-card">
-              <div className="editorial-post-meta">
-                <span>{longDateFormatter.format(post.date)}</span>
-                {post.readingTime && <span>{post.readingTime} min read</span>}
-              </div>
-              <h2>{post.title}</h2>
-              {post.summary && <p className="editorial-post-summary">{post.summary}</p>}
+        <article className="editorial-home-card">
+          <p className="editorial-home-card-label">Month index</p>
+          <h3>{monthName}</h3>
+          <p>
+            {monthPosts.length} post{monthPosts.length !== 1 ? 's' : ''} arranged newest first, with summaries and topic links left visible for scanning.
+          </p>
+          {monthPosts[0] ? (
+            <div>
+              <p className="editorial-home-card-label">Featured post</p>
+              <Link href={`/posts/${monthPosts[0].slug}`} className="editorial-home-card-link">
+                {monthPosts[0].title}
+              </Link>
+              {monthPosts[0].summary && <p className="editorial-post-summary">{monthPosts[0].summary}</p>}
               <div className="editorial-chip-row">
-                {post.tags.slice(0, 4).map((tag) => (
+                {monthPosts[0].tags.slice(0, 4).map((tag) => (
                   <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
                     {tag}
                   </Link>
                 ))}
               </div>
-              <Link href={`/posts/${post.slug}`} className="editorial-post-link">
-                Read post
-              </Link>
-            </article>
-          ))}
-        </div>
+            </div>
+          ) : null}
+          <ul className="posts-list">
+            {monthPosts.slice(1).map((post) => (
+              <li key={post.slug} className="archive-post">
+                <Link href={`/posts/${post.slug}`}>
+                  <time className="archive-post-date">{longDateFormatter.format(post.date)}</time>
+                  <span className="archive-post-title">{post.title}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+          <Link href="/archive" className="editorial-home-card-link">
+            Back to archive
+          </Link>
+        </article>
       </section>
     </EditorialPageFrame>
   );

--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -1,6 +1,21 @@
 import Link from 'next/link';
 import { EditorialPageFrame } from '../components/EditorialPageFrame';
 
+const bookNotes = [
+  {
+    label: 'What the book covers',
+    title: 'How AI systems remember, retrieve, compress, and decide what to act on.',
+    summary:
+      'The book is a practical guide to the mechanics behind durable agent behavior: storing useful context, retrieving it at the right time, and keeping the system understandable once it is in production.',
+  },
+  {
+    label: 'Why it belongs here',
+    title: 'It extends the same editorial arc as the essays, reports, and talks.',
+    summary:
+      'This page should make the book legible before launch without turning it into a separate identity. The subject, audience, and technical point of view all stay connected to the rest of the site.',
+  },
+];
+
 export default function BookPage() {
   return (
     <EditorialPageFrame currentPath="/book">
@@ -29,19 +44,14 @@ export default function BookPage() {
 
         <aside className="editorial-home-book-card">
           <p className="editorial-home-card-label">Working direction</p>
-          <h2>Why it belongs here</h2>
+          <h2>Practical memory systems for production agents.</h2>
           <p>
             One domain, one body of work, one list. The book should reinforce the site&apos;s technical arc, not split it into a second identity.
           </p>
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">one</span>
-              <span className="editorial-page-metric-label">coherent public arc</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">O&apos;Reilly</span>
-              <span className="editorial-page-metric-label">publisher and home base</span>
-            </div>
+          <div className="editorial-home-book-meta">
+            <span>in progress</span>
+            <span>O&apos;Reilly</span>
+            <span>agent memory</span>
           </div>
         </aside>
       </section>
@@ -56,21 +66,20 @@ export default function BookPage() {
         <span>production AI</span>
       </section>
 
-      <section className="editorial-home-grid">
-        <article className="editorial-home-card">
-          <p className="editorial-home-card-label">What belongs here</p>
-          <h3>Context, audience, and ongoing updates.</h3>
-          <p>
-            This page should make the book legible before launch: what problem it solves, who it is for, and why it belongs in the same public arc as the essays and talks.
-          </p>
-        </article>
-        <article className="editorial-home-card">
-          <p className="editorial-home-card-label">How it connects</p>
-          <h3>The reports, talks, and book should read as one arc.</h3>
-          <p>
-            Use this page to point back to the O&apos;Reilly reports, talks, and essays so the book reads as the next step in the same body of work.
-          </p>
-        </article>
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Working notes</p>
+          <h2 className="editorial-page-section-title">The book page should answer three things quickly: what, why, and where it connects.</h2>
+        </div>
+        <div className="editorial-two-column">
+          {bookNotes.map((item) => (
+            <article key={item.label} className="editorial-home-card">
+              <p className="editorial-home-card-label">{item.label}</p>
+              <h3>{item.title}</h3>
+              <p>{item.summary}</p>
+            </article>
+          ))}
+        </div>
       </section>
     </EditorialPageFrame>
   );

--- a/app/code-ai/[id]/page.tsx
+++ b/app/code-ai/[id]/page.tsx
@@ -1,10 +1,11 @@
-import Link from 'next/link';
 import { Metadata } from 'next';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { EditorialPageFrame } from '../../components/EditorialPageFrame';
 import { getSiteUrl } from '../../utils/siteUrl';
 import {
   formatCodeToolsDate,
@@ -18,6 +19,40 @@ import {
   normalizeCodeToolsLanguage,
 } from '../../utils/codeTools';
 
+const codeBlockStyle = {
+  background: 'rgba(246, 242, 233, 0.94)',
+  border: '1px solid rgba(16, 34, 54, 0.08)',
+  borderRadius: '18px',
+  boxShadow: '0 16px 32px rgba(24, 36, 49, 0.08)',
+  overflow: 'hidden',
+} as const;
+
+const syntaxStyle = {
+  margin: 0,
+  padding: '1rem',
+  fontSize: '0.9rem',
+  lineHeight: '1.72',
+  background: 'transparent',
+} as const;
+
+const codeActionStyle = {
+  alignItems: 'center',
+  background: 'rgba(255, 255, 255, 0.72)',
+  border: '1px solid rgba(16, 34, 54, 0.08)',
+  borderRadius: '999px',
+  color: 'var(--editorial-ink)',
+  cursor: 'pointer',
+  display: 'inline-flex',
+  fontFamily: 'Inter, var(--font-body)',
+  fontSize: '0.82rem',
+  fontWeight: 700,
+  gap: '0.35rem',
+  justifyContent: 'center',
+  minHeight: '34px',
+  padding: '0 12px',
+  textDecoration: 'none',
+} as const;
+
 export async function generateStaticParams() {
   return getCodeToolsStaticParams();
 }
@@ -28,14 +63,14 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
 
   if (!item) {
     return {
-      title: 'Not Found | Economic Notes',
+      title: 'Not Found | Code & Tools',
     };
   }
 
   const canonicalUrl = `${getSiteUrl()}${getCodeToolsUrl(id)}`;
 
   return {
-    title: `${item.title} | Code & Tools | Economic Notes`,
+    title: `${item.title} | Code & Tools | Ben Labaschin`,
     description: item.description,
     alternates: {
       canonical: canonicalUrl,
@@ -65,96 +100,105 @@ export default async function CodeAIDetailPage({ params }: { params: Promise<{ i
   const dateLabel = item.date ? formatCodeToolsDate(item.date, { year: 'numeric', month: 'long', day: 'numeric' }) : 'No date';
 
   return (
-    <article
-      className="code-ai-detail"
-      style={{
-        display: 'grid',
-        gap: '1.5rem',
-        maxWidth: '1120px',
-        margin: '0 auto',
-      }}
-    >
-      <div className="code-ai-detail-header" style={{ display: 'grid', gap: '1rem' }}>
-        <div className="breadcrumb">
-          <Link href="/code-ai">← Back to Code & Tools</Link>
+    <EditorialPageFrame currentPath="/code-ai" pageClassName="editorial-book-page">
+      <section className="editorial-page-hero">
+        <div className="editorial-page-hero-copy">
+          <p className="editorial-home-kicker">Code & tools</p>
+          <h1 className="editorial-page-title">{item.title}</h1>
+          <p className="editorial-page-copy">{item.description}</p>
+          <p className="editorial-post-summary" style={{ marginTop: '14px', maxWidth: '58ch' }}>
+            The detail view keeps the writeup and code together, so the route behaves like the rest of the editorial site instead of a separate utility app.
+          </p>
+
+          <div className="editorial-home-actions">
+            <Link href="/code-ai" className="editorial-home-button editorial-home-button-secondary">
+              Back to Code & Tools
+            </Link>
+            {item.gistUrl && (
+              <a href={item.gistUrl} target="_blank" rel="noopener noreferrer" className="editorial-home-button editorial-home-button-primary">
+                View on GitHub
+              </a>
+            )}
+          </div>
+
+          <div className="editorial-chip-row">
+            <span className="editorial-chip">{categoryConfig?.label || item.category}</span>
+            <span className="editorial-chip">{dateLabel}</span>
+            <span className="editorial-chip">{getCodeToolsLanguageLabel(item.language)}</span>
+            {item.filename && <span className="editorial-chip">{item.filename}</span>}
+            <span className="editorial-chip">{lineCount} lines</span>
+          </div>
         </div>
 
-        <div
-          className="code-ai-detail-meta"
-          style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem', alignItems: 'center' }}
-        >
-          <span className="code-ai-detail-category">
-            {categoryConfig?.icon} {categoryConfig?.label || item.category}
-          </span>
-          <time className="code-ai-detail-date">{dateLabel}</time>
-          <span className="code-ai-detail-date">{getCodeToolsLanguageLabel(item.language)}</span>
-          {item.filename && <span className="code-ai-detail-date">{item.filename}</span>}
-          <span className="code-ai-detail-date">{lineCount} lines</span>
-        </div>
-
-        <div style={{ maxWidth: '70ch' }}>
-          <h1 className="code-ai-detail-title" style={{ marginBottom: '0.5rem' }}>
-            {item.title}
-          </h1>
-          <p className="code-ai-detail-description">{item.description}</p>
-        </div>
-
-        <div className="code-ai-detail-tags">
-          {item.tags.map((tag) => (
-            <span key={tag} className="code-ai-detail-tag">
-              {tag}
-            </span>
-          ))}
-        </div>
-
-        <div className="code-ai-detail-actions">
-          {item.gistUrl && (
-            <a
-              href={item.gistUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="action-button github-button"
-            >
-              <svg className="icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
-                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-              </svg>
-              View on GitHub
-            </a>
-          )}
-          <Link href="/code-ai" className="action-button">
-            Browse all snippets
-          </Link>
-        </div>
-      </div>
-
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'minmax(0, 1.6fr) minmax(280px, 0.9fr)',
-          gap: '1.25rem',
-          alignItems: 'start',
-        }}
-      >
-        <section style={{ display: 'grid', gap: '1rem' }}>
-          {item.writeup && (
-            <div className="item-writeup" style={{ padding: '1.1rem 1.15rem', borderRadius: '16px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.writeup}</ReactMarkdown>
+        <aside className="editorial-page-aside">
+          <p className="editorial-home-card-label">At a glance</p>
+          <div className="editorial-page-metric-list">
+            <div>
+              <span className="editorial-page-metric-value">{categoryConfig?.label || item.category}</span>
+              <span className="editorial-page-metric-label">category</span>
             </div>
-          )}
+            <div>
+              <span className="editorial-page-metric-value">{getCodeToolsLanguageLabel(item.language)}</span>
+              <span className="editorial-page-metric-label">language</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">{item.filename || 'Inline snippet'}</span>
+              <span className="editorial-page-metric-label">source</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">{item.tags.length}</span>
+              <span className="editorial-page-metric-label">tags</span>
+            </div>
+          </div>
+        </aside>
+      </section>
 
-          <div className="code-block">
-            <div className="code-header">
-              <div className="code-filename">{getCodeToolsLanguageLabel(item.language)}</div>
-              <div className="code-actions">
-                <span className="code-action" style={{ pointerEvents: 'none' }}>
-                  {lineCount} lines
-                </span>
+      <section className="editorial-home-proof-strip" aria-label="Code & Tools context">
+        <span>{categoryConfig?.label || item.category}</span>
+        <span>/</span>
+        <span>{dateLabel}</span>
+        <span>/</span>
+        <span>{lineCount} lines</span>
+        <span>/</span>
+        <span>{item.tags.length} tags</span>
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-two-column">
+          <section style={{ display: 'grid', gap: '18px' }}>
+            {item.writeup && (
+              <div className="editorial-post-card" style={{ background: 'rgba(255, 255, 255, 0.58)' }}>
+                <p className="editorial-home-card-label">Writeup</p>
+                <div className="item-writeup" style={{ marginTop: '12px' }}>
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.writeup}</ReactMarkdown>
+                </div>
               </div>
-            </div>
-            <div className="code-container">
+            )}
+
+            <div style={codeBlockStyle}>
+              <div style={{ alignItems: 'center', display: 'flex', flexWrap: 'wrap', gap: '0.75rem', justifyContent: 'space-between', padding: '0.85rem 1rem' }}>
+                <div style={{ display: 'grid', gap: '0.18rem' }}>
+                  <div style={{ color: 'var(--editorial-ink)', fontFamily: 'IBM Plex Mono, Roboto Mono, monospace', fontSize: '0.78rem', fontWeight: 700, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+                    {getCodeToolsLanguageLabel(item.language)}
+                  </div>
+                  <div style={{ color: 'var(--editorial-slate)', fontFamily: 'Inter, var(--font-body)', fontSize: '0.88rem' }}>
+                    {item.filename || 'Inline snippet'}
+                  </div>
+                </div>
+
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', justifyContent: 'flex-end' }}>
+                  {item.gistUrl && (
+                    <a href={item.gistUrl} target="_blank" rel="noopener noreferrer" style={codeActionStyle}>
+                      Gist
+                    </a>
+                  )}
+                  <span style={{ ...codeActionStyle, cursor: 'default' }}>{lineCount} lines</span>
+                </div>
+              </div>
+
               <SyntaxHighlighter
                 language={normalizeCodeToolsLanguage(item.language)}
-                style={oneDark}
+                style={oneLight}
                 showLineNumbers
                 wrapLines
                 lineNumberStyle={{
@@ -162,75 +206,59 @@ export default async function CodeAIDetailPage({ params }: { params: Promise<{ i
                   paddingRight: '1em',
                   textAlign: 'right',
                   userSelect: 'none',
-                  opacity: 0.5,
+                  opacity: 0.45,
                 }}
-                customStyle={{
-                  margin: 0,
-                  padding: '1rem',
-                  fontSize: '0.9rem',
-                  lineHeight: '1.7',
-                  borderRadius: '0 0 8px 8px',
-                  background: '#282c34',
-                }}
+                customStyle={syntaxStyle}
                 codeTagProps={{
                   style: {
-                    fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace",
+                    fontFamily: "'IBM Plex Mono', 'Roboto Mono', 'Consolas', 'Monaco', monospace",
                   },
                 }}
               >
                 {item.content}
               </SyntaxHighlighter>
             </div>
-          </div>
-        </section>
-
-        <aside style={{ display: 'grid', gap: '1rem' }}>
-          <section style={{ padding: '1rem 1.1rem', borderRadius: '16px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
-            <h2 style={{ marginTop: 0, marginBottom: '0.75rem', fontSize: '1rem' }}>At a glance</h2>
-            <div style={{ display: 'grid', gap: '0.7rem' }}>
-              <div>
-                <div style={{ fontSize: '0.76rem', textTransform: 'uppercase', letterSpacing: '0.12em', opacity: 0.7 }}>Category</div>
-                <div style={{ marginTop: '0.2rem' }}>{categoryConfig?.label || item.category}</div>
-              </div>
-              <div>
-                <div style={{ fontSize: '0.76rem', textTransform: 'uppercase', letterSpacing: '0.12em', opacity: 0.7 }}>Language</div>
-                <div style={{ marginTop: '0.2rem' }}>{getCodeToolsLanguageLabel(item.language)}</div>
-              </div>
-              <div>
-                <div style={{ fontSize: '0.76rem', textTransform: 'uppercase', letterSpacing: '0.12em', opacity: 0.7 }}>Source</div>
-                <div style={{ marginTop: '0.2rem' }}>{item.filename || 'Inline snippet'}</div>
-              </div>
-              <div>
-                <div style={{ fontSize: '0.76rem', textTransform: 'uppercase', letterSpacing: '0.12em', opacity: 0.7 }}>Tags</div>
-                <div style={{ marginTop: '0.2rem' }}>{item.tags.length}</div>
-              </div>
-            </div>
           </section>
 
-          {relatedItems.length > 0 && (
-            <section style={{ padding: '1rem 1.1rem', borderRadius: '16px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
-              <h2 style={{ marginTop: 0, marginBottom: '0.75rem', fontSize: '1rem' }}>Related snippets</h2>
-              <div style={{ display: 'grid', gap: '0.75rem' }}>
-                {relatedItems.map((relatedItem) => (
-                  <article key={relatedItem.id} style={{ paddingBottom: '0.75rem', borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
-                    <h3 style={{ margin: 0, fontSize: '0.98rem' }}>
-                      <Link href={getCodeToolsUrl(relatedItem.id)}>{relatedItem.title}</Link>
-                    </h3>
-                    <p style={{ margin: '0.35rem 0 0', opacity: 0.78 }}>{relatedItem.description}</p>
-                  </article>
+          <aside style={{ display: 'grid', gap: '18px' }}>
+            <section className="editorial-page-aside">
+              <p className="editorial-home-card-label">Collection note</p>
+              <p className="editorial-post-summary" style={{ marginTop: '10px' }}>
+                This snippet stays in the editorial index alongside the rest of the collection, which keeps the browsing model stable as the presentation changes.
+              </p>
+            </section>
+
+            {relatedItems.length > 0 && (
+              <section className="editorial-page-aside">
+                <p className="editorial-home-card-label">Related snippets</p>
+                <div style={{ display: 'grid', gap: '14px', marginTop: '12px' }}>
+                  {relatedItems.map((relatedItem) => (
+                    <article key={relatedItem.id} style={{ paddingBottom: '14px', borderBottom: '1px solid rgba(16, 34, 54, 0.08)' }}>
+                      <h3 style={{ margin: 0, color: 'var(--editorial-ink)', fontFamily: 'Space Grotesk, Inter, sans-serif', fontSize: '1.2rem', letterSpacing: '-0.04em' }}>
+                        <Link href={getCodeToolsUrl(relatedItem.id)}>{relatedItem.title}</Link>
+                      </h3>
+                      <p className="editorial-post-summary" style={{ marginTop: '8px' }}>
+                        {relatedItem.description}
+                      </p>
+                    </article>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            <section className="editorial-page-aside">
+              <p className="editorial-home-card-label">Tags</p>
+              <div className="editorial-chip-row" style={{ marginTop: '12px' }}>
+                {item.tags.map((tag) => (
+                  <span key={tag} className="editorial-chip">
+                    {tag}
+                  </span>
                 ))}
               </div>
             </section>
-          )}
-
-          <section style={{ padding: '1rem 1.1rem', borderRadius: '16px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
-            <h2 style={{ marginTop: 0, marginBottom: '0.75rem', fontSize: '1rem' }}>Collection note</h2>
-            <p style={{ margin: 0, opacity: 0.82 }}>
-              This snippet lives in the Code & Tools library alongside the rest of the collection, so the route structure stays stable even as the presentation gets more editorial.
-            </p>
-          </section>
-        </aside>
-      </div>
-    </article>
+          </aside>
+        </div>
+      </section>
+    </EditorialPageFrame>
   );
 }

--- a/app/code-ai/page.tsx
+++ b/app/code-ai/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { workshopConfig, type WorkshopItem } from '../config/workshopConfig';
 import {
   formatCodeToolsDate,
@@ -17,6 +17,154 @@ import {
   getCodeToolsUrl,
   normalizeCodeToolsLanguage,
 } from '../utils/codeTools';
+
+const editorialNavItems = [
+  { href: '/posts', label: 'Posts' },
+  { href: '/talks', label: 'Talks' },
+  { href: '/publications', label: 'Publications' },
+  { href: '/book', label: 'Book' },
+  { href: '/archive', label: 'Archive' },
+  { href: '/search', label: 'Search' },
+  { href: '/about', label: 'About' },
+  { href: '/code-ai', label: 'Code & Tools' },
+];
+
+const codeBlockStyle = {
+  background: 'rgba(246, 242, 233, 0.94)',
+  border: '1px solid rgba(16, 34, 54, 0.08)',
+  borderRadius: '18px',
+  boxShadow: '0 16px 32px rgba(24, 36, 49, 0.08)',
+  overflow: 'hidden',
+} as const;
+
+const syntaxStyle = {
+  margin: 0,
+  padding: '1rem',
+  fontSize: '0.88rem',
+  lineHeight: '1.7',
+  background: 'transparent',
+} as const;
+
+const categoryButtonStyle = {
+  alignItems: 'center',
+  cursor: 'pointer',
+  display: 'inline-flex',
+  gap: '0.45rem',
+  justifyContent: 'center',
+  lineHeight: 1,
+} as const;
+
+const controlButtonStyle = {
+  alignItems: 'center',
+  cursor: 'pointer',
+  display: 'inline-flex',
+  gap: '0.4rem',
+  justifyContent: 'center',
+  lineHeight: 1,
+} as const;
+
+const codeHeaderStyle = {
+  alignItems: 'center',
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '0.75rem',
+  justifyContent: 'space-between',
+  padding: '0.85rem 1rem',
+} as const;
+
+const codeActionStyle = {
+  alignItems: 'center',
+  background: 'rgba(255, 255, 255, 0.72)',
+  border: '1px solid rgba(16, 34, 54, 0.08)',
+  borderRadius: '999px',
+  color: 'var(--editorial-ink)',
+  cursor: 'pointer',
+  display: 'inline-flex',
+  fontFamily: 'Inter, var(--font-body)',
+  fontSize: '0.82rem',
+  fontWeight: 700,
+  gap: '0.35rem',
+  justifyContent: 'center',
+  minHeight: '34px',
+  padding: '0 12px',
+  textDecoration: 'none',
+} as const;
+
+const groupCardStyle = {
+  background: 'rgba(255, 255, 255, 0.58)',
+  border: '1px solid rgba(16, 34, 54, 0.08)',
+  borderRadius: '22px',
+  boxShadow: '0 16px 32px rgba(24, 36, 49, 0.08)',
+  padding: '22px 24px 24px',
+} as const;
+
+const compactCardStyle = {
+  background: 'rgba(255, 255, 255, 0.74)',
+  border: '1px solid rgba(16, 34, 54, 0.08)',
+  borderRadius: '22px',
+  boxShadow: '0 16px 32px rgba(24, 36, 49, 0.08)',
+  padding: '22px 24px 24px',
+} as const;
+
+function isActivePath(currentPath: string, href: string) {
+  if (href === '/') {
+    return currentPath === href;
+  }
+
+  return currentPath === href || currentPath.startsWith(`${href}/`);
+}
+
+function SnippetCodeBlock({ item, onCopy, copyLabel }: { item: WorkshopItem; onCopy: () => void; copyLabel: string }) {
+  return (
+    <div style={codeBlockStyle}>
+      <div style={codeHeaderStyle}>
+        <div style={{ display: 'grid', gap: '0.18rem' }}>
+          <div style={{ color: 'var(--editorial-ink)', fontFamily: 'IBM Plex Mono, Roboto Mono, monospace', fontSize: '0.78rem', fontWeight: 700, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+            {getCodeToolsLanguageLabel(item.language)}
+          </div>
+          <div style={{ color: 'var(--editorial-slate)', fontFamily: 'Inter, var(--font-body)', fontSize: '0.88rem' }}>
+            {item.filename || 'Inline snippet'}
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', justifyContent: 'flex-end' }}>
+          {item.gistUrl && (
+            <a href={item.gistUrl} target="_blank" rel="noopener noreferrer" style={codeActionStyle}>
+              Gist
+            </a>
+          )}
+          <button type="button" onClick={onCopy} style={codeActionStyle}>
+            {copyLabel}
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <SyntaxHighlighter
+          language={normalizeCodeToolsLanguage(item.language)}
+          style={oneLight}
+          showLineNumbers
+          wrapLines
+          lineNumberStyle={{
+            minWidth: '3em',
+            paddingRight: '1em',
+            textAlign: 'right',
+            userSelect: 'none',
+            opacity: 0.45,
+          }}
+          customStyle={syntaxStyle}
+          codeTagProps={{
+            style: {
+              fontFamily: "'IBM Plex Mono', 'Roboto Mono', 'Consolas', 'Monaco', monospace",
+            },
+          }}
+        >
+          {item.content}
+        </SyntaxHighlighter>
+      </div>
+    </div>
+  );
+}
 
 export default function CodeAIPage() {
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
@@ -52,6 +200,7 @@ export default function CodeAIPage() {
     if (!acc[item.category]) {
       acc[item.category] = [];
     }
+
     acc[item.category].push(item);
     return acc;
   }, {} as Record<string, WorkshopItem[]>);
@@ -68,417 +217,411 @@ export default function CodeAIPage() {
 
   const copyToClipboard = (content: string, itemId: string) => {
     navigator.clipboard.writeText(content);
-    setCopyStates((prev) => ({ ...prev, [itemId]: 'Copied!' }));
-    setTimeout(() => {
+    setCopyStates((prev) => ({ ...prev, [itemId]: 'Copied' }));
+    window.setTimeout(() => {
       setCopyStates((prev) => ({ ...prev, [itemId]: 'Copy' }));
     }, 2000);
   };
 
   return (
-    <div className="code-ai-container">
-      <div className="code-ai-header">
-        <p style={{ margin: 0, textTransform: 'uppercase', letterSpacing: '0.16em', fontSize: '0.72rem', opacity: 0.72 }}>
-          Reference library
-        </p>
-        <h1>{title}</h1>
-        <p className="code-ai-subtitle">{subtitle}</p>
-
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
-            gap: '0.85rem',
-            marginTop: '1.25rem',
-          }}
-        >
-          <div style={{ padding: '1rem 1.1rem', borderRadius: '14px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
-            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.14em', opacity: 0.7 }}>Snippets</div>
-            <div style={{ fontSize: '1.35rem', fontWeight: 700, marginTop: '0.35rem' }}>{allItems.length}</div>
+    <div className="editorial-home-page">
+      <div className="editorial-home-shell">
+        <header className="editorial-home-topbar">
+          <div className="editorial-home-brand">
+            <Link href="/" className="editorial-home-brand-link" aria-label="Go to home">
+              <p className="editorial-home-brand-name">BEN LABASCHIN</p>
+            </Link>
+            <p className="editorial-home-brand-note">AI systems, memory, and editorial writing</p>
           </div>
-          <div style={{ padding: '1rem 1.1rem', borderRadius: '14px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
-            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.14em', opacity: 0.7 }}>Active categories</div>
-            <div style={{ fontSize: '1.35rem', fontWeight: 700, marginTop: '0.35rem' }}>{activeCategoryCount}</div>
-          </div>
-          <div style={{ padding: '1rem 1.1rem', borderRadius: '14px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
-            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.14em', opacity: 0.7 }}>Featured</div>
-            <div style={{ fontSize: '1.35rem', fontWeight: 700, marginTop: '0.35rem' }}>{featuredItems.length}</div>
-          </div>
-          <div style={{ padding: '1rem 1.1rem', borderRadius: '14px', background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
-            <div style={{ fontSize: '0.72rem', textTransform: 'uppercase', letterSpacing: '0.14em', opacity: 0.7 }}>Latest</div>
-            <div style={{ fontSize: '1rem', fontWeight: 700, marginTop: '0.35rem' }}>
-              {latestItem ? formatCodeToolsDate(latestItem.date, { month: 'short', day: 'numeric', year: 'numeric' }) : 'No items yet'}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div className="code-ai-controls">
-        <div className="code-ai-search">
-          <input
-            type="text"
-            placeholder="Search snippets..."
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            className="code-ai-search-input"
-          />
-        </div>
-
-        <div className="code-ai-view-toggle">
-          <button
-            className={`view-toggle-btn ${viewMode === 'compact' ? 'active' : ''}`}
-            onClick={() => setViewMode('compact')}
-            title="Compact view"
-            type="button"
-          >
-            ☰
-          </button>
-          <button
-            className={`view-toggle-btn ${viewMode === 'full' ? 'active' : ''}`}
-            onClick={() => setViewMode('full')}
-            title="Full view"
-            type="button"
-          >
-            ⊞
-          </button>
-        </div>
-      </div>
-
-      <div
-        style={{
-          display: 'flex',
-          flexWrap: 'wrap',
-          gap: '0.75rem',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          marginBottom: '1rem',
-        }}
-      >
-        <div style={{ opacity: 0.84 }}>
-          Showing <strong>{filteredItems.length}</strong> of <strong>{allItems.length}</strong> items in <strong>{selectedCategoryLabel}</strong>
-          {searchQuery ? <> for <strong>“{searchQuery}”</strong></> : null}
-        </div>
-        <div style={{ opacity: 0.72 }}>
-          Browse the compact list for quick scanning, or open an item to read the note and copy the code.
-        </div>
-      </div>
-
-      {featuredItems.length > 0 && (
-        <section style={{ marginBottom: '1.5rem' }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '1rem', marginBottom: '0.75rem' }}>
-            <h2 style={{ margin: 0, fontSize: '1.05rem' }}>Featured picks</h2>
-            <span style={{ opacity: 0.7, fontSize: '0.92rem' }}>Handpicked snippets that show the collection at its best.</span>
-          </div>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '0.85rem' }}>
-            {featuredItems.slice(0, 3).map((item) => (
-              <article key={item.id} style={{ padding: '1rem 1.1rem', borderRadius: '16px', border: '1px solid rgba(255,255,255,0.08)', background: 'rgba(255,255,255,0.035)' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.75rem', alignItems: 'start' }}>
-                  <div>
-                    <h3 style={{ margin: 0, fontSize: '1rem' }}>
-                      <Link href={getCodeToolsUrl(item.id)}>{item.title}</Link>
-                    </h3>
-                    <p style={{ margin: '0.45rem 0 0', opacity: 0.8 }}>{item.description}</p>
-                  </div>
-                  {item.date && (
-                    <span className="date-badge" style={{ whiteSpace: 'nowrap' }}>
-                      {formatCodeToolsDate(item.date, { month: 'short', day: 'numeric' })}
-                    </span>
-                  )}
-                </div>
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginTop: '0.85rem', opacity: 0.85 }}>
-                  <span className="language-badge">{getCodeToolsLanguageLabel(item.language)}</span>
-                  <span className="date-badge">{getCodeToolsItemLineCount(item)} lines</span>
-                </div>
-              </article>
-            ))}
-          </div>
-        </section>
-      )}
-
-      <div className="code-ai-layout">
-        <aside className="code-ai-sidebar">
-          <h3>Categories</h3>
-          <nav className="code-ai-nav">
-            {categories.map((category) => {
-              const count = category.id === 'all' ? allItems.length : categoryCounts[category.id] ?? 0;
+          <nav className="editorial-home-nav" aria-label="Primary">
+            {editorialNavItems.map((item) => {
+              const active = isActivePath('/code-ai', item.href);
 
               return (
-                <button
-                  key={category.id}
-                  className={`code-ai-nav-item ${selectedCategory === category.id ? 'active' : ''}`}
-                  onClick={() => setSelectedCategory(category.id)}
-                  type="button"
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={`editorial-home-nav-link ${active ? 'is-active' : ''}`}
+                  aria-current={active ? 'page' : undefined}
                 >
-                  <span className="nav-icon">{category.icon}</span>
-                  <span className="nav-label">{category.label}</span>
-                  <span className="nav-count">{count}</span>
-                </button>
+                  {item.label}
+                </Link>
               );
             })}
           </nav>
-        </aside>
+        </header>
 
-        <main className="code-ai-main">
-          {viewMode === 'compact' ? (
-            <div className="code-ai-list">
-              {Object.entries(groupedItems)
-                .sort(([, itemsA], [, itemsB]) => {
-                  const latestA = itemsA[0]?.date ? new Date(itemsA[0].date).getTime() : 0;
-                  const latestB = itemsB[0]?.date ? new Date(itemsB[0].date).getTime() : 0;
-                  return latestB - latestA;
-                })
-                .map(([category, categoryItems]) => (
-                  <div key={category} className="code-ai-category-group">
-                    <h3 className="category-group-title">
-                      {categories.find((categoryConfig) => categoryConfig.id === category)?.label || category}
-                      <span style={{ marginLeft: '0.5rem', opacity: 0.65, fontSize: '0.9rem' }}>
-                        ({categoryItems.length})
-                      </span>
-                    </h3>
-                    {categoryItems.map((item) => (
-                      <div key={item.id} className="code-ai-item-compact">
-                        <div className="item-header" onClick={() => toggleExpanded(item.id)}>
-                          <div className="item-title-row">
-                            <span className="expand-icon">
-                              {expandedItems.has(item.id) ? '▼' : '▶'}
-                            </span>
-                            <h4 style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
-                              <Link href={getCodeToolsUrl(item.id)} onClick={(event) => event.stopPropagation()}>
-                                {item.title}
-                              </Link>
-                              {item.featured && (
-                                <span className="date-badge" style={{ background: 'rgba(255, 193, 7, 0.18)' }}>
-                                  Featured
-                                </span>
-                              )}
-                            </h4>
-                            <div className="item-badges">
-                              {item.date && (
-                                <span className="date-badge">
-                                  {formatCodeToolsDate(item.date)}
-                                </span>
-                              )}
-                              <span className={`language-badge ${normalizeCodeToolsLanguage(item.language)}`}>
-                                {getCodeToolsLanguageLabel(item.language)}
-                              </span>
-                              {item.filename && (
-                                <span className="date-badge" title="Source filename">
-                                  {item.filename}
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                          <p className="item-description">{item.description}</p>
-                        </div>
+        <main className="editorial-home-content">
+          <section className="editorial-page-hero">
+            <div className="editorial-page-hero-copy">
+              <p className="editorial-home-kicker">Code library</p>
+              <h1 className="editorial-page-title">{title}</h1>
+              <p className="editorial-page-copy">{subtitle}</p>
+              <p className="editorial-post-summary" style={{ marginTop: '14px', maxWidth: '58ch' }}>
+                Browse snippets, configs, and lightweight tools in an editorial layout that stays aligned with the rest of the site on desktop and mobile.
+              </p>
 
-                        {expandedItems.has(item.id) && (
-                          <div className="item-expanded">
-                            {item.writeup && (
-                              <div className="item-writeup">
-                                <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.writeup}</ReactMarkdown>
-                              </div>
-                            )}
-                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.6rem', margin: '0 0 0.9rem', opacity: 0.9 }}>
-                              <Link href={getCodeToolsUrl(item.id)} style={{ textDecoration: 'none', fontWeight: 600 }}>
-                                Open detail page
-                              </Link>
-                              <span>•</span>
-                              <span>{getCodeToolsItemLineCount(item)} lines</span>
-                              <span>•</span>
-                              <span>{item.tags.length} tags</span>
-                            </div>
-                            <div className="code-block">
-                              <div className="code-header">
-                                <div className="code-filename">{getCodeToolsLanguageLabel(item.language)}</div>
-                                <div className="code-actions">
-                                  {item.gistUrl && (
-                                    <a
-                                      href={item.gistUrl}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      className="code-action gist-link"
-                                      title="View on GitHub"
-                                    >
-                                      <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-                                        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-                                      </svg>
-                                      Gist
-                                    </a>
-                                  )}
-                                  <button
-                                    className="code-action"
-                                    onClick={() => copyToClipboard(item.content, item.id)}
-                                    type="button"
-                                  >
-                                    {copyStates[item.id] || 'Copy'}
-                                  </button>
-                                </div>
-                              </div>
-                              <div className="code-container">
-                                <SyntaxHighlighter
-                                  language={normalizeCodeToolsLanguage(item.language)}
-                                  style={oneDark}
-                                  showLineNumbers
-                                  wrapLines
-                                  lineNumberStyle={{
-                                    minWidth: '3em',
-                                    paddingRight: '1em',
-                                    textAlign: 'right',
-                                    userSelect: 'none',
-                                    opacity: 0.5,
-                                  }}
-                                  customStyle={{
-                                    margin: 0,
-                                    padding: '1rem',
-                                    fontSize: '0.875rem',
-                                    lineHeight: '1.6',
-                                    borderRadius: '0 0 8px 8px',
-                                    background: '#282c34',
-                                  }}
-                                  codeTagProps={{
-                                    style: {
-                                      fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace",
-                                    },
-                                  }}
-                                >
-                                  {item.content}
-                                </SyntaxHighlighter>
-                              </div>
-                            </div>
-                            <div className="item-footer">
-                              <div className="item-tags">
-                                {item.tags.map((tag: string) => (
-                                  <span key={tag} className="tag">
-                                    #{tag}
-                                  </span>
-                                ))}
-                              </div>
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                ))}
+              <div className="editorial-home-actions">
+                <Link href="#code-tools-index" className="editorial-home-button editorial-home-button-primary">
+                  Browse the index
+                </Link>
+                <Link href="/search" className="editorial-home-button editorial-home-button-secondary">
+                  Search the archive
+                </Link>
+              </div>
+
+              <div className="editorial-chip-row">
+                <span className="editorial-chip">
+                  {allItems.length} snippets
+                </span>
+                <span className="editorial-chip">
+                  {activeCategoryCount} active categories
+                </span>
+                <span className="editorial-chip">
+                  {featuredItems.length} featured
+                </span>
+                <span className="editorial-chip">
+                  {latestItem ? formatCodeToolsDate(latestItem.date, { month: 'short', day: 'numeric', year: 'numeric' }) : 'No latest item'}
+                </span>
+              </div>
             </div>
-          ) : (
-            <div className="code-ai-grid">
-              {filteredItems.map((item) => (
-                <div key={item.id} className="code-ai-card">
-                  <div className="code-ai-card-header">
-                    <h3>
-                      <Link href={getCodeToolsUrl(item.id)}>{item.title}</Link>
-                    </h3>
-                    <div className="code-ai-card-badges">
-                      {item.featured && (
-                        <span className="code-ai-date" style={{ background: 'rgba(255, 193, 7, 0.18)' }}>
-                          Featured
-                        </span>
-                      )}
-                      {item.date && (
-                        <span className="code-ai-date">
-                          {formatCodeToolsDate(item.date)}
-                        </span>
-                      )}
-                      {item.filename && (
-                        <span className="code-ai-date">
-                          {item.filename}
-                        </span>
-                      )}
-                    </div>
-                  </div>
 
-                  <p className="code-ai-card-description">{item.description}</p>
+            <aside className="editorial-page-aside">
+              <p className="editorial-home-card-label">At a glance</p>
+              <div className="editorial-page-metric-list">
+                <div>
+                  <span className="editorial-page-metric-value">{allItems.length}</span>
+                  <span className="editorial-page-metric-label">snippets and tools</span>
+                </div>
+                <div>
+                  <span className="editorial-page-metric-value">{activeCategoryCount}</span>
+                  <span className="editorial-page-metric-label">active categories</span>
+                </div>
+                <div>
+                  <span className="editorial-page-metric-value">{featuredItems.length}</span>
+                  <span className="editorial-page-metric-label">featured entries</span>
+                </div>
+                <div>
+                  <span className="editorial-page-metric-value">
+                    {latestItem ? formatCodeToolsDate(latestItem.date, { month: 'short', day: 'numeric' }) : 'n/a'}
+                  </span>
+                  <span className="editorial-page-metric-label">latest addition</span>
+                </div>
+              </div>
+              <div className="editorial-chip-row" style={{ marginTop: '18px' }}>
+                <span className="editorial-chip">copy-ready</span>
+                <span className="editorial-chip">searchable</span>
+                <span className="editorial-chip">gists linked</span>
+              </div>
+            </aside>
+          </section>
 
-                  {item.writeup && (
-                    <div className="item-writeup">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.writeup}</ReactMarkdown>
-                    </div>
-                  )}
+          <section className="editorial-home-proof-strip" aria-label="Code & Tools summary">
+            <span>code notes</span>
+            <span>/</span>
+            <span>snippets + configs</span>
+            <span>/</span>
+            <span>search + filter</span>
+            <span>/</span>
+            <span>code rendering</span>
+            <span>/</span>
+            <span>mobile-friendly shell</span>
+          </section>
 
-                  <div className="code-block">
-                    <div className="code-header">
-                      <div className="code-filename">{getCodeToolsLanguageLabel(item.language)}</div>
-                      <div className="code-actions">
-                        {item.gistUrl && (
-                          <a
-                            href={item.gistUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="code-action gist-link"
-                            title="View on GitHub"
-                          >
-                            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-                              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-                            </svg>
-                            Gist
-                          </a>
-                        )}
+          <section className="editorial-list-section" id="code-tools-index">
+            <div className="editorial-list-heading">
+              <p className="editorial-home-section-label">Browse</p>
+              <h2 className="editorial-page-section-title">Search by title, tag, or category, then open a card to keep the writeup and code in view.</h2>
+            </div>
+
+            <div className="editorial-page-aside" style={{ marginBottom: '20px' }}>
+              <div className="search-input-container" role="search" aria-label="Code & Tools search">
+                <input
+                  type="text"
+                  placeholder="Search snippets, tags, filenames, or descriptions..."
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  className="search-input-large"
+                />
+              </div>
+
+              <div style={{ display: 'grid', gap: '14px', marginTop: '18px' }}>
+                <div>
+                  <p className="editorial-home-card-label" style={{ marginBottom: '10px' }}>
+                    Categories
+                  </p>
+                  <div className="editorial-chip-row" style={{ marginTop: 0 }}>
+                    {categories.map((category) => {
+                      const count = category.id === 'all' ? allItems.length : categoryCounts[category.id] ?? 0;
+                      const active = selectedCategory === category.id;
+
+                      return (
                         <button
-                          className="code-action"
-                          onClick={() => copyToClipboard(item.content, item.id)}
+                          key={category.id}
                           type="button"
+                          onClick={() => setSelectedCategory(category.id)}
+                          className="editorial-chip"
+                          style={{
+                            ...categoryButtonStyle,
+                            background: active ? 'rgba(33, 78, 230, 0.14)' : 'rgba(33, 78, 230, 0.08)',
+                            borderColor: active ? 'rgba(33, 78, 230, 0.2)' : 'rgba(33, 78, 230, 0.08)',
+                            color: 'var(--editorial-blue)',
+                            fontWeight: active ? 700 : 600,
+                          }}
+                          aria-pressed={active}
                         >
-                          {copyStates[item.id] || 'Copy'}
+                          <span>{category.icon}</span>
+                          <span>{category.label}</span>
+                          <span>({count})</span>
                         </button>
-                      </div>
-                    </div>
-                    <div className="code-container">
-                      <SyntaxHighlighter
-                        language={normalizeCodeToolsLanguage(item.language)}
-                        style={oneDark}
-                        showLineNumbers
-                        wrapLines
-                        lineNumberStyle={{
-                          minWidth: '3em',
-                          paddingRight: '1em',
-                          textAlign: 'right',
-                          userSelect: 'none',
-                          opacity: 0.5,
-                        }}
-                        customStyle={{
-                          margin: 0,
-                          padding: '1rem',
-                          fontSize: '0.875rem',
-                          lineHeight: '1.6',
-                          borderRadius: '0 0 8px 8px',
-                          background: '#282c34',
-                        }}
-                        codeTagProps={{
-                          style: {
-                            fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace",
-                          },
-                        }}
-                      >
-                        {item.content}
-                      </SyntaxHighlighter>
-                    </div>
-                  </div>
-
-                  <div className="code-ai-card-footer">
-                    <div className="code-ai-tags">
-                      {item.tags.map((tag: string) => (
-                        <span key={tag} className="code-ai-tag">
-                          #{tag}
-                        </span>
-                      ))}
-                    </div>
-                    <Link href={getCodeToolsUrl(item.id)} className="code-ai-card-link">
-                      Read detail
-                    </Link>
+                      );
+                    })}
                   </div>
                 </div>
-              ))}
-            </div>
-          )}
 
-          {filteredItems.length === 0 && (
-            <div className="code-ai-empty" style={{ padding: '2rem 1.5rem' }}>
-              <p style={{ margin: 0, fontSize: '1.05rem' }}>No snippets match the current filter.</p>
-              <p style={{ marginTop: '0.5rem', opacity: 0.75 }}>
-                Try a different category, clear the search, or switch to full view to browse the whole collection.
-              </p>
+                <div>
+                  <p className="editorial-home-card-label" style={{ marginBottom: '10px' }}>
+                    View mode
+                  </p>
+                  <div className="editorial-chip-row" style={{ marginTop: 0 }}>
+                    <button
+                      type="button"
+                      className="editorial-chip"
+                      style={{
+                        ...controlButtonStyle,
+                        background: viewMode === 'compact' ? 'rgba(16, 34, 54, 0.92)' : 'rgba(255,255,255,0.55)',
+                        color: viewMode === 'compact' ? '#fff' : 'var(--editorial-ink)',
+                        borderColor: 'rgba(16, 34, 54, 0.08)',
+                      }}
+                      onClick={() => setViewMode('compact')}
+                      aria-pressed={viewMode === 'compact'}
+                    >
+                      Compact
+                    </button>
+                    <button
+                      type="button"
+                      className="editorial-chip"
+                      style={{
+                        ...controlButtonStyle,
+                        background: viewMode === 'full' ? 'rgba(16, 34, 54, 0.92)' : 'rgba(255,255,255,0.55)',
+                        color: viewMode === 'full' ? '#fff' : 'var(--editorial-ink)',
+                        borderColor: 'rgba(16, 34, 54, 0.08)',
+                      }}
+                      onClick={() => setViewMode('full')}
+                      aria-pressed={viewMode === 'full'}
+                    >
+                      Full
+                    </button>
+                  </div>
+                </div>
+              </div>
             </div>
-          )}
+
+            <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', justifyContent: 'space-between', gap: '0.75rem', marginBottom: '18px' }}>
+              <div className="editorial-post-summary" style={{ margin: 0 }}>
+                Showing <strong>{filteredItems.length}</strong> of <strong>{allItems.length}</strong> items in <strong>{selectedCategoryLabel}</strong>
+                {searchQuery ? <> for <strong>“{searchQuery}”</strong></> : null}
+              </div>
+              <div className="editorial-post-summary" style={{ margin: 0 }}>
+                Compact mode keeps the index scannable. Full mode keeps the writeup and code visible.
+              </div>
+            </div>
+
+            {featuredItems.length > 0 && (
+              <section style={{ marginBottom: '28px' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '1rem', marginBottom: '12px' }}>
+                  <h3 style={{ margin: 0, color: 'var(--editorial-ink)', fontFamily: 'Space Grotesk, Inter, sans-serif', fontSize: '1.5rem', letterSpacing: '-0.04em' }}>
+                    Featured picks
+                  </h3>
+                  <span className="editorial-post-summary" style={{ margin: 0 }}>Curated snippets with the strongest editorial value.</span>
+                </div>
+
+                <div className="editorial-post-grid">
+                  {featuredItems.slice(0, 3).map((item) => (
+                    <article key={item.id} className="editorial-post-card" style={{ display: 'grid', gap: '14px' }}>
+                      <div className="editorial-post-meta">
+                        <span>{getCodeToolsLanguageLabel(item.language)}</span>
+                        {item.date && <span>{formatCodeToolsDate(item.date)}</span>}
+                        <span>{getCodeToolsItemLineCount(item)} lines</span>
+                      </div>
+
+                      <h2 style={{ fontSize: '1.75rem', marginBottom: 0 }}>
+                        <Link href={getCodeToolsUrl(item.id)}>{item.title}</Link>
+                      </h2>
+
+                      <p className="editorial-post-summary">{item.description}</p>
+
+                      <div className="editorial-chip-row">
+                        <span className="editorial-chip" style={{ background: 'rgba(33, 78, 230, 0.14)' }}>Featured</span>
+                        <span className="editorial-chip">{item.filename || 'Inline snippet'}</span>
+                        <span className="editorial-chip">{item.tags.length} tags</span>
+                      </div>
+
+                      <Link href={getCodeToolsUrl(item.id)} className="editorial-post-link">
+                        Open detail page
+                      </Link>
+                    </article>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {viewMode === 'compact' ? (
+              <div style={{ display: 'grid', gap: '18px' }}>
+                {Object.entries(groupedItems)
+                  .sort(([, itemsA], [, itemsB]) => {
+                    const latestA = itemsA[0]?.date ? new Date(itemsA[0].date).getTime() : 0;
+                    const latestB = itemsB[0]?.date ? new Date(itemsB[0].date).getTime() : 0;
+                    return latestB - latestA;
+                  })
+                  .map(([category, categoryItems]) => (
+                    <section key={category} style={groupCardStyle}>
+                      <h3 className="editorial-page-section-title" style={{ fontSize: '1.55rem', marginBottom: '18px', maxWidth: 'none' }}>
+                        {categories.find((categoryConfig) => categoryConfig.id === category)?.label || category}
+                        <span style={{ marginLeft: '0.5rem', color: 'var(--editorial-slate)', fontFamily: 'IBM Plex Mono, Roboto Mono, monospace', fontSize: '0.72rem', letterSpacing: '0.08em', textTransform: 'uppercase' }}>
+                          ({categoryItems.length})
+                        </span>
+                      </h3>
+
+                      <div style={{ display: 'grid', gap: '16px' }}>
+                        {categoryItems.map((item) => {
+                          const isExpanded = expandedItems.has(item.id);
+
+                          return (
+                            <article key={item.id} style={compactCardStyle}>
+                              <div style={{ display: 'grid', gap: '14px' }}>
+                                <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap', alignItems: 'start' }}>
+                                  <div style={{ maxWidth: '58ch' }}>
+                                    <div className="editorial-post-meta" style={{ marginBottom: '8px' }}>
+                                      {item.date && <span>{formatCodeToolsDate(item.date)}</span>}
+                                      <span>{getCodeToolsLanguageLabel(item.language)}</span>
+                                      <span>{getCodeToolsItemLineCount(item)} lines</span>
+                                    </div>
+
+                                    <h3 style={{ margin: 0, fontSize: '1.55rem' }}>
+                                      <Link href={getCodeToolsUrl(item.id)}>{item.title}</Link>
+                                    </h3>
+                                    <p className="editorial-post-summary" style={{ marginTop: '10px' }}>{item.description}</p>
+                                  </div>
+
+                                  {item.featured && (
+                                    <span className="editorial-chip" style={{ background: 'rgba(33, 78, 230, 0.14)' }}>
+                                      Featured
+                                    </span>
+                                  )}
+                                </div>
+
+                                <div className="editorial-chip-row" style={{ marginTop: 0 }}>
+                                  {item.tags.slice(0, 4).map((tag) => (
+                                    <span key={tag} className="editorial-chip">
+                                      {tag}
+                                    </span>
+                                  ))}
+                                </div>
+
+                                <div className="editorial-home-actions" style={{ marginTop: 0 }}>
+                                  <Link href={getCodeToolsUrl(item.id)} className="editorial-home-button editorial-home-button-secondary">
+                                    Open detail page
+                                  </Link>
+                                  <button
+                                    type="button"
+                                    onClick={() => toggleExpanded(item.id)}
+                                    className="editorial-home-button editorial-home-button-primary"
+                                  >
+                                    {isExpanded ? 'Hide preview' : 'Show preview'}
+                                  </button>
+                                </div>
+
+                                {isExpanded && (
+                                  <>
+                                    {item.writeup && (
+                                      <div className="item-writeup" style={{ background: 'rgba(255,255,255,0.45)', borderRadius: '18px', border: '1px solid rgba(16, 34, 54, 0.08)', padding: '1rem 1.05rem' }}>
+                                        <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.writeup}</ReactMarkdown>
+                                      </div>
+                                    )}
+
+                                    <SnippetCodeBlock
+                                      item={item}
+                                      onCopy={() => copyToClipboard(item.content, item.id)}
+                                      copyLabel={copyStates[item.id] || 'Copy'}
+                                    />
+                                  </>
+                                )}
+                              </div>
+                            </article>
+                          );
+                        })}
+                      </div>
+                    </section>
+                  ))}
+              </div>
+            ) : (
+              <div className="editorial-post-grid">
+                {filteredItems.map((item) => {
+                  const isExpanded = true;
+
+                  return (
+                    <article key={item.id} className="editorial-post-card" style={{ display: 'grid', gap: '16px' }}>
+                      <div className="editorial-post-meta">
+                        {item.category && (
+                          <span>{categories.find((category) => category.id === item.category)?.label || item.category}</span>
+                        )}
+                        {item.date && <span>{formatCodeToolsDate(item.date)}</span>}
+                        <span>{getCodeToolsLanguageLabel(item.language)}</span>
+                        <span>{getCodeToolsItemLineCount(item)} lines</span>
+                      </div>
+
+                      <h2 style={{ fontSize: '1.75rem', marginBottom: 0 }}>
+                        <Link href={getCodeToolsUrl(item.id)}>{item.title}</Link>
+                      </h2>
+                      <p className="editorial-post-summary">{item.description}</p>
+
+                      <div className="editorial-chip-row">
+                        {item.featured && (
+                          <span className="editorial-chip" style={{ background: 'rgba(33, 78, 230, 0.14)' }}>
+                            Featured
+                          </span>
+                        )}
+                        {item.filename && <span className="editorial-chip">{item.filename}</span>}
+                        {item.tags.slice(0, 4).map((tag) => (
+                          <span key={tag} className="editorial-chip">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+
+                      {item.writeup && (
+                        <div className="item-writeup" style={{ background: 'rgba(255,255,255,0.45)', borderRadius: '18px', border: '1px solid rgba(16, 34, 54, 0.08)', padding: '1rem 1.05rem' }}>
+                          <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.writeup}</ReactMarkdown>
+                        </div>
+                      )}
+
+                      {isExpanded && (
+                        <SnippetCodeBlock
+                          item={item}
+                          onCopy={() => copyToClipboard(item.content, item.id)}
+                          copyLabel={copyStates[item.id] || 'Copy'}
+                        />
+                      )}
+
+                      <Link href={getCodeToolsUrl(item.id)} className="editorial-post-link">
+                        Read detail
+                      </Link>
+                    </article>
+                  );
+                })}
+              </div>
+            )}
+
+            {filteredItems.length === 0 && (
+              <div className="editorial-page-aside" style={{ marginTop: '20px' }}>
+                <p className="editorial-home-card-label">No matches</p>
+                <p className="editorial-post-summary" style={{ marginTop: '10px' }}>
+                  No snippets match the current filter. Try a different category, clear the search, or switch to full view to browse the whole collection.
+                </p>
+              </div>
+            )}
+          </section>
         </main>
       </div>
     </div>

--- a/app/components/MainContent.tsx
+++ b/app/components/MainContent.tsx
@@ -55,7 +55,7 @@ const DefaultHomeContent = ({ posts }: DefaultHomeContentProps) => {
           <p className="editorial-home-kicker">Technical writing archive</p>
           <h1>Writing about how AI systems remember, fail, and scale in production.</h1>
           <p className="editorial-home-subtitle">
-            A public body of work on AI systems, agent memory, and the engineering decisions that separate demos from durable products.
+            Essays, talks, and book notes on the engineering decisions that separate demos from durable products.
           </p>
           <div className="editorial-home-actions">
             <Link href={`/posts/${newestPost.slug}`} className="editorial-home-button editorial-home-button-primary">
@@ -96,10 +96,13 @@ const DefaultHomeContent = ({ posts }: DefaultHomeContentProps) => {
         <p className="editorial-home-section-label">Selected writing</p>
         <h2>Recent essays with enough context to know where to go next.</h2>
         <div className="editorial-home-grid">
-          {featuredPosts.map((post) => {
+          {featuredPosts.map((post, index) => {
             const excerpt = getExcerpt(post.content, post.summary);
             return (
-              <article key={post.slug} className="editorial-home-card">
+              <article
+                key={post.slug}
+                className={`editorial-home-card ${index === 0 ? 'editorial-home-card-featured' : 'editorial-home-card-compact'}`}
+              >
                 <p className="editorial-home-card-label">{getPrimaryTag(post)}</p>
                 <h3>
                   <Link href={`/posts/${post.slug}`} className="editorial-home-card-link">

--- a/app/globals.css
+++ b/app/globals.css
@@ -7953,22 +7953,22 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
   color: var(--editorial-ink);
   margin-top: 0;
   min-height: 100vh;
-  padding: 18px 16px 28px;
+  padding: 16px 14px 24px;
 }
 
 .editorial-home-shell {
-  background: linear-gradient(180deg, rgba(251, 247, 240, 0.98) 0%, rgba(245, 239, 230, 0.98) 100%);
+  background: linear-gradient(180deg, rgba(251, 247, 240, 0.99) 0%, rgba(245, 239, 230, 0.98) 48%, rgba(240, 233, 220, 0.98) 100%);
   border-radius: 26px;
   border: 1px solid var(--shell-border);
   box-shadow: var(--editorial-shadow);
   margin: 0 auto;
-  max-width: 1240px;
-  padding: 24px clamp(24px, 4vw, 60px) 44px;
+  max-width: 1228px;
+  padding: 24px clamp(24px, 4vw, 56px) 48px;
 }
 
 .editorial-home-content {
   display: grid;
-  gap: 38px;
+  gap: 32px;
 }
 
 .editorial-home-topbar {
@@ -7979,11 +7979,11 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
   display: flex;
   justify-content: space-between;
   gap: 24px;
-  margin-bottom: 34px;
+  margin-bottom: 30px;
   position: sticky;
   top: 0;
   z-index: 20;
-  padding-bottom: 18px;
+  padding-bottom: 16px;
 }
 
 .editorial-home-brand {
@@ -8066,8 +8066,8 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
 .editorial-book-hero {
   align-items: start;
   display: grid;
-  gap: 40px;
-  grid-template-columns: minmax(0, 1.4fr) minmax(300px, 360px);
+  gap: 32px;
+  grid-template-columns: minmax(0, 1.25fr) minmax(320px, 360px);
   margin-bottom: 0;
 }
 
@@ -8086,19 +8086,19 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
 }
 
 .editorial-home-kicker {
-  margin-bottom: 22px;
+  margin-bottom: 18px;
 }
 
 .editorial-home-hero h1,
 .editorial-book-hero h1 {
   color: var(--editorial-ink);
   font-family: 'Space Grotesk', 'Inter', sans-serif;
-  font-size: clamp(3rem, 5.2vw, 4.6rem);
+  font-size: clamp(3rem, 5vw, 4.4rem);
   font-weight: 700;
   letter-spacing: -0.055em;
-  line-height: 0.94;
+  line-height: 0.92;
   margin-bottom: 18px;
-  max-width: 10.2ch;
+  max-width: 11ch;
 }
 
 .editorial-book-hero h1 {
@@ -8110,12 +8110,12 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
 .editorial-home-book-card p {
   color: var(--editorial-slate);
   font-family: 'Inter', var(--font-body);
-  font-size: 1.06rem;
-  line-height: 1.45;
+  font-size: 1.03rem;
+  line-height: 1.5;
 }
 
 .editorial-home-subtitle {
-  max-width: 600px;
+  max-width: 580px;
 }
 
 .editorial-home-actions {
@@ -8123,7 +8123,7 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
   display: flex;
   flex-wrap: wrap;
   gap: 14px;
-  margin-top: 30px;
+  margin-top: 26px;
 }
 
 .editorial-home-button {
@@ -8184,7 +8184,7 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
 
 .editorial-home-book-card {
   align-self: start;
-  padding: 24px 26px 26px;
+  padding: 26px 28px 28px;
   position: relative;
 }
 
@@ -8217,7 +8217,7 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
 }
 
 .editorial-home-book-card h2 {
-  font-size: 2rem;
+  font-size: 1.95rem;
   line-height: 1.05;
   margin-bottom: 10px;
 }
@@ -8225,8 +8225,8 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
 .editorial-home-book-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 14px;
-  margin: 18px 0 20px;
+  gap: 12px;
+  margin: 18px 0 18px;
 }
 
 .editorial-home-book-meta span {
@@ -8242,16 +8242,28 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
   color: rgba(255, 255, 255, 0.92);
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 10px 12px;
   font-family: 'Inter', var(--font-body);
-  font-size: 0.96rem;
+  font-size: 0.95rem;
   font-weight: 500;
-  margin-bottom: 38px;
-  padding: 18px 22px;
+  margin-bottom: 34px;
+  padding: 18px 20px;
+}
+
+.editorial-home-proof-strip span:first-child {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  color: #fff;
+  font-weight: 700;
+  padding: 7px 12px;
 }
 
 .editorial-home-proof-strip span:nth-child(even) {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgba(255, 255, 255, 0.34);
+}
+
+.editorial-home-proof-strip span:nth-child(odd):not(:first-child) {
+  color: rgba(255, 255, 255, 0.9);
 }
 
 .editorial-home-section {
@@ -8263,30 +8275,43 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
 }
 
 .editorial-home-section h2 {
-  font-size: clamp(2rem, 3vw, 2.7rem);
-  line-height: 1.06;
-  margin-bottom: 22px;
-  max-width: 14ch;
+  font-size: clamp(2.1rem, 2.8vw, 2.75rem);
+  line-height: 1.04;
+  margin-bottom: 20px;
+  max-width: 13ch;
 }
 
 .editorial-home-grid {
   display: grid;
-  gap: 20px;
+  gap: 18px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .editorial-home-card {
-  min-height: 246px;
-  padding: 26px 24px 24px;
+  min-height: 236px;
+  padding: 24px 22px 22px;
   position: relative;
   overflow: hidden;
 }
 
+.editorial-home-card-featured {
+  grid-column: 1 / -1;
+  min-height: 0;
+  padding: 30px 28px 26px;
+}
+
 .editorial-home-card h3 {
-  font-size: 2rem;
+  font-size: 1.95rem;
   line-height: 1.02;
   margin: 14px 0 14px;
   max-width: 12ch;
+}
+
+.editorial-home-card-featured h3 {
+  font-size: clamp(2.35rem, 3.4vw, 3.2rem);
+  line-height: 0.96;
+  margin-top: 16px;
+  max-width: 10ch;
 }
 
 .editorial-home-card p {
@@ -8303,6 +8328,17 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
   position: relative;
   z-index: 1;
   text-decoration: none;
+}
+
+.editorial-home-card-link::after {
+  content: '→';
+  display: inline-block;
+  margin-left: 6px;
+  transition: transform 0.2s ease;
+}
+
+.editorial-home-card-link:hover::after {
+  transform: translateX(2px);
 }
 
 .editorial-home-card-footnote {
@@ -8326,8 +8362,10 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
 
 .editorial-home-cta-band {
   align-items: center;
-  background: linear-gradient(135deg, rgba(220, 229, 255, 0.92), rgba(245, 238, 226, 0.96));
+  background: linear-gradient(135deg, rgba(220, 229, 255, 0.92), rgba(245, 238, 226, 0.94));
   border-radius: 24px;
+  border: 1px solid rgba(16, 34, 54, 0.08);
+  box-shadow: var(--editorial-card-shadow);
   display: grid;
   gap: 24px;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -8335,8 +8373,8 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
 }
 
 .editorial-home-cta-band h3 {
-  font-size: 2.2rem;
-  line-height: 1.02;
+  font-size: 2rem;
+  line-height: 1.04;
   margin: 10px 0 12px;
   max-width: 12ch;
 }
@@ -8345,8 +8383,8 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
   color: var(--editorial-slate);
   font-family: 'Inter', var(--font-body);
   font-size: 1rem;
-  line-height: 1.45;
-  max-width: 48ch;
+  line-height: 1.5;
+  max-width: 44ch;
 }
 
 .editorial-book-page .editorial-home-shell {
@@ -8692,6 +8730,11 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
     grid-template-columns: 1fr;
   }
 
+  .editorial-home-card-featured {
+    grid-column: auto;
+    padding: 22px 18px 20px;
+  }
+
   .editorial-post-grid,
   .editorial-publication-grid,
   .editorial-talk-grid,
@@ -8717,6 +8760,12 @@ body.sidebar-open .toggle-icon span:nth-child(4) {
 
   .editorial-home-card h3 {
     font-size: 1.9rem;
+  }
+
+  .editorial-home-card-featured h3 {
+    font-size: 1.9rem;
+    line-height: 1.02;
+    margin-top: 14px;
   }
 
   .editorial-home-section h2 {

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -92,7 +92,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
           <h1 className="editorial-page-title">{post.title}</h1>
           {post.summary && <p className="editorial-page-copy">{post.summary}</p>}
           <p className="editorial-post-summary">
-            Published {longDateFormatter.format(post.date)}{post.readingTime ? ` · ${post.readingTime} min read` : ''}
+            Published {longDateFormatter.format(post.date)}{post.readingTime ? ` · ${post.readingTime} min read` : ''} and filed with the post archive.
           </p>
           <div className="editorial-home-actions">
             <Link href="/posts" className="editorial-home-button editorial-home-button-secondary">
@@ -109,19 +109,19 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
           </div>
         </div>
         <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">Post details</p>
+          <p className="editorial-home-card-label">Reading frame</p>
           <div className="editorial-page-metric-list">
             <div>
               <span className="editorial-page-metric-value">{longDateFormatter.format(post.date)}</span>
-              <span className="editorial-page-metric-label">published date</span>
+              <span className="editorial-page-metric-label">publication date</span>
             </div>
             <div>
               <span className="editorial-page-metric-value">{post.readingTime ? `${post.readingTime} min` : 'Essay'}</span>
-              <span className="editorial-page-metric-label">reading time</span>
+              <span className="editorial-page-metric-label">reading length</span>
             </div>
             <div>
               <span className="editorial-page-metric-value">{monthYearFormatter.format(post.date)}</span>
-              <span className="editorial-page-metric-label">archive month</span>
+              <span className="editorial-page-metric-label">filed in</span>
             </div>
           </div>
           <div className="editorial-chip-row">

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -8,13 +8,15 @@ export const metadata: Metadata = {
   description: 'Essays, field notes, and technical writing on AI systems, memory, engineering practice, and adjacent work.',
 };
 
+type Posts = Awaited<ReturnType<typeof postService.getAllPosts>>;
+
 const formatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'short',
   day: 'numeric',
 });
 
-const countTags = (posts: Awaited<ReturnType<typeof postService.getAllPosts>>) => {
+const countTags = (posts: Posts) => {
   const counts = new Map<string, number>();
 
   posts.forEach((post) => {
@@ -28,11 +30,30 @@ const countTags = (posts: Awaited<ReturnType<typeof postService.getAllPosts>>) =
     .slice(0, 4);
 };
 
+const groupPostsByYear = (posts: Posts) => {
+  const groups = new Map<number, Posts>();
+
+  posts.forEach((post) => {
+    const year = post.date.getFullYear();
+    const yearPosts = groups.get(year) ?? [];
+    yearPosts.push(post);
+    groups.set(year, yearPosts);
+  });
+
+  return Array.from(groups.entries())
+    .sort((a, b) => b[0] - a[0])
+    .map(([year, yearPosts]) => ({
+      year,
+      posts: yearPosts,
+    }));
+};
+
 export default async function PostsPage() {
   const posts = await postService.getAllPosts();
   const featuredPost = posts[0];
   const topTags = countTags(posts);
-  const publicationYears = new Set(posts.map((post) => post.date.getFullYear())).size;
+  const postsByYear = groupPostsByYear(posts);
+  const publicationYears = postsByYear.length;
 
   return (
     <EditorialPageFrame currentPath="/posts">
@@ -41,7 +62,7 @@ export default async function PostsPage() {
           <p className="editorial-home-kicker">Writing archive</p>
           <h1 className="editorial-page-title">Posts</h1>
           <p className="editorial-page-copy">
-            Essays, field notes, and working-throughs on agent memory, AI systems, engineering practice, and the occasional economics detour.
+            Essays, field notes, and working-throughs on agent memory, AI systems, engineering practice, and the occasional economics detour, arranged so the newest work stays easy to find.
           </p>
           <div className="editorial-chip-row">
             {topTags.map(([tag, count]) => (
@@ -56,20 +77,18 @@ export default async function PostsPage() {
           <div className="editorial-page-metric-list">
             <div>
               <span className="editorial-page-metric-value">{posts.length}</span>
-              <span className="editorial-page-metric-label">published essays</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">
-                {featuredPost ? formatter.format(featuredPost.date) : 'n/a'}
-              </span>
-              <span className="editorial-page-metric-label">latest post</span>
+              <span className="editorial-page-metric-label">posts in the archive</span>
             </div>
             <div>
               <span className="editorial-page-metric-value">{publicationYears}</span>
-              <span className="editorial-page-metric-label">years of writing</span>
+              <span className="editorial-page-metric-label">years represented</span>
             </div>
           </div>
-          {featuredPost?.summary && <p className="editorial-post-summary">{featuredPost.summary}</p>}
+          {featuredPost && (
+            <p className="editorial-post-summary">
+              Latest: {featuredPost.title} on {formatter.format(featuredPost.date)}.
+            </p>
+          )}
           {featuredPost && (
             <Link href={`/posts/${featuredPost.slug}`} className="editorial-home-button editorial-home-button-secondary">
               Start with the latest essay
@@ -78,51 +97,75 @@ export default async function PostsPage() {
         </aside>
       </section>
 
-      <section className="editorial-home-proof-strip" aria-label="Posts summary">
-        <span>{posts.length} posts</span>
-        <span>/</span>
-        <span>essays + field notes</span>
-        <span>/</span>
-        <span>agent memory</span>
-        <span>/</span>
-        <span>systems + workflow</span>
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Featured reading</p>
+          <h2 className="editorial-page-section-title">Start with the latest essay, then move backward by year.</h2>
+        </div>
+        {featuredPost ? (
+          <article className="editorial-home-card">
+            <p className="editorial-home-card-label">{formatter.format(featuredPost.date)}</p>
+            <h3>
+              <Link href={`/posts/${featuredPost.slug}`}>{featuredPost.title}</Link>
+            </h3>
+            {featuredPost.summary && <p>{featuredPost.summary}</p>}
+            <div className="editorial-post-meta">
+              {featuredPost.tags[0] ? (
+                <Link href={`/tags/${encodeURIComponent(featuredPost.tags[0])}`} className="editorial-chip">
+                  <span>{featuredPost.tags[0]}</span>
+                </Link>
+              ) : (
+                <span className="editorial-chip">Essay</span>
+              )}
+              <span>{featuredPost.readingTime ? `${featuredPost.readingTime} min read` : 'Long-form note'}</span>
+            </div>
+            <div className="editorial-chip-row">
+              {featuredPost.tags.slice(0, 3).map((tag) => (
+                <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
+                  {tag}
+                </Link>
+              ))}
+            </div>
+            <Link href={`/posts/${featuredPost.slug}`} className="editorial-home-card-link">
+              Read the post
+            </Link>
+          </article>
+        ) : null}
       </section>
 
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Archive</p>
-          <h2 className="editorial-page-section-title">Recent writing, newest first, with tags and context left visible.</h2>
+          <p className="editorial-home-section-label">By year</p>
+          <h2 className="editorial-page-section-title">A compact index that keeps each year readable on mobile.</h2>
         </div>
 
-        <div className="editorial-post-grid">
-          {posts.map((post) => (
-            <article key={post.slug} className="editorial-post-card">
-              <div className="editorial-post-meta">
-                {post.tags[0] ? (
-                  <Link href={`/tags/${encodeURIComponent(post.tags[0])}`} className="editorial-chip">
-                    <span>{post.tags[0]}</span>
+        <div className="editorial-two-column">
+          {postsByYear.map(({ year, posts: yearPosts }) => (
+            <article key={year} className="editorial-home-card">
+              <p className="editorial-home-card-label">Year {year}</p>
+              <h3>{yearPosts.length} post{yearPosts.length !== 1 ? 's' : ''}</h3>
+              <p>Newest first, with each post left visible so the archive can be scanned without opening every page.</p>
+              {yearPosts[0] ? (
+                <div>
+                  <p className="editorial-home-card-label">Featured post</p>
+                  <Link href={`/posts/${yearPosts[0].slug}`} className="editorial-home-card-link">
+                    {yearPosts[0].title}
                   </Link>
-                ) : (
-                  <span className="editorial-chip">Essay</span>
-                )}
-                <span>{formatter.format(post.date)}</span>
-                {post.readingTime && <span>{post.readingTime} min read</span>}
-                <span>{post.tags.length} tags</span>
-              </div>
-              <h2>
-                <Link href={`/posts/${post.slug}`}>{post.title}</Link>
-              </h2>
-              {post.summary && <p className="editorial-post-summary">{post.summary}</p>}
-              <div className="editorial-chip-row">
-                {post.tags.slice(0, 3).map((tag) => (
-                  <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
-                    {tag}
-                  </Link>
+                  {yearPosts[0].summary && <p className="editorial-post-summary">{yearPosts[0].summary}</p>}
+                </div>
+              ) : null}
+              <ul className="posts-list">
+                {yearPosts.slice(1).map((post) => (
+                  <li key={post.slug} className="archive-post">
+                    <Link href={`/posts/${post.slug}`}>
+                      <time className="archive-post-date">
+                        {post.date.getDate().toString().padStart(2, '0')}
+                      </time>
+                      <span className="archive-post-title">{post.title}</span>
+                    </Link>
+                  </li>
                 ))}
-              </div>
-              <Link href={`/posts/${post.slug}`} className="editorial-post-link">
-                Read the post
-              </Link>
+              </ul>
             </article>
           ))}
         </div>

--- a/app/publications/page.tsx
+++ b/app/publications/page.tsx
@@ -1,6 +1,6 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import { EditorialPageFrame } from '../components/EditorialPageFrame';
-import { publicationsConfig, Publication } from '../config/publicationsConfig';
+import { publicationsConfig, type Publication } from '../config/publicationsConfig';
 
 export const metadata: Metadata = {
   title: 'Publications | Ben Labaschin',
@@ -10,8 +10,8 @@ export const metadata: Metadata = {
 export default function PublicationsPage() {
   const { publications } = publicationsConfig;
   const sortedPublications = [...publications].sort((a, b) => b.year - a.year);
-  const featuredPublications = sortedPublications.filter(pub => pub.featured);
-  const otherPublications = sortedPublications.filter(pub => !pub.featured);
+  const featuredPublications = sortedPublications.filter((pub) => pub.featured);
+  const otherPublications = sortedPublications.filter((pub) => !pub.featured);
   const latestPublication = sortedPublications[0];
 
   return (
@@ -49,7 +49,22 @@ export default function PublicationsPage() {
           <p className="editorial-post-summary">
             Featured work appears first so the most important pieces are easy to find before you dig into the archive.
           </p>
+          {latestPublication && (
+            <a href={getPublicationHref(latestPublication)} target="_blank" rel="noopener noreferrer" className="editorial-post-link">
+              Open the latest publication
+            </a>
+          )}
         </aside>
+      </section>
+
+      <section className="editorial-home-proof-strip" aria-label="Publications summary">
+        <span>{publications.length} publications</span>
+        <span>/</span>
+        <span>technical reports</span>
+        <span>/</span>
+        <span>formal research</span>
+        <span>/</span>
+        <span>long-form writing</span>
       </section>
 
       {featuredPublications.length > 0 && (
@@ -58,9 +73,9 @@ export default function PublicationsPage() {
             <p className="editorial-home-section-label">Featured</p>
             <h2 className="editorial-page-section-title">The work that best frames the site&apos;s technical point of view.</h2>
           </div>
-          <div className="editorial-publication-grid">
+          <div className="editorial-timeline">
             {featuredPublications.map((pub) => (
-              <PublicationCard key={pub.id} publication={pub} featured />
+              <PublicationEntry key={pub.id} publication={pub} featured />
             ))}
           </div>
         </section>
@@ -72,9 +87,9 @@ export default function PublicationsPage() {
             <p className="editorial-home-section-label">Archive</p>
             <h2 className="editorial-page-section-title">Background reports and earlier writing, kept for completeness.</h2>
           </div>
-          <div className="editorial-publication-grid">
+          <div className="editorial-timeline">
             {otherPublications.map((pub) => (
-              <PublicationCard key={pub.id} publication={pub} />
+              <PublicationEntry key={pub.id} publication={pub} />
             ))}
           </div>
         </section>
@@ -83,79 +98,84 @@ export default function PublicationsPage() {
   );
 }
 
-function PublicationCard({ publication, featured = false }: { 
-  publication: Publication; 
+function getPublicationType(publication: Publication) {
+  if (publication.venue === "O'Reilly Media") {
+    return "O'Reilly report";
+  }
+
+  const labels: Record<Publication['type'], string> = {
+    book: 'Book',
+    journal: 'Journal',
+    conference: 'Conference',
+    report: 'Report',
+    workshop: 'Workshop',
+    other: 'Writing',
+  };
+
+  return labels[publication.type];
+}
+
+function getPublicationHref(publication: Publication) {
+  return publication.url || publication.pdfUrl || (publication.doi ? `https://doi.org/${publication.doi}` : undefined);
+}
+
+function getPublicationActionLabel(publication: Publication) {
+  if (publication.url) {
+    return publication.venue === "O'Reilly Media" ? 'Read the report' : 'Read online';
+  }
+
+  if (publication.pdfUrl) {
+    return 'Open PDF';
+  }
+
+  if (publication.doi) {
+    return 'View DOI record';
+  }
+
+  return undefined;
+}
+
+function PublicationEntry({
+  publication,
+  featured = false,
+}: {
+  publication: Publication;
   featured?: boolean;
 }) {
-  const displayType = (() => {
-    if (publication.venue === "O'Reilly Media") {
-      return "O'Reilly report";
-    }
-    const labels: Record<Publication['type'], string> = {
-      book: 'Book',
-      journal: 'Journal',
-      conference: 'Conference',
-      report: 'Report',
-      workshop: 'Workshop',
-      other: 'Writing',
-    };
-    return labels[publication.type];
-  })();
-
-  const actionHref = publication.url || publication.pdfUrl || (publication.doi ? `https://doi.org/${publication.doi}` : undefined);
-  const actionLabel = publication.url
-    ? publication.venue === "O'Reilly Media"
-      ? 'Read the report'
-      : 'Read online'
-    : publication.pdfUrl
-      ? 'Open PDF'
-      : publication.doi
-        ? 'View DOI record'
-        : undefined;
+  const actionHref = getPublicationHref(publication);
+  const actionLabel = getPublicationActionLabel(publication);
 
   return (
-    <article
-      id={publication.id}
-      className={`editorial-publication-card ${featured ? 'is-featured' : ''}`}
-    >
-      {publication.coverImage && (
+    <article id={publication.id} className={`editorial-timeline-item ${featured ? 'is-featured' : ''}`}>
+      {featured && publication.coverImage && (
         <div className="editorial-publication-cover">
-          <img
-            src={publication.coverImage}
-            alt={`Cover for ${publication.title}`}
-          />
+          <img src={publication.coverImage} alt={`Cover for ${publication.title}`} />
         </div>
       )}
-      <div className="editorial-publication-content">
-        <div className="editorial-post-meta">
-          <span>{displayType}</span>
-          <span>{publication.year}</span>
-        </div>
-
-        <h3>{publication.title}</h3>
-        <p className="editorial-publication-authors">{publication.authors}</p>
-        {publication.venue && <p className="editorial-publication-venue">{publication.venue}</p>}
-        {publication.abstract && <p className="editorial-post-summary">{publication.abstract}</p>}
-
-        <div className="editorial-chip-row">
-          {publication.topics.slice(0, 4).map((topic) => (
-            <span key={topic} className="editorial-chip">
-              {topic}
-            </span>
-          ))}
-        </div>
-
-        {actionHref && actionLabel && (
-          <a
-            href={actionHref}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="editorial-post-link"
-          >
-            {actionLabel}
-          </a>
-        )}
+      <div className="editorial-post-meta">
+        <span>{getPublicationType(publication)}</span>
+        <span>{publication.year}</span>
+        {featured && <span>Featured</span>}
       </div>
+
+      <h3>{publication.title}</h3>
+      <p className="editorial-publication-authors">{publication.authors}</p>
+      {publication.venue && <p className="editorial-publication-venue">{publication.venue}</p>}
+      {publication.abstract && <p className="editorial-post-summary">{publication.abstract}</p>}
+
+      <div className="editorial-chip-row">
+        {publication.topics.slice(0, 4).map((topic) => (
+          <span key={topic} className="editorial-chip">
+            {topic}
+          </span>
+        ))}
+      </div>
+
+      {actionHref && actionLabel && (
+        <a href={actionHref} target="_blank" rel="noopener noreferrer" className="editorial-post-link">
+          {actionLabel}
+        </a>
+      )}
     </article>
   );
 }

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -17,11 +17,36 @@ function formatResultDate(date?: Date) {
   }).format(new Date(date));
 }
 
+const resultTypeOrder: SearchResult['type'][] = ['post', 'publication', 'talk', 'code-ai'];
+
+const groupResultsByType = (results: SearchResult[]) => {
+  const groups = new Map<SearchResult['type'], SearchResult[]>();
+
+  results.forEach((result) => {
+    const typeResults = groups.get(result.type) ?? [];
+    typeResults.push(result);
+    groups.set(result.type, typeResults);
+  });
+
+  return resultTypeOrder
+    .filter((type) => groups.has(type))
+    .map((type) => ({
+      type,
+      results: groups.get(type) ?? [],
+    }));
+};
+
 function SearchContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const query = searchParams.get('q') || '';
   const normalizedQuery = query.trim();
+  const typeLabels: Record<SearchResult['type'], string> = {
+    post: 'Blog post',
+    talk: 'Talk',
+    publication: 'Publication',
+    'code-ai': 'Code & tools',
+  };
 
   const [results, setResults] = useState<SearchResult[]>([]);
   const [loading, setLoading] = useState(false);
@@ -68,13 +93,7 @@ function SearchContent() {
 
     router.replace(`/search?q=${encodeURIComponent(nextQuery)}`);
   };
-
-  const typeLabels: Record<SearchResult['type'], string> = {
-    post: 'Blog post',
-    talk: 'Talk',
-    publication: 'Publication',
-    'code-ai': 'Code & tools',
-  };
+  const groupedResults = groupResultsByType(results);
 
   return (
     <EditorialPageFrame currentPath="/search" pageClassName="editorial-book-page">
@@ -83,7 +102,7 @@ function SearchContent() {
           <p className="editorial-home-kicker">Search</p>
           <h1 className="editorial-page-title">Search Results</h1>
           <p className="editorial-page-copy">
-            Search posts, talks, publications, and code notes without leaving the editorial index.
+            Search posts, talks, publications, and code notes without leaving the editorial index, with results grouped so the page reads in sections instead of one long feed.
           </p>
           <p className="editorial-post-summary">
             {normalizedQuery ? `Showing results for “${normalizedQuery}”.` : 'Search the archive by topic, title, or theme.'}
@@ -159,34 +178,66 @@ function SearchContent() {
               Found {results.length} result{results.length !== 1 ? 's' : ''} for “{normalizedQuery}”
             </p>
 
-            <div className="editorial-post-grid">
-              {results.map((result) => (
-                <Link
-                  key={`${result.type}-${result.title}`}
-                  href={result.url}
-                  className="editorial-post-card search-result-item"
-                >
-                  <div className="editorial-post-meta">
-                    <span>{typeLabels[result.type]}</span>
-                    {result.date && <span>{formatResultDate(result.date)}</span>}
+            {groupedResults.map(({ type, results: typeResults }) => {
+              const [featuredResult, ...moreResults] = typeResults;
+
+              return (
+                <section key={type} className="editorial-list-section">
+                  <div className="editorial-list-heading">
+                    <p className="editorial-home-section-label">{typeLabels[type]}</p>
+                    <h2 className="editorial-page-section-title">
+                      {typeResults.length} result{typeResults.length !== 1 ? 's' : ''} in this section.
+                    </h2>
                   </div>
 
-                  <h2>{result.title}</h2>
+                  {featuredResult ? (
+                    <article className="editorial-home-card">
+                      <p className="editorial-home-card-label">{typeLabels[featuredResult.type]}</p>
+                      <h3>
+                        <Link href={featuredResult.url}>{featuredResult.title}</Link>
+                      </h3>
+                      {featuredResult.description && <p>{featuredResult.description}</p>}
+                      <div className="editorial-post-meta">
+                        {featuredResult.date ? (
+                          <span>{formatResultDate(featuredResult.date)}</span>
+                        ) : (
+                          <span>{typeLabels[featuredResult.type]}</span>
+                        )}
+                        <span>{featuredResult.tags?.length ? `${featuredResult.tags.length} tags` : 'No tags listed'}</span>
+                      </div>
+                      <div className="editorial-chip-row">
+                        {featuredResult.tags?.slice(0, 3).map((tag) => (
+                          <span key={tag} className="editorial-chip">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                      <Link href={featuredResult.url} className="editorial-home-card-link">
+                        Open result
+                      </Link>
+                    </article>
+                  ) : null}
 
-                  {result.description && <p className="editorial-post-summary">{result.description}</p>}
-
-                  <div className="editorial-chip-row">
-                    {result.tags?.slice(0, 3).map((tag) => (
-                      <span key={tag} className="editorial-chip">
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-
-                  <span className="editorial-post-link">Open result</span>
-                </Link>
-              ))}
-            </div>
+                  {moreResults.length > 0 ? (
+                    <article className="editorial-home-card">
+                      <p className="editorial-home-card-label">More {typeLabels[type]}</p>
+                      <ul className="posts-list">
+                        {moreResults.map((result) => (
+                          <li key={`${result.type}-${result.title}`} className="archive-post">
+                            <Link href={result.url}>
+                              <time className="archive-post-date">
+                                {result.date ? formatResultDate(result.date) ?? typeLabels[result.type] : typeLabels[result.type]}
+                              </time>
+                              <span className="archive-post-title">{result.title}</span>
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    </article>
+                  ) : null}
+                </section>
+              );
+            })}
           </>
         )}
       </section>

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -16,6 +16,26 @@ const longDateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
 });
 
+type Posts = Awaited<ReturnType<typeof postService.getPostsByTag>>;
+
+const groupPostsByYear = (posts: Posts) => {
+  const groups = new Map<number, Posts>();
+
+  posts.forEach((post) => {
+    const year = post.date.getFullYear();
+    const yearPosts = groups.get(year) ?? [];
+    yearPosts.push(post);
+    groups.set(year, yearPosts);
+  });
+
+  return Array.from(groups.entries())
+    .sort((a, b) => b[0] - a[0])
+    .map(([year, yearPosts]) => ({
+      year,
+      posts: yearPosts,
+    }));
+};
+
 export async function generateMetadata({ params }: TagPageProps): Promise<Metadata> {
   const { tag: encodedTag } = await params;
   const tag = decodeURIComponent(encodedTag);
@@ -37,6 +57,8 @@ export default async function TagPage({ params }: TagPageProps) {
   const { tag: encodedTag } = await params;
   const tag = decodeURIComponent(encodedTag);
   const posts = await postService.getPostsByTag(tag);
+  const postsByYear = groupPostsByYear(posts);
+  const featuredPost = posts[0];
 
   if (posts.length === 0) {
     notFound();
@@ -49,7 +71,7 @@ export default async function TagPage({ params }: TagPageProps) {
           <p className="editorial-home-kicker">Tag archive</p>
           <h1 className="editorial-page-title">{tag}</h1>
           <p className="editorial-page-copy">
-            {posts.length} post{posts.length !== 1 ? 's' : ''} found for this topic, ordered newest first.
+            {posts.length} post{posts.length !== 1 ? 's' : ''} found for this topic, ordered newest first and arranged so the topic reads like a guided trail.
           </p>
           <div className="editorial-chip-row">
             <span className="editorial-chip">{posts.length} posts</span>
@@ -65,7 +87,7 @@ export default async function TagPage({ params }: TagPageProps) {
               <span className="editorial-page-metric-label">posts in this tag</span>
             </div>
             <div>
-              <span className="editorial-page-metric-value">{new Set(posts.map((post) => post.date.getFullYear())).size}</span>
+              <span className="editorial-page-metric-value">{postsByYear.length}</span>
               <span className="editorial-page-metric-label">years represented</span>
             </div>
             <div>
@@ -79,28 +101,66 @@ export default async function TagPage({ params }: TagPageProps) {
 
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Posts</p>
-          <h2 className="editorial-page-section-title">Everything indexed under {tag}.</h2>
+          <p className="editorial-home-section-label">Featured match</p>
+          <h2 className="editorial-page-section-title">Start with the newest post, then move through the year-by-year trail.</h2>
         </div>
-        <div className="editorial-post-grid">
-          {posts.map((post) => (
-            <article key={post.slug} className="editorial-post-card">
-              <div className="editorial-post-meta">
-                <span>{longDateFormatter.format(post.date)}</span>
-                <span>{post.readingTime ? `${post.readingTime} min read` : `${post.tags.length} tags`}</span>
-              </div>
-              <h2>{post.title}</h2>
-              {post.summary && <p className="editorial-post-summary">{post.summary}</p>}
-              <div className="editorial-chip-row">
-                {post.tags.map((postTag) => (
-                  <Link key={postTag} href={`/tags/${encodeURIComponent(postTag)}`} className="editorial-chip">
-                    {postTag}
+        {featuredPost ? (
+          <article className="editorial-home-card">
+            <p className="editorial-home-card-label">{longDateFormatter.format(featuredPost.date)}</p>
+            <h3>
+              <Link href={`/posts/${featuredPost.slug}`}>{featuredPost.title}</Link>
+            </h3>
+            {featuredPost.summary && <p>{featuredPost.summary}</p>}
+            <div className="editorial-post-meta">
+              <span>{featuredPost.readingTime ? `${featuredPost.readingTime} min read` : `${featuredPost.tags.length} tags`}</span>
+              <span>{featuredPost.tags.length} topic tag{featuredPost.tags.length !== 1 ? 's' : ''}</span>
+            </div>
+            <div className="editorial-chip-row">
+              {featuredPost.tags.map((postTag) => (
+                <Link key={postTag} href={`/tags/${encodeURIComponent(postTag)}`} className="editorial-chip">
+                  {postTag}
+                </Link>
+              ))}
+            </div>
+            <Link href={`/posts/${featuredPost.slug}`} className="editorial-home-card-link">
+              Read post
+            </Link>
+          </article>
+        ) : null}
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">By year</p>
+          <h2 className="editorial-page-section-title">A lighter index that keeps every tagged post visible on mobile.</h2>
+        </div>
+        <div className="editorial-two-column">
+          {postsByYear.map(({ year, posts: yearPosts }) => (
+            <article key={year} className="editorial-home-card">
+              <p className="editorial-home-card-label">Year {year}</p>
+              <h3>{yearPosts.length} post{yearPosts.length !== 1 ? 's' : ''}</h3>
+              <p>Newest first, with titles and summaries kept together so the topic stays scannable.</p>
+              {yearPosts[0] ? (
+                <div>
+                  <p className="editorial-home-card-label">Featured post</p>
+                  <Link href={`/posts/${yearPosts[0].slug}`} className="editorial-home-card-link">
+                    {yearPosts[0].title}
                   </Link>
+                  {yearPosts[0].summary && <p className="editorial-post-summary">{yearPosts[0].summary}</p>}
+                </div>
+              ) : null}
+              <ul className="posts-list">
+                {yearPosts.slice(1).map((post) => (
+                  <li key={post.slug} className="archive-post">
+                    <Link href={`/posts/${post.slug}`}>
+                      <time className="archive-post-date">
+                        {post.date.getDate().toString().padStart(2, '0')}
+                      </time>
+                      <span className="archive-post-title">{post.title}</span>
+                    </Link>
+                  </li>
                 ))}
-              </div>
-              <Link href={`/posts/${post.slug}`} className="editorial-post-link">
-                Read post
-              </Link>
+              </ul>
             </article>
           ))}
         </div>

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -40,7 +40,7 @@ export default async function TagsPage() {
           <p className="editorial-home-kicker">Topics</p>
           <h1 className="editorial-page-title">Tags</h1>
           <p className="editorial-page-copy">
-            Explore topics across {posts.length} posts, with links preserved to every tag-specific archive.
+            Explore topics across {posts.length} posts, with links preserved to every tag-specific archive and the broadest themes surfaced first.
           </p>
           <div className="editorial-chip-row">
             {topTags.map(([tag, count]) => (
@@ -71,7 +71,7 @@ export default async function TagsPage() {
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
           <p className="editorial-home-section-label">All tags</p>
-          <h2 className="editorial-page-section-title">A weighted cloud with direct links.</h2>
+          <h2 className="editorial-page-section-title">A weighted cloud for broad browsing.</h2>
         </div>
         <div className="tag-cloud">
           <div className="tag-cloud-container">
@@ -100,7 +100,7 @@ export default async function TagsPage() {
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
           <p className="editorial-home-section-label">Alphabetical</p>
-          <h2 className="editorial-page-section-title">Browse the same index by first letter.</h2>
+          <h2 className="editorial-page-section-title">The same index, re-sorted for precision.</h2>
         </div>
         <div className="tags-alphabetical">
           {sortedLetters.map((letter) => (

--- a/app/talks/page.tsx
+++ b/app/talks/page.tsx
@@ -19,6 +19,7 @@ export default function TalksPage() {
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
   );
   const latestTalk = talks[0];
+  const earlierTalks = talks.slice(1);
 
   return (
     <EditorialPageFrame currentPath="/talks">
@@ -51,6 +52,11 @@ export default function TalksPage() {
           <p className="editorial-post-summary">
             Newest entries appear first, with watch, listen, and read links preserved where they exist.
           </p>
+          {latestTalk && (
+            <a href={getTalkHref(latestTalk)} target="_blank" rel="noopener noreferrer" className="editorial-post-link">
+              Open the latest appearance
+            </a>
+          )}
         </aside>
       </section>
 
@@ -64,61 +70,90 @@ export default function TalksPage() {
         <span>podcasts and streams</span>
       </section>
 
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Appearances</p>
-          <h2 className="editorial-page-section-title">Selected talks and recordings, organized newest first.</h2>
-        </div>
-        <div className="editorial-talk-grid">
-          {talks.map((talk) => {
-            const primaryUrl = talk.spotifyUrl
-              ? talk.spotifyUrl
-              : talk.youtubeId
-                ? `https://www.youtube.com/watch?v=${talk.youtubeId}`
-                : undefined;
+      {latestTalk && (
+        <section className="editorial-list-section">
+          <div className="editorial-list-heading">
+            <p className="editorial-home-section-label">Featured appearance</p>
+            <h2 className="editorial-page-section-title">The most recent recording, expanded enough to set the tone.</h2>
+          </div>
+          <div className="editorial-timeline">
+            <TalkEntry talk={latestTalk} featured />
+          </div>
+        </section>
+      )}
 
-            return (
-              <article key={talk.id} className="editorial-talk-card">
-                <div className="editorial-post-meta">
-                  <span>{talk.event}</span>
-                  <span>{formatDate(talk.date)}</span>
-                </div>
-                <h3>{talk.title}</h3>
-                <p className="editorial-post-summary">{talk.description}</p>
-                <div className="editorial-chip-row">
-                  {talk.topics.slice(0, 4).map((topic) => (
-                    <span key={topic} className="editorial-chip">
-                      {topic}
-                    </span>
-                  ))}
-                </div>
-                <div className="editorial-link-row">
-                  {primaryUrl && (
-                    <a
-                      href={primaryUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="editorial-post-link"
-                    >
-                      {talk.spotifyUrl ? 'Listen to recording' : 'Watch recording'}
-                    </a>
-                  )}
-                  {talk.transcriptUrl && (
-                    <a
-                      href={talk.transcriptUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="editorial-post-link"
-                    >
-                      Read transcript
-                    </a>
-                  )}
-                </div>
-              </article>
-            );
-          })}
-        </div>
-      </section>
+      {earlierTalks.length > 0 && (
+        <section className="editorial-list-section">
+          <div className="editorial-list-heading">
+            <p className="editorial-home-section-label">Earlier appearances</p>
+            <h2 className="editorial-page-section-title">Selected talks and recordings, organized newest first.</h2>
+          </div>
+          <div className="editorial-timeline">
+            {earlierTalks.map((talk) => (
+              <TalkEntry key={talk.id} talk={talk} />
+            ))}
+          </div>
+        </section>
+      )}
     </EditorialPageFrame>
+  );
+}
+
+function getTalkHref(talk: (typeof talksConfig.talks)[number]) {
+  return talk.spotifyUrl
+    ? talk.spotifyUrl
+    : talk.youtubeId
+      ? `https://www.youtube.com/watch?v=${talk.youtubeId}`
+      : undefined;
+}
+
+function TalkEntry({
+  talk,
+  featured = false,
+}: {
+  talk: (typeof talksConfig.talks)[number];
+  featured?: boolean;
+}) {
+  const primaryUrl = getTalkHref(talk);
+
+  return (
+    <article className={`editorial-timeline-item ${featured ? 'is-featured' : ''}`}>
+      <div className="editorial-post-meta">
+        <span>{talk.event}</span>
+        <span>{formatDate(talk.date)}</span>
+        {featured && <span>Featured</span>}
+      </div>
+      <h3>{talk.title}</h3>
+      <p className="editorial-post-summary">{talk.description}</p>
+      <div className="editorial-chip-row">
+        {talk.topics.slice(0, 4).map((topic) => (
+          <span key={topic} className="editorial-chip">
+            {topic}
+          </span>
+        ))}
+      </div>
+      <div className="editorial-link-row">
+        {primaryUrl && (
+          <a
+            href={primaryUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="editorial-post-link"
+          >
+            {talk.spotifyUrl ? 'Listen to recording' : 'Watch recording'}
+          </a>
+        )}
+        {talk.transcriptUrl && (
+          <a
+            href={talk.transcriptUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="editorial-post-link"
+          >
+            Read transcript
+          </a>
+        )}
+      </div>
+    </article>
   );
 }

--- a/openspec/changes/preserve-site-parity-before-expansion/design.md
+++ b/openspec/changes/preserve-site-parity-before-expansion/design.md
@@ -10,6 +10,8 @@ The first implementation wave is already split into stacked draft PRs for the sh
 
 The combined preview makes the remaining issues concrete. The site is now directionally coherent, but several routes still reveal their transitional state: `About` is cramped, `Book` still reads like a placeholder, `Publications` and `Talks` are still card-grid heavy, `Posts` remains too dense, and `Code & Tools` still feels like a separate product rather than part of the same editorial platform.
 
+The latest review adds a sharper constraint: the redesign must become more practical and less self-conscious. In the current preview, the site gets weaker when it starts narrating itself with labels like "essays," "pieces," "appearances," "major publications," and "featured entries," or when it introduces visual devices such as proof strips and metric sidebars that do not help people actually use the page. The old site handled some of this better, especially on `Talks`, where embedded media made the page immediately useful and about-page content still behaved like a real CV.
+
 ## Goals / Non-Goals
 
 **Goals:**
@@ -61,6 +63,27 @@ Alternatives considered:
 - Rely only on `next build`: rejected because content loss can still slip through.
 - Require exhaustive visual parity review for every route before building new surfaces: rejected because it over-constrains progress.
 
+### 6. The design thesis is practical, direct, and content-first
+The site should feel useful, grounded, and easy to navigate. Labels should describe what the content is in plain terms: posts, talks, publications, resume. Visual emphasis should come from the content itself, not from self-promotional metrics or decorative summary bands.
+
+Alternatives considered:
+- Keep the more self-consciously editorial language: rejected because it reads as pretentious and obscures what the pages actually are.
+- Lean harder into metrics and "at a glance" cards: rejected because the current review shows they create awkward empty space and bragging cues more often than useful orientation.
+- Treat the about page as a pure narrative page instead of a CV: rejected because the old site’s resume-first utility is still part of what the page needs to do.
+
+### 7. Talks should prioritize watch/listen utility over summary framing
+The current rewritten talks page degrades compared with the old implementation because it removes the embedded media experience and replaces it with summary metrics and generic framing. The correct direction is to restore embedded playback and make the page easy to browse and consume directly.
+
+Alternatives considered:
+- Keep the "latest appearance" / "recorded appearances" framing: rejected because it reads as bragging and is less useful than embedded media.
+- Keep abstract proof strips about venues: rejected because they do not help the user decide what to watch.
+
+### 8. Navigation should include an explicit Home destination
+The brand link is not enough as the only way back to the homepage once the site has more destinations. The editorial shell should expose a clear `Home` entry in navigation.
+
+Alternatives considered:
+- Rely on the site title/brand only: rejected because explicit wayfinding is clearer and more practical.
+
 ## Architecture
 
 ```mermaid
@@ -98,6 +121,7 @@ flowchart TD
 5. Review the redesigned site for continuity gaps, then queue copy/book/newsletter refinements for the next pass.
 6. Create an integrated preview branch from the active stacked slices and run a second pass for shared visual fidelity, language, and subpage polish.
 7. Run a combined-preview review, then launch another polish wave for structured pages, discovery density, and code/tools shell alignment.
+8. Run a practical-refinement wave that removes pretentious language, restores useful embedded media where the old site was stronger, and re-centers the about page on CV utility.
 
 ## Execution Constraints
 

--- a/openspec/changes/preserve-site-parity-before-expansion/tasks.md
+++ b/openspec/changes/preserve-site-parity-before-expansion/tasks.md
@@ -53,3 +53,11 @@
 - [ ] 8.3 Refine `/posts`, `/posts/[slug]`, `/archive`, `/archives/[month]`, `/tags`, `/tags/[tag]`, and `/search` to reduce density and improve hierarchy where the combined preview still feels list-heavy
 - [ ] 8.4 Reconcile `/code-ai` and `/code-ai/[id]` with the shared editorial shell so they no longer feel like a separate site while preserving their browsing affordances
 - [ ] 8.5 Publish another integrated preview branch and local review server after the next polish wave so the whole system can be judged together again
+
+## 9. Practical Refinement Pass
+
+- [ ] 9.1 Replace self-conscious labels and brag metrics with direct, practical navigation language across shared surfaces and posts
+- [ ] 9.2 Rebuild `/talks` around embedded watch/listen utility, remove venue summary stripes and "latest appearance" framing, and keep the page easy to browse
+- [ ] 9.3 Rework `/publications` to remove empty metric holes and summary filler, using content-driven layout and plain labels instead
+- [ ] 9.4 Restore `/about` as a useful CV page first, while still supporting the broader public-work narrative
+- [ ] 9.5 Add an explicit `Home` destination to the editorial shell and run another integrated preview after the practical pass


### PR DESCRIPTION
## Context

The previous integrated preview established the second-wave redesign direction, but it also made the remaining gaps obvious: the homepage still needed stronger pacing, the structured pages still felt transitional, the discovery routes were still too dense, and Code & Tools still looked like a separate product surface. Those issues were hard to judge in isolation because each improvement landed in its own draft PR.

The latest polish wave intentionally stayed split by ownership so the homepage, structured pages, discovery routes, and code/tools could advance in parallel without conflicts. That was the right implementation shape, but it means we again need a stacked review branch to evaluate the result as one site rather than four unrelated diffs.

This PR creates that next combined review preview. It stacks the third-wave polish work on top of the existing end-state preview branch so design and product review can happen against something much closer to the final platform feel before anything is merged.

## What changed

- **Homepage polish**: Stacked the tighter homepage hierarchy pass so the hero, proof strip, featured writing, and CTA band read more like a composed editorial front page.
- **Structured pages**: Stacked the About, Book, Publications, and Talks refinements so those routes feel like finished editorial destinations instead of grid-heavy or placeholder shells.
- **Discovery routes**: Stacked the posts, archive, tag, and search hierarchy pass so browsing surfaces are easier to scan and less list-heavy on desktop and mobile.
- **Code & Tools**: Stacked the code/tools alignment work so that section now uses the same editorial shell language instead of feeling like a separate utility app.
- **OpenSpec continuity**: Carried forward the combined-preview refinement planning updates so the next polish wave remains explicitly tied to rendered review, not just abstract design intent.

## Why this matters

This is the branch that lets us answer the real question: does the site now feel like one coherent platform? That answer does not come from reading four PRs independently. It comes from seeing how the shell, copy, browsing surfaces, and utility sections behave together.

Without this preview branch, design review stays fragmented and we end up approving local improvements that may still clash in combination. With it, we can judge the system as a whole and decide whether the redesign is close enough to start converging instead of continuing to widen the branch stack.

## Next steps

- Review the combined preview locally and in Vercel.
- Decide whether another polish wave is needed or whether the branch set is ready to start collapsing toward the main redesign stack.
- Keep the child polish PRs unmerged until the combined direction is accepted.

## Test plan

- [x] `npm ci`
- [x] `npm run build`
- [ ] Manual browser review on the combined preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
