### PR TITLE
chore: simplify editorial copy and navigation

### DIFF
--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -10,9 +10,9 @@ const bookNotes = [
   },
   {
     label: 'Why it belongs here',
-    title: 'It extends the same editorial arc as the essays, reports, and talks.',
+    title: 'It extends the same practical arc as the posts, reports, and talks.',
     summary:
-      'This page should make the book legible before launch without turning it into a separate identity. The subject, audience, and technical point of view all stay connected to the rest of the site.',
+      'The page should make the book easy to understand before launch without turning it into a separate identity. The subject, audience, and technical point of view stay tied to the rest of the site.',
   },
 ];
 

--- a/app/code-ai/page.tsx
+++ b/app/code-ai/page.tsx
@@ -19,6 +19,7 @@ import {
 } from '../utils/codeTools';
 
 const editorialNavItems = [
+  { href: '/', label: 'Home' },
   { href: '/posts', label: 'Posts' },
   { href: '/talks', label: 'Talks' },
   { href: '/publications', label: 'Publications' },
@@ -278,7 +279,7 @@ export default function CodeAIPage() {
                   {activeCategoryCount} active categories
                 </span>
                 <span className="editorial-chip">
-                  {featuredItems.length} featured
+                  {featuredItems.length} selected
                 </span>
                 <span className="editorial-chip">
                   {latestItem ? formatCodeToolsDate(latestItem.date, { month: 'short', day: 'numeric', year: 'numeric' }) : 'No latest item'}
@@ -299,7 +300,7 @@ export default function CodeAIPage() {
                 </div>
                 <div>
                   <span className="editorial-page-metric-value">{featuredItems.length}</span>
-                  <span className="editorial-page-metric-label">featured entries</span>
+                  <span className="editorial-page-metric-label">selected items</span>
                 </div>
                 <div>
                   <span className="editorial-page-metric-value">

--- a/app/components/EditorialPageFrame.tsx
+++ b/app/components/EditorialPageFrame.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import Link from 'next/link';
 
 const navItems = [
+  { href: '/', label: 'Home' },
   { href: '/posts', label: 'Posts' },
   { href: '/talks', label: 'Talks' },
   { href: '/publications', label: 'Publications' },

--- a/app/components/MainContent.tsx
+++ b/app/components/MainContent.tsx
@@ -32,7 +32,7 @@ const getExcerpt = (content: string, summary?: string): string => {
   return firstParagraph.substring(0, 147) + '...';
 };
 
-const getPrimaryTag = (post: Post): string => post.tags[0] ?? 'Essay';
+const getPrimaryTag = (post: Post): string => post.tags[0] ?? 'Post';
 
 const DefaultHomeContent = ({ posts }: DefaultHomeContentProps) => {
   if (!posts || posts.length === 0) {
@@ -53,13 +53,13 @@ const DefaultHomeContent = ({ posts }: DefaultHomeContentProps) => {
       <section className="editorial-home-hero">
         <div className="editorial-home-hero-copy">
           <p className="editorial-home-kicker">Technical writing archive</p>
-          <h1>Writing about how AI systems remember, fail, and scale in production.</h1>
+          <h1>Posts on how AI systems remember, fail, and scale in production.</h1>
           <p className="editorial-home-subtitle">
-            Essays, talks, and book notes on the engineering decisions that separate demos from durable products.
+            Posts, talks, and book notes on the engineering choices that separate demos from durable products.
           </p>
           <div className="editorial-home-actions">
             <Link href={`/posts/${newestPost.slug}`} className="editorial-home-button editorial-home-button-primary">
-              Read the newest essay
+              Read the newest post
             </Link>
             <Link href="/posts" className="editorial-home-button editorial-home-button-secondary">
               Browse the archive
@@ -68,7 +68,7 @@ const DefaultHomeContent = ({ posts }: DefaultHomeContentProps) => {
         </div>
 
         <aside className="editorial-home-book-card">
-          <p className="editorial-home-card-label">Newest essay</p>
+          <p className="editorial-home-card-label">Latest post</p>
           <h2>{newestPost.title}</h2>
           <p>{newestExcerpt}</p>
           <div className="editorial-home-book-meta">
@@ -77,7 +77,7 @@ const DefaultHomeContent = ({ posts }: DefaultHomeContentProps) => {
             <span>{getPrimaryTag(newestPost)}</span>
           </div>
           <Link href={`/posts/${newestPost.slug}`} className="editorial-home-button editorial-home-button-accent">
-            Read the full piece
+            Read the post
           </Link>
         </aside>
       </section>
@@ -94,7 +94,7 @@ const DefaultHomeContent = ({ posts }: DefaultHomeContentProps) => {
 
       <section className="editorial-home-section">
         <p className="editorial-home-section-label">Selected writing</p>
-        <h2>Recent essays with enough context to know where to go next.</h2>
+        <h2>Recent posts with enough context to know where to go next.</h2>
         <div className="editorial-home-grid">
           {featuredPosts.map((post, index) => {
             const excerpt = getExcerpt(post.content, post.summary);

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -5,7 +5,7 @@ import { postService } from '../services/PostService';
 
 export const metadata: Metadata = {
   title: 'Posts | Ben Labaschin',
-  description: 'Essays, field notes, and technical writing on AI systems, memory, engineering practice, and adjacent work.',
+  description: 'Posts, field notes, and technical writing on AI systems, memory, engineering practice, and adjacent work.',
 };
 
 type Posts = Awaited<ReturnType<typeof postService.getAllPosts>>;
@@ -62,7 +62,7 @@ export default async function PostsPage() {
           <p className="editorial-home-kicker">Writing archive</p>
           <h1 className="editorial-page-title">Posts</h1>
           <p className="editorial-page-copy">
-            Essays, field notes, and working-throughs on agent memory, AI systems, engineering practice, and the occasional economics detour, arranged so the newest work stays easy to find.
+            Posts, field notes, and working-throughs on agent memory, AI systems, engineering practice, and the occasional economics detour, arranged so the newest work stays easy to find.
           </p>
           <div className="editorial-chip-row">
             {topTags.map(([tag, count]) => (
@@ -91,7 +91,7 @@ export default async function PostsPage() {
           )}
           {featuredPost && (
             <Link href={`/posts/${featuredPost.slug}`} className="editorial-home-button editorial-home-button-secondary">
-              Start with the latest essay
+              Start with the latest post
             </Link>
           )}
         </aside>
@@ -99,8 +99,8 @@ export default async function PostsPage() {
 
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Featured reading</p>
-          <h2 className="editorial-page-section-title">Start with the latest essay, then move backward by year.</h2>
+          <p className="editorial-home-section-label">Latest post</p>
+          <h2 className="editorial-page-section-title">Start with the latest post, then move backward by year.</h2>
         </div>
         {featuredPost ? (
           <article className="editorial-home-card">
@@ -115,7 +115,7 @@ export default async function PostsPage() {
                   <span>{featuredPost.tags[0]}</span>
                 </Link>
               ) : (
-                <span className="editorial-chip">Essay</span>
+                <span className="editorial-chip">Post</span>
               )}
               <span>{featuredPost.readingTime ? `${featuredPost.readingTime} min read` : 'Long-form note'}</span>
             </div>


### PR DESCRIPTION
## Context

This slice tightens the shared editorial shell and the main content entry points so the site reads more directly. The current copy leaned on labels like essays and piece, and the shared nav did not expose Home as an explicit destination, which made the shell feel more editorial than practical.

This change keeps the existing layout and structure but replaces the most self-conscious labels with plain language that matches the rest of the site. It also adds a Home nav item to the shared editorial shell and the code/tools page shell so navigation is direct from any section.

## What changed

- **`app/components/EditorialPageFrame.tsx`**: Added a Home nav item to the shared editorial shell.
- **`app/components/MainContent.tsx`**: Reworded the home hero and featured post copy to use posts instead of essays or piece language.
- **`app/posts/page.tsx`**: Simplified the posts index copy and labels to keep the archive practical and direct.
- **`app/book/page.tsx`**: Reworked the book notes copy so it stays connected to the posts and talks without sounding overly editorial.
- **`app/code-ai/page.tsx`**: Added Home to the local nav and replaced the promotional featured labels with more functional language.

## Why this matters

The result is a clearer, lower-ego navigation layer across the shared shell and related landing pages. Users can move around the site without being told to start with an essay or piece, and the Home destination is now explicit instead of implied.

This also makes the editorial areas more consistent with the practical tone the user asked for, without changing layout or behavior.

## Test plan

- [x] `npm ci`
- [x] `npm run build`
