### PR TITLE
feat: restore practical talks playback

### DIFF
--- a/app/config/talksConfig.ts
+++ b/app/config/talksConfig.ts
@@ -17,8 +17,8 @@ export const talksConfig = {
   /**
    * Page title and description
    */
-  title: "Conference Talks, Presentations, and Live Streams",
-  subtitle: "A collection of my conference talks, workshops, and presentations on tech topics.",
+  title: "Talks and Recordings",
+  subtitle: "Watch, listen, and open the source or transcript without leaving the page.",
 
   /**
    * Array of talks

--- a/app/talks/TalksClient.tsx
+++ b/app/talks/TalksClient.tsx
@@ -1,83 +1,148 @@
 'use client';
 
-import React, { useState } from 'react';
-import { talksConfig, Talk } from '../config/talksConfig';
+import { useEffect, useState } from 'react';
+import { talksConfig, type Talk } from '../config/talksConfig';
 
-interface TalkCardProps {
+const formatDate = (dateStr: string): string =>
+  new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(new Date(dateStr));
+
+const getYouTubeUrl = (talk: Talk): string | null => {
+  if (!talk.youtubeId) return null;
+  return `https://www.youtube.com/watch?v=${talk.youtubeId}`;
+};
+
+const getYouTubeEmbedUrl = (talk: Talk): string | null => {
+  if (!talk.youtubeId) return null;
+  return `https://www.youtube.com/embed/${talk.youtubeId}?autoplay=1`;
+};
+
+const getSpotifyEmbedUrl = (talk: Talk): string | null => {
+  if (!talk.spotifyUrl) return null;
+
+  const match = talk.spotifyUrl.match(/episode\/([a-zA-Z0-9]+)/);
+  if (!match) return null;
+
+  return `https://open.spotify.com/embed/episode/${match[1]}?utm_source=generator&theme=0`;
+};
+
+const getPrimaryActionLabel = (talk: Talk): string => {
+  if (talk.spotifyUrl && !talk.youtubeId) {
+    return 'Open player';
+  }
+
+  return 'Play in page';
+};
+
+const getPrimarySourceLabel = (talk: Talk): string => {
+  if (talk.spotifyUrl && !talk.youtubeId) {
+    return 'Listen on Spotify';
+  }
+
+  return 'Watch on YouTube';
+};
+
+function TalkCard({
+  talk,
+  viewMode,
+  isOpen,
+  onOpen,
+}: {
   talk: Talk;
   viewMode: 'list' | 'grid';
-}
-
-const TalkCard: React.FC<TalkCardProps> = ({ talk, viewMode }) => {
+  isOpen: boolean;
+  onOpen: () => void;
+}) {
   const [isHovered, setIsHovered] = useState(false);
-  const [isPlaying, setIsPlaying] = useState(false);
-
-  const formatDate = (dateStr: string): string => {
-    const date = new Date(dateStr);
-    return date.toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric'
-    });
-  };
-
-  const handlePlay = () => {
-    setIsPlaying(true);
-  };
-
-  const getYouTubeUrl = (): string => {
-    return `https://www.youtube.com/watch?v=${talk.youtubeId}`;
-  };
-
-  const getSpotifyEmbedUrl = (): string | null => {
-    if (!talk.spotifyUrl) return null;
-    // Extract episode ID from Spotify URL
-    const match = talk.spotifyUrl.match(/episode\/([a-zA-Z0-9]+)/);
-    if (match) {
-      return `https://open.spotify.com/embed/episode/${match[1]}?utm_source=generator&theme=0`;
-    }
-    return null;
-  };
-
-  const isSpotify = !!talk.spotifyUrl && !talk.youtubeId;
-
-  const cardClasses = `talk-card ${isHovered ? 'talk-card-hovered' : ''} ${
-    viewMode === 'grid' ? 'talk-card-grid' : ''
-  }`;
+  const spotifyEmbedUrl = getSpotifyEmbedUrl(talk);
+  const youtubeEmbedUrl = getYouTubeEmbedUrl(talk);
+  const youtubeUrl = getYouTubeUrl(talk);
+  const isSpotifyOnly = Boolean(talk.spotifyUrl && !talk.youtubeId);
+  const primarySourceUrl = talk.spotifyUrl ?? youtubeUrl;
 
   return (
-    <div
-      className={cardClasses}
+    <article
+      className={`talk-card ${isHovered ? 'talk-card-hovered' : ''} ${
+        viewMode === 'grid' ? 'talk-card-grid' : ''
+      } ${isOpen ? 'is-open' : ''}`}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
       <div className="talk-card-video">
-        {isSpotify && getSpotifyEmbedUrl() ? (
+        {isSpotifyOnly ? (
+          isOpen && spotifyEmbedUrl ? (
+            <iframe
+              src={spotifyEmbedUrl}
+              title={talk.title}
+              frameBorder="0"
+              allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+              allowFullScreen
+              loading="lazy"
+              className="spotify-embed"
+            />
+          ) : (
+            <div
+              className="talk-thumbnail-container spotify-container"
+              role="button"
+              tabIndex={0}
+              onClick={onOpen}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  onOpen();
+                }
+              }}
+              aria-label={`Open ${talk.title} in the inline player`}
+            >
+              <div className="spotify-placeholder">
+                <span className="spotify-label">Spotify episode</span>
+                <div className="talk-play-button" aria-hidden="true">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M8 5v14l11-7z" />
+                  </svg>
+                </div>
+                <span className="spotify-label">Open player</span>
+              </div>
+            </div>
+          )
+        ) : isOpen && youtubeEmbedUrl ? (
           <iframe
-            src={getSpotifyEmbedUrl()!}
-            title={talk.title}
-            frameBorder="0"
-            allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-            allowFullScreen
-            loading="lazy"
-            className="spotify-embed"
-          ></iframe>
-        ) : isPlaying ? (
-          <iframe
-            src={`https://www.youtube.com/embed/${talk.youtubeId}?autoplay=1`}
+            src={youtubeEmbedUrl}
             title={talk.title}
             frameBorder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
-          ></iframe>
+          />
         ) : (
-          <div className="talk-thumbnail-container" onClick={handlePlay}>
-            <img
-              src={`https://img.youtube.com/vi/${talk.youtubeId}/hqdefault.jpg`}
-              alt={talk.title}
-              className="talk-thumbnail"
-            />
-            <div className="talk-play-button">
+          <div
+            className="talk-thumbnail-container"
+            role="button"
+            tabIndex={0}
+            onClick={onOpen}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                onOpen();
+              }
+            }}
+            aria-label={`Open ${talk.title} in the inline player`}
+          >
+            {talk.youtubeId ? (
+              <img
+                src={`https://img.youtube.com/vi/${talk.youtubeId}/hqdefault.jpg`}
+                alt={talk.title}
+                className="talk-thumbnail"
+              />
+            ) : (
+              <div className="spotify-placeholder">
+                <span className="spotify-label">Recording</span>
+                <span className="spotify-label">Open to play</span>
+              </div>
+            )}
+            <div className="talk-play-button" aria-hidden="true">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M8 5v14l11-7z" />
               </svg>
@@ -92,131 +157,106 @@ const TalkCard: React.FC<TalkCardProps> = ({ talk, viewMode }) => {
           <div className="talk-card-meta">
             <span className="talk-card-event">{talk.event}</span>
             <span className="talk-card-date">{formatDate(talk.date)}</span>
+            {isOpen && <span>Playing in page</span>}
           </div>
         </div>
 
-        {viewMode !== 'grid' && (
-          <p className="talk-card-description">{talk.description}</p>
-        )}
+        {viewMode !== 'grid' && <p className="talk-card-description">{talk.description}</p>}
 
         <div className="talk-card-topics">
-          {talk.topics.map((topic, index) => (
-            <span key={index} className="talk-topic-tag">{topic}</span>
+          {talk.topics.slice(0, viewMode === 'grid' ? 4 : 6).map((topic) => (
+            <span key={topic} className="talk-topic-tag">
+              {topic}
+            </span>
           ))}
         </div>
 
         <div className="talk-card-actions">
-          {isSpotify ? (
-            <>
-              <a
-                href={talk.spotifyUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="watch-talk-button spotify-button"
-                aria-label={`Listen to ${talk.title} on Spotify`}
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 496 512" fill="currentColor">
-                  <path d="M248 8C111.1 8 0 119.1 0 256s111.1 248 248 248 248-111.1 248-248S384.9 8 248 8zm100.7 364.9c-4.2 0-6.8-1.3-10.7-3.6-62.4-37.6-135-39.2-206.7-24.5-3.9 1-9 2.6-11.9 2.6-9.7 0-15.8-7.7-15.8-15.8 0-10.3 6.1-15.2 13.6-16.8 81.9-18.1 165.6-16.5 237 26.2 6.1 3.9 9.7 7.4 9.7 16.5s-7.1 15.4-15.2 15.4zm26.9-65.6c-5.2 0-8.7-2.3-12.3-4.2-62.5-37-155.7-51.9-238.6-29.4-4.8 1.3-7.4 2.6-11.9 2.6-10.7 0-19.4-8.7-19.4-19.4s5.2-17.8 15.5-20.7c27.8-7.8 56.2-13.6 97.8-13.6 64.9 0 127.6 16.1 177 45.5 8.1 4.8 11.3 11 11.3 19.7-.1 10.8-8.5 19.5-19.4 19.5zm31-76.2c-5.2 0-8.4-1.3-12.9-3.9-71.2-42.5-198.5-52.7-280.9-29.7-3.6 1-8.1 2.6-12.9 2.6-13.2 0-23.3-10.3-23.3-23.6 0-13.6 8.4-21.3 17.4-23.9 35.2-10.3 74.6-15.2 117.5-15.2 73 0 149.5 15.2 205.4 47.8 7.8 4.5 12.9 10.7 12.9 22.6 0 13.6-11 23.3-23.2 23.3z"/>
-                </svg>
-                <span>Listen on Spotify</span>
-              </a>
-              {talk.transcriptUrl && (
-                <a
-                  href={talk.transcriptUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="watch-talk-button transcript-button"
-                  aria-label={`Read transcript of ${talk.title}`}
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-                    <polyline points="14 2 14 8 20 8"></polyline>
-                    <line x1="16" y1="13" x2="8" y2="13"></line>
-                    <line x1="16" y1="17" x2="8" y2="17"></line>
-                    <polyline points="10 9 9 9 8 9"></polyline>
-                  </svg>
-                  <span>Read Transcript</span>
-                </a>
-              )}
-            </>
-          ) : (
+          {primarySourceUrl && (
             <a
-              href={getYouTubeUrl()}
+              href={primarySourceUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="watch-talk-button"
-              aria-label={`Watch ${talk.title} on YouTube`}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M22.54 6.42a2.78 2.78 0 0 0-1.94-2C18.88 4 12 4 12 4s-6.88 0-8.6.46a2.78 2.78 0 0 0-1.94 2A29 29 0 0 0 1 11.75a29 29 0 0 0 .46 5.33A2.78 2.78 0 0 0 3.4 19c1.72.46 8.6.46 8.6.46s6.88 0 8.6-.46a2.78 2.78 0 0 0 1.94-2 29 29 0 0 0 .46-5.25 29 29 0 0 0-.46-5.33z"></path>
-                <polygon points="9.75 15.02 15.5 11.75 9.75 8.48 9.75 15.02"></polygon>
-              </svg>
-              <span>Watch Talk</span>
+              <span>{getPrimarySourceLabel(talk)}</span>
             </a>
           )}
+          {talk.transcriptUrl && (
+            <a
+              href={talk.transcriptUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="watch-talk-button transcript-button"
+            >
+              <span>Read transcript</span>
+            </a>
+          )}
+          <button type="button" className="watch-talk-button" onClick={onOpen}>
+            <span>{getPrimaryActionLabel(talk)}</span>
+          </button>
         </div>
       </div>
-    </div>
+    </article>
   );
-};
+}
 
-const TalksClient: React.FC = () => {
+export default function TalksClient() {
   const [activeFilter, setActiveFilter] = useState<string>('all');
   const [viewMode, setViewMode] = useState<'list' | 'grid'>('grid');
-  const { title, subtitle, talks } = talksConfig;
+  const { talks } = talksConfig;
 
-  // Sort talks by date (newest first)
-  const sortedTalks = [...talks].sort((a, b) =>
-    new Date(b.date).getTime() - new Date(a.date).getTime()
+  const sortedTalks = [...talks].sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
   );
 
-  const getTopTenTopics = (): string[] => {
-    const topicCount = new Map<string, number>();
-
-    talks.forEach(talk => {
-      talk.topics.forEach(topic => {
-        topicCount.set(topic, (topicCount.get(topic) || 0) + 1);
-      });
+  const topicCounts = new Map<string, number>();
+  sortedTalks.forEach((talk) => {
+    talk.topics.forEach((topic) => {
+      topicCounts.set(topic, (topicCounts.get(topic) ?? 0) + 1);
     });
+  });
 
-    return Array.from(topicCount.entries())
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 15)
-      .map(entry => entry[0]);
-  };
+  const topicFilters = Array.from(topicCounts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 12)
+    .map(([topic]) => topic);
 
-  const getFilteredTalks = (): Talk[] => {
-    if (activeFilter === 'all') {
-      return sortedTalks;
+  const filteredTalks =
+    activeFilter === 'all'
+      ? sortedTalks
+      : sortedTalks.filter((talk) => talk.topics.includes(activeFilter));
+
+  const [activeTalkId, setActiveTalkId] = useState<string>(sortedTalks[0]?.id ?? '');
+
+  useEffect(() => {
+    if (filteredTalks.length === 0) {
+      setActiveTalkId('');
+      return;
     }
-    return sortedTalks.filter(talk => talk.topics.includes(activeFilter));
-  };
 
-  const handleFilterChange = (filter: string) => {
-    setActiveFilter(filter);
-  };
+    if (!filteredTalks.some((talk) => talk.id === activeTalkId)) {
+      setActiveTalkId(filteredTalks[0].id);
+    }
+  }, [activeTalkId, filteredTalks]);
 
   return (
     <div className="talks-page">
-      <div className="section-header">
-        <h1 className="section-title">{title}</h1>
-        <div className="section-line"></div>
-        <p className="section-subtitle">{subtitle}</p>
-      </div>
-
       <div className="talks-controls">
-        <div className="talks-filter">
+        <div className="talks-filter" aria-label="Talk topics">
           <button
+            type="button"
             className={`filter-button ${activeFilter === 'all' ? 'active' : ''}`}
-            onClick={() => handleFilterChange('all')}
+            onClick={() => setActiveFilter('all')}
           >
-            All Topics
+            All talks
           </button>
-          {getTopTenTopics().map(topic => (
+          {topicFilters.map((topic) => (
             <button
+              type="button"
               key={topic}
               className={`filter-button ${activeFilter === topic ? 'active' : ''}`}
-              onClick={() => handleFilterChange(topic)}
+              onClick={() => setActiveFilter(topic)}
             >
               {topic}
             </button>
@@ -227,35 +267,37 @@ const TalksClient: React.FC = () => {
       <div className="talks-component-box">
         <div className="talks-component-header">
           <h2 className="talks-component-title">
-            {activeFilter === 'all' ? 'All Talks' : `Talks about ${activeFilter}`}
+            {activeFilter === 'all' ? 'Browse recordings' : `Talks about ${activeFilter}`}
           </h2>
-          <div className="view-toggle">
+          <div className="view-toggle" aria-label="Talk view mode">
             <button
+              type="button"
               className={`view-button ${viewMode === 'grid' ? 'active' : ''}`}
               onClick={() => setViewMode('grid')}
-              aria-label="Grid View"
-              title="Grid View"
+              aria-label="Grid view"
+              title="Grid view"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <rect x="3" y="3" width="7" height="7"></rect>
-                <rect x="14" y="3" width="7" height="7"></rect>
-                <rect x="14" y="14" width="7" height="7"></rect>
-                <rect x="3" y="14" width="7" height="7"></rect>
+                <rect x="3" y="3" width="7" height="7" />
+                <rect x="14" y="3" width="7" height="7" />
+                <rect x="14" y="14" width="7" height="7" />
+                <rect x="3" y="14" width="7" height="7" />
               </svg>
             </button>
             <button
+              type="button"
               className={`view-button ${viewMode === 'list' ? 'active' : ''}`}
               onClick={() => setViewMode('list')}
-              aria-label="List View"
-              title="List View"
+              aria-label="List view"
+              title="List view"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <line x1="8" y1="6" x2="21" y2="6"></line>
-                <line x1="8" y1="12" x2="21" y2="12"></line>
-                <line x1="8" y1="18" x2="21" y2="18"></line>
-                <line x1="3" y1="6" x2="3.01" y2="6"></line>
-                <line x1="3" y1="12" x2="3.01" y2="12"></line>
-                <line x1="3" y1="18" x2="3.01" y2="18"></line>
+                <line x1="8" y1="6" x2="21" y2="6" />
+                <line x1="8" y1="12" x2="21" y2="12" />
+                <line x1="8" y1="18" x2="21" y2="18" />
+                <line x1="3" y1="6" x2="3.01" y2="6" />
+                <line x1="3" y1="12" x2="3.01" y2="12" />
+                <line x1="3" y1="18" x2="3.01" y2="18" />
               </svg>
             </button>
           </div>
@@ -263,25 +305,29 @@ const TalksClient: React.FC = () => {
 
         <div className="talks-component-content">
           <div className={`talks-container ${viewMode === 'list' ? 'talks-list' : 'talks-grid'}`}>
-            {getFilteredTalks().map(talk => (
-              <TalkCard key={talk.id} talk={talk} viewMode={viewMode} />
+            {filteredTalks.map((talk) => (
+              <TalkCard
+                key={talk.id}
+                talk={talk}
+                viewMode={viewMode}
+                isOpen={talk.id === activeTalkId}
+                onOpen={() => setActiveTalkId(talk.id)}
+              />
             ))}
           </div>
 
-          {getFilteredTalks().length === 0 && (
+          {filteredTalks.length === 0 && (
             <div className="no-talks-message">
               <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="12" cy="12" r="10"></circle>
-                <line x1="12" y1="8" x2="12" y2="12"></line>
-                <line x1="12" y1="16" x2="12.01" y2="16"></line>
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="8" x2="12" y2="12" />
+                <line x1="12" y1="16" x2="12.01" y2="16" />
               </svg>
-              <p>No talks found with the selected topic.</p>
+              <p>No talks found for that topic.</p>
             </div>
           )}
         </div>
       </div>
     </div>
   );
-};
-
-export default TalksClient;
+}

--- a/app/talks/page.tsx
+++ b/app/talks/page.tsx
@@ -1,159 +1,39 @@
 import type { Metadata } from 'next';
 import { EditorialPageFrame } from '../components/EditorialPageFrame';
-import { talksConfig } from '../config/talksConfig';
+import TalksClient from './TalksClient';
 
 export const metadata: Metadata = {
   title: 'Talks | Ben Labaschin',
-  description: 'Conference talks, podcasts, and recorded appearances on AI systems, memory, and engineering.',
+  description: 'Recorded talks, podcasts, and livestreams with inline playback, transcripts, and direct source links.',
 };
 
-const formatDate = (dateStr: string) =>
-  new Intl.DateTimeFormat('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  }).format(new Date(dateStr));
-
 export default function TalksPage() {
-  const talks = [...talksConfig.talks].sort(
-    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-  );
-  const latestTalk = talks[0];
-  const earlierTalks = talks.slice(1);
-
   return (
     <EditorialPageFrame currentPath="/talks">
       <section className="editorial-page-hero">
         <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Speaking</p>
+          <p className="editorial-home-kicker">Watch and listen</p>
           <h1 className="editorial-page-title">Talks</h1>
           <p className="editorial-page-copy">
-            Talks, podcast conversations, and community appearances on memory systems, AI engineering, and the realities of production workflows.
+            Recorded talks, podcast conversations, and livestreams with inline playback, transcripts when available, and direct links back to the source.
           </p>
           <div className="editorial-chip-row">
-            <span className="editorial-chip">Podcasts</span>
-            <span className="editorial-chip">Conferences</span>
-            <span className="editorial-chip">Streams</span>
+            <span className="editorial-chip">Inline playback</span>
             <span className="editorial-chip">Transcripts</span>
+            <span className="editorial-chip">Source links</span>
           </div>
         </div>
         <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">At a glance</p>
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">{talks.length}</span>
-              <span className="editorial-page-metric-label">recorded appearances</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">{latestTalk ? formatDate(latestTalk.date) : 'n/a'}</span>
-              <span className="editorial-page-metric-label">latest appearance</span>
-            </div>
-          </div>
           <p className="editorial-post-summary">
-            Newest entries appear first, with watch, listen, and read links preserved where they exist.
+            Open a card, play it in place, and use the watch, listen, or transcript links that matter for that recording.
           </p>
-          {latestTalk && (
-            <a href={getTalkHref(latestTalk)} target="_blank" rel="noopener noreferrer" className="editorial-post-link">
-              Open the latest appearance
-            </a>
-          )}
+          <p className="editorial-post-summary">
+            The page stays practical on purpose: no appearance counts, no latest-item badge, just a browsable set of recordings.
+          </p>
         </aside>
       </section>
 
-      <section className="editorial-home-proof-strip" aria-label="Talks summary">
-        <span>MLOps Community</span>
-        <span>/</span>
-        <span>ODSC West</span>
-        <span>/</span>
-        <span>Normconf</span>
-        <span>/</span>
-        <span>podcasts and streams</span>
-      </section>
-
-      {latestTalk && (
-        <section className="editorial-list-section">
-          <div className="editorial-list-heading">
-            <p className="editorial-home-section-label">Featured appearance</p>
-            <h2 className="editorial-page-section-title">The most recent recording, expanded enough to set the tone.</h2>
-          </div>
-          <div className="editorial-timeline">
-            <TalkEntry talk={latestTalk} featured />
-          </div>
-        </section>
-      )}
-
-      {earlierTalks.length > 0 && (
-        <section className="editorial-list-section">
-          <div className="editorial-list-heading">
-            <p className="editorial-home-section-label">Earlier appearances</p>
-            <h2 className="editorial-page-section-title">Selected talks and recordings, organized newest first.</h2>
-          </div>
-          <div className="editorial-timeline">
-            {earlierTalks.map((talk) => (
-              <TalkEntry key={talk.id} talk={talk} />
-            ))}
-          </div>
-        </section>
-      )}
+      <TalksClient />
     </EditorialPageFrame>
-  );
-}
-
-function getTalkHref(talk: (typeof talksConfig.talks)[number]) {
-  return talk.spotifyUrl
-    ? talk.spotifyUrl
-    : talk.youtubeId
-      ? `https://www.youtube.com/watch?v=${talk.youtubeId}`
-      : undefined;
-}
-
-function TalkEntry({
-  talk,
-  featured = false,
-}: {
-  talk: (typeof talksConfig.talks)[number];
-  featured?: boolean;
-}) {
-  const primaryUrl = getTalkHref(talk);
-
-  return (
-    <article className={`editorial-timeline-item ${featured ? 'is-featured' : ''}`}>
-      <div className="editorial-post-meta">
-        <span>{talk.event}</span>
-        <span>{formatDate(talk.date)}</span>
-        {featured && <span>Featured</span>}
-      </div>
-      <h3>{talk.title}</h3>
-      <p className="editorial-post-summary">{talk.description}</p>
-      <div className="editorial-chip-row">
-        {talk.topics.slice(0, 4).map((topic) => (
-          <span key={topic} className="editorial-chip">
-            {topic}
-          </span>
-        ))}
-      </div>
-      <div className="editorial-link-row">
-        {primaryUrl && (
-          <a
-            href={primaryUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="editorial-post-link"
-          >
-            {talk.spotifyUrl ? 'Listen to recording' : 'Watch recording'}
-          </a>
-        )}
-        {talk.transcriptUrl && (
-          <a
-            href={talk.transcriptUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="editorial-post-link"
-          >
-            Read transcript
-          </a>
-        )}
-      </div>
-    </article>
   );
 }


### PR DESCRIPTION
## Context

The talks page had drifted into a summary-first layout: it emphasized appearance counts, a latest-appearance badge, and a venue-name strip, which made the page read more like a status board than a place to consume recordings. The older blog experience was more useful because it let people watch or listen inline and then jump straight to the source or transcript.

This PR brings that behavior back in a practical way. The page now leads with a simple watch/listen hero, removes the self-important summary language, and restores inline playback through the existing talks browser so each recording can be opened and consumed in place.

## What changed

- **app/talks/page.tsx**: Replaced the summary/count-focused layout with a practical hero and removed the latest-appearance and venue-name stripe treatment.
- **app/talks/TalksClient.tsx**: Reworked the talks browser into an inline playback index with selectable YouTube/Spotify embeds, transcript links, topic filters, and list/grid browsing.
- **app/config/talksConfig.ts**: Tightened the page copy so the talks section reads as a watch/listen index instead of a status summary.

## Why this matters

The page now serves the job users actually have: find a talk, open the player, and keep moving. That reduces friction for recordings that matter more than their surrounding metadata, and it keeps the page aligned with the rest of the site’s practical tone.

## Test plan

- [x] `npm ci`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)