### PR TITLE
feat(#34): integrate book and code detail second wave

### DIFF
--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -113,14 +113,19 @@ export default function BookPage() {
                 </p>
               </div>
               <div className="mt-8 flex items-center gap-4">
-                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#dbe1ff]">
-                  <span className="material-symbols-outlined text-[#00174b]" aria-hidden="true">
-                    psychology
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#dbe1ff] text-[#00174b]">
+                  <span className="font-headline text-[10px] font-black uppercase tracking-[0.25em]">
+                    AM
                   </span>
                 </div>
-                <span className="font-headline text-sm font-bold uppercase tracking-tight text-[#1d1c16]">
-                  Architectural Deep-Dive
-                </span>
+                <div className="space-y-1">
+                  <span className="block font-headline text-sm font-bold uppercase tracking-tight text-[#1d1c16]">
+                    Architectural Deep-Dive
+                  </span>
+                  <span className="block font-label text-[10px] uppercase tracking-widest text-[#555f70]">
+                    Memory systems, retrieval, and production trade-offs
+                  </span>
+                </div>
               </div>
             </div>
             <div className="flex flex-col justify-center rounded-xl bg-[#e7e2d8] p-10">

--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -1,86 +1,201 @@
 import Link from 'next/link';
 import { EditorialPageFrame } from '../components/EditorialPageFrame';
 
-const bookNotes = [
+const chapterInsights = [
   {
     label: 'What the book covers',
-    title: 'How AI systems remember, retrieve, compress, and decide what to act on.',
+    title: 'How memory, retrieval, compression, and action fit together in production agents.',
     summary:
       'The book is a practical guide to the mechanics behind durable agent behavior: storing useful context, retrieving it at the right time, and keeping the system understandable once it is in production.',
   },
   {
     label: 'Why it belongs here',
-    title: 'It extends the same practical arc as the posts, reports, and talks.',
+    title: 'It extends the same technical arc as the posts, reports, and talks.',
     summary:
-      'The page should make the book easy to understand before launch without turning it into a separate identity. The subject, audience, and technical point of view stay tied to the rest of the site.',
+      'The page should make the book easy to understand before launch without turning it into a separate identity. The subject, audience, and point of view stay tied to the rest of the site.',
+  },
+  {
+    label: 'What readers should take away',
+    title: 'Practical patterns for building memory systems people can trust.',
+    summary:
+      'The emphasis is on system design, operational trade-offs, and the architectural choices that determine whether long-running agents stay useful or become opaque.',
   },
 ];
+
+const bookFacts = [
+  ['Status', 'In progress'],
+  ['Publisher', "O'Reilly Media"],
+  ['Format', 'Print + digital'],
+  ['Focus', 'Agent memory systems'],
+] as const;
 
 export default function BookPage() {
   return (
     <EditorialPageFrame currentPath="/book">
-      <section className="editorial-book-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Forthcoming O&apos;Reilly book</p>
-          <h1 className="editorial-page-title">Agent Memory</h1>
-          <p className="editorial-page-copy">
-            A practical guide to how AI systems should remember, retrieve, compress, and act on information in production.
-          </p>
-          <div className="editorial-chip-row">
-            <span className="editorial-chip">Memory</span>
-            <span className="editorial-chip">Retrieval</span>
-            <span className="editorial-chip">Compression</span>
-            <span className="editorial-chip">Action</span>
+      <main className="mx-auto max-w-7xl px-8">
+        <header className="grid grid-cols-1 items-center gap-12 py-20 md:grid-cols-12 md:py-32">
+          <div className="space-y-8 md:col-span-7">
+            <div className="inline-block rounded-sm bg-[#bdc7db] px-3 py-1">
+              <span className="font-label text-xs font-bold uppercase tracking-widest text-[#121c2b]">
+                Forthcoming O&apos;Reilly Book
+              </span>
+            </div>
+            <h1 className="font-headline text-6xl font-black leading-none tracking-tighter text-[#1d1c16] md:text-8xl">
+              Agent
+              <br />
+              Memory.
+            </h1>
+            <p className="max-w-xl font-body text-2xl italic leading-relaxed text-[#555f70] md:text-3xl">
+              A practical guide to how AI systems should remember, retrieve, compress, and act on
+              information in production.
+            </p>
+            <div className="flex flex-wrap gap-6 pt-4">
+              <a
+                href="mailto:benjaminlabaschindev@gmail.com?subject=Agent%20Memory%20updates"
+                className="rounded-lg bg-[#2563eb] px-8 py-4 font-headline text-sm font-bold uppercase tracking-wider text-white shadow-[0_24px_40px_rgba(37,99,235,0.1)] transition-opacity hover:opacity-90"
+              >
+                Get book updates
+              </a>
+              <Link
+                href="/publications"
+                className="rounded-lg border border-[#c3c6d7] px-8 py-4 font-headline text-sm font-bold uppercase tracking-wider transition-colors hover:bg-[#f8f3e9]"
+              >
+                See related work
+              </Link>
+            </div>
           </div>
-          <div className="editorial-home-actions">
-            <a href="mailto:benjaminlabaschindev@gmail.com?subject=Agent%20Memory%20updates" className="editorial-home-button editorial-home-button-primary">
-              Get book updates
-            </a>
-            <Link href="/publications" className="editorial-home-button editorial-home-button-secondary">
-              See related work
-            </Link>
+
+          <div className="relative md:col-span-5">
+            <div className="relative flex aspect-[3/4] items-center justify-center overflow-hidden rounded-xl bg-[#e7e2d8] p-12 shadow-[0_24px_40px_rgba(29,28,22,0.05)]">
+              <div className="relative z-10 flex h-full w-full flex-col justify-between rounded-sm bg-[#1d1c16] p-8 text-[#fef9ef]">
+                <div className="space-y-1">
+                  <p className="font-headline text-[10px] uppercase tracking-[0.3em] opacity-60">
+                    Working Manuscript
+                  </p>
+                  <h2 className="font-headline text-4xl font-black leading-none">
+                    AGENT
+                    <br />
+                    MEMORY
+                  </h2>
+                </div>
+                <div className="space-y-4">
+                  <p className="font-body text-lg italic opacity-80">
+                    Practical memory systems for production agents.
+                  </p>
+                  <div className="h-px w-12 bg-[#fef9ef]/20" />
+                  <p className="font-headline text-xs font-bold uppercase tracking-widest">
+                    ECONOBEN.DEV
+                  </p>
+                </div>
+              </div>
+              <div className="pointer-events-none absolute inset-0 opacity-10 mix-blend-overlay">
+                <div className="absolute -mr-32 -mt-32 h-64 w-64 rounded-full border-[40px] border-[#004ac6]" />
+              </div>
+            </div>
           </div>
-        </div>
+        </header>
 
-        <aside className="editorial-home-book-card">
-          <p className="editorial-home-card-label">Working direction</p>
-          <h2>Practical memory systems for production agents.</h2>
-          <p>
-            One domain, one body of work, one list. The book should reinforce the site&apos;s technical arc, not split it into a second identity.
-          </p>
-          <div className="editorial-home-book-meta">
-            <span>in progress</span>
-            <span>O&apos;Reilly</span>
-            <span>agent memory</span>
+        <section className="py-20">
+          <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
+            <div className="flex min-h-[400px] flex-col justify-between rounded-xl bg-[#f8f3e9] p-12 md:col-span-2">
+              <div className="max-w-xl">
+                <span className="mb-4 block font-label text-xs font-bold uppercase tracking-widest text-[#004ac6]">
+                  Central Thesis
+                </span>
+                <h3 className="mb-6 font-headline text-4xl font-bold tracking-tight text-[#1d1c16]">
+                  The memory problem is really a systems problem.
+                </h3>
+                <p className="font-body text-xl leading-relaxed text-[#434655]">
+                  The book is about the mechanics that sit between a one-shot model call and a
+                  durable agent: what should be remembered, how it should be compressed, when it
+                  should be retrieved, and how those choices affect reliability once the system is
+                  live.
+                </p>
+              </div>
+              <div className="mt-8 flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#dbe1ff]">
+                  <span className="material-symbols-outlined text-[#00174b]" aria-hidden="true">
+                    psychology
+                  </span>
+                </div>
+                <span className="font-headline text-sm font-bold uppercase tracking-tight text-[#1d1c16]">
+                  Architectural Deep-Dive
+                </span>
+              </div>
+            </div>
+            <div className="flex flex-col justify-center rounded-xl bg-[#e7e2d8] p-10">
+              <h4 className="mb-6 font-headline text-5xl font-black text-[#1d1c16]/10">01.</h4>
+              <p className="font-body text-lg italic text-[#434655]">
+                Memory is not just storage. It is the structure that decides what historical intent
+                remains available to the agent when the next decision matters.
+              </p>
+            </div>
           </div>
-        </aside>
-      </section>
+        </section>
 
-      <section className="editorial-home-proof-strip" aria-label="Book summary">
-        <span>Memory systems</span>
-        <span>/</span>
-        <span>retrieval design</span>
-        <span>/</span>
-        <span>compression strategies</span>
-        <span>/</span>
-        <span>production AI</span>
-      </section>
+        <section className="border-t border-[#1d1c16]/5 py-20">
+          <div className="flex flex-col gap-16 md:flex-row">
+            <div className="md:w-1/3">
+              <h2 className="sticky top-32 font-headline text-4xl font-black tracking-tighter text-[#1d1c16]">
+                Chapter
+                <br />
+                Insights.
+              </h2>
+            </div>
+            <div className="space-y-16 md:w-2/3">
+              {chapterInsights.map((item) => (
+                <div key={item.label}>
+                  <span className="mb-2 block font-label text-xs uppercase tracking-widest text-[#555f70]">
+                    {item.label}
+                  </span>
+                  <h4 className="mb-4 font-headline text-2xl font-bold text-[#1d1c16] transition-colors hover:text-[#004ac6]">
+                    {item.title}
+                  </h4>
+                  <p className="max-w-2xl font-body text-lg leading-relaxed text-[#434655]">
+                    {item.summary}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
 
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Working notes</p>
-          <h2 className="editorial-page-section-title">The book page should answer three things quickly: what, why, and where it connects.</h2>
-        </div>
-        <div className="editorial-two-column">
-          {bookNotes.map((item) => (
-            <article key={item.label} className="editorial-home-card">
-              <p className="editorial-home-card-label">{item.label}</p>
-              <h3>{item.title}</h3>
-              <p>{item.summary}</p>
-            </article>
+        <section className="my-20 grid grid-cols-1 gap-12 rounded-xl bg-[#f8f3e9] p-12 md:grid-cols-4">
+          {bookFacts.map(([label, value]) => (
+            <div key={label} className="space-y-2">
+              <p className="font-label text-[10px] font-bold uppercase tracking-widest text-[#555f70]">
+                {label}
+              </p>
+              <p className="font-headline text-lg font-bold text-[#1d1c16]">{value}</p>
+            </div>
           ))}
-        </div>
-      </section>
+        </section>
+
+        <section className="flex justify-center py-32">
+          <div className="w-full max-w-3xl space-y-8 text-center">
+            <div className="space-y-4">
+              <h2 className="font-headline text-5xl font-black tracking-tighter text-[#1d1c16]">
+                Follow the research.
+              </h2>
+              <p className="font-body text-xl text-[#555f70]">
+                There is no fake signup form here. Email if you want updates on Agent Memory or
+                want to talk about the posts, talks, or publications that feed into it.
+              </p>
+            </div>
+            <div className="flex justify-center">
+              <a
+                href="mailto:benjaminlabaschindev@gmail.com?subject=Agent%20Memory%20updates"
+                className="rounded-md bg-[#1d1c16] px-8 py-4 font-headline text-xs font-bold uppercase tracking-widest text-[#fef9ef] transition-colors hover:bg-[#004ac6]"
+              >
+                Email for updates
+              </a>
+            </div>
+            <p className="font-label text-[10px] uppercase tracking-[0.2em] text-[#555f70]">
+              Posts, talks, and publications will keep carrying the work in the meantime.
+            </p>
+          </div>
+        </section>
+      </main>
     </EditorialPageFrame>
   );
 }

--- a/app/code-ai/[id]/page.tsx
+++ b/app/code-ai/[id]/page.tsx
@@ -35,14 +35,6 @@ const syntaxStyle = {
   background: 'transparent',
 } as const;
 
-function MaterialIcon({ name, className = '' }: { name: string; className?: string }) {
-  return (
-    <span className={`material-symbols-outlined ${className}`.trim()} aria-hidden="true">
-      {name}
-    </span>
-  );
-}
-
 function DetailStat({ label, value }: { label: string; value: string | number }) {
   return (
     <div>
@@ -157,7 +149,7 @@ export default async function CodeAIDetailPage({ params }: { params: Promise<{ i
                   href="/code-ai"
                   className="inline-flex flex-1 items-center justify-center gap-2 rounded-lg border border-[#c3c6d7] px-4 py-3 font-headline text-sm font-bold text-[#1d1c16] transition-colors hover:bg-white"
                 >
-                  <MaterialIcon name="arrow_back" className="text-sm" />
+                  <span aria-hidden="true">←</span>
                   Back to Code &amp; Tools
                 </Link>
                 {item.gistUrl && (
@@ -167,7 +159,7 @@ export default async function CodeAIDetailPage({ params }: { params: Promise<{ i
                     rel="noopener noreferrer"
                     className="inline-flex flex-1 items-center justify-center gap-2 rounded-lg bg-[#2563eb] px-4 py-3 font-headline text-sm font-bold text-white transition-opacity hover:opacity-90"
                   >
-                    <MaterialIcon name="terminal" className="text-sm" />
+                    <span aria-hidden="true">{'</>'}</span>
                     View on GitHub
                   </a>
                 )}
@@ -299,7 +291,7 @@ export default async function CodeAIDetailPage({ params }: { params: Promise<{ i
                     className="inline-flex items-center gap-1 font-headline font-bold text-[#004ac6] hover:underline"
                   >
                     View full catalog
-                    <MaterialIcon name="arrow_forward" className="text-sm" />
+                    <span aria-hidden="true">→</span>
                   </Link>
                 </div>
                 <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
@@ -319,12 +311,10 @@ export default async function CodeAIDetailPage({ params }: { params: Promise<{ i
                         {relatedItem.description}
                       </p>
                       <div className="flex items-center gap-4 font-label text-xs font-bold text-[#555f70]">
-                        <span className="flex items-center gap-1">
-                          <MaterialIcon name="code" className="text-xs" />
+                        <span className="rounded-full bg-white px-2.5 py-1">
                           {getCodeToolsLanguageLabel(relatedItem.language)}
                         </span>
-                        <span className="flex items-center gap-1">
-                          <MaterialIcon name="history" className="text-xs" />
+                        <span className="rounded-full bg-white px-2.5 py-1">
                           {relatedItem.date ? formatCodeToolsDate(relatedItem.date) : 'Undated'}
                         </span>
                       </div>

--- a/app/code-ai/[id]/page.tsx
+++ b/app/code-ai/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
@@ -35,23 +35,41 @@ const syntaxStyle = {
   background: 'transparent',
 } as const;
 
-const codeActionStyle = {
-  alignItems: 'center',
-  background: 'rgba(255, 255, 255, 0.72)',
-  border: '1px solid rgba(16, 34, 54, 0.08)',
-  borderRadius: '999px',
-  color: 'var(--editorial-ink)',
-  cursor: 'pointer',
-  display: 'inline-flex',
-  fontFamily: 'Inter, var(--font-body)',
-  fontSize: '0.82rem',
-  fontWeight: 700,
-  gap: '0.35rem',
-  justifyContent: 'center',
-  minHeight: '34px',
-  padding: '0 12px',
-  textDecoration: 'none',
-} as const;
+function MaterialIcon({ name, className = '' }: { name: string; className?: string }) {
+  return (
+    <span className={`material-symbols-outlined ${className}`.trim()} aria-hidden="true">
+      {name}
+    </span>
+  );
+}
+
+function DetailStat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <span className="block font-headline text-xl font-bold text-[#1d1c16]">{value}</span>
+      <span className="mt-1 block font-label text-[10px] font-bold uppercase tracking-widest text-[#555f70]">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function SidebarBlock({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-xl bg-[#f8f3e9] p-6">
+      <h3 className="mb-4 font-headline text-sm font-bold uppercase tracking-widest text-[#555f70]">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
 
 export async function generateStaticParams() {
   return getCodeToolsStaticParams();
@@ -70,7 +88,7 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   const canonicalUrl = `${getSiteUrl()}${getCodeToolsUrl(id)}`;
 
   return {
-    title: `${item.title} | Code & Tools | Ben Labaschin`,
+    title: `${item.title} | Code & Tools | ECONOBEN.DEV`,
     description: item.description,
     alternates: {
       canonical: canonicalUrl,
@@ -97,168 +115,227 @@ export default async function CodeAIDetailPage({ params }: { params: Promise<{ i
   const categoryConfig = getCodeToolsCategoryMeta(item.category);
   const relatedItems = getCodeToolsRelatedItems(item, 3);
   const lineCount = getCodeToolsItemLineCount(item);
-  const dateLabel = item.date ? formatCodeToolsDate(item.date, { year: 'numeric', month: 'long', day: 'numeric' }) : 'No date';
+  const dateLabel = item.date
+    ? formatCodeToolsDate(item.date, { year: 'numeric', month: 'long', day: 'numeric' })
+    : 'Undated';
+  const languageLabel = getCodeToolsLanguageLabel(item.language);
 
   return (
     <EditorialPageFrame currentPath="/code-ai" pageClassName="editorial-book-page">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Code & tools</p>
-          <h1 className="editorial-page-title">{item.title}</h1>
-          <p className="editorial-page-copy">{item.description}</p>
-          <p className="editorial-post-summary" style={{ marginTop: '14px', maxWidth: '58ch' }}>
-            The detail view keeps the writeup and code together, so the route behaves like the rest of the editorial site instead of a separate utility app.
-          </p>
-
-          <div className="editorial-home-actions">
-            <Link href="/code-ai" className="editorial-home-button editorial-home-button-secondary">
-              Back to Code & Tools
-            </Link>
-            {item.gistUrl && (
-              <a href={item.gistUrl} target="_blank" rel="noopener noreferrer" className="editorial-home-button editorial-home-button-primary">
-                View on GitHub
-              </a>
-            )}
+      <main className="mx-auto max-w-7xl px-8 py-16">
+        <section className="mb-20 grid grid-cols-1 gap-16 lg:grid-cols-12">
+          <div className="lg:col-span-8">
+            <div className="mb-6 flex flex-wrap items-center gap-3">
+              <span className="rounded-sm bg-[#bdc7db] px-3 py-1 font-label text-xs font-bold uppercase tracking-widest text-[#121c2b]">
+                {categoryConfig?.label || item.category}
+              </span>
+              <span className="font-label text-sm italic text-[#555f70]">{dateLabel}</span>
+            </div>
+            <h1 className="mb-6 font-headline text-5xl font-extrabold tracking-tight text-[#1d1c16]">
+              {item.title}
+            </h1>
+            <p className="max-w-2xl font-body text-xl italic leading-relaxed text-[#434655]">
+              {item.description}
+            </p>
+            <p className="mt-6 max-w-3xl font-body text-lg leading-relaxed text-[#555f70]">
+              The detail page keeps the writeup and source together, so the route behaves like the
+              rest of the editorial site instead of falling back to a disconnected tools surface.
+            </p>
           </div>
 
-          <div className="editorial-chip-row">
-            <span className="editorial-chip">{categoryConfig?.label || item.category}</span>
-            <span className="editorial-chip">{dateLabel}</span>
-            <span className="editorial-chip">{getCodeToolsLanguageLabel(item.language)}</span>
-            {item.filename && <span className="editorial-chip">{item.filename}</span>}
-            <span className="editorial-chip">{lineCount} lines</span>
-          </div>
-        </div>
-
-        <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">At a glance</p>
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">{categoryConfig?.label || item.category}</span>
-              <span className="editorial-page-metric-label">category</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">{getCodeToolsLanguageLabel(item.language)}</span>
-              <span className="editorial-page-metric-label">language</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">{item.filename || 'Inline snippet'}</span>
-              <span className="editorial-page-metric-label">source</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">{item.tags.length}</span>
-              <span className="editorial-page-metric-label">tags</span>
-            </div>
-          </div>
-        </aside>
-      </section>
-
-      <section className="editorial-home-proof-strip" aria-label="Code & Tools context">
-        <span>{categoryConfig?.label || item.category}</span>
-        <span>/</span>
-        <span>{dateLabel}</span>
-        <span>/</span>
-        <span>{lineCount} lines</span>
-        <span>/</span>
-        <span>{item.tags.length} tags</span>
-      </section>
-
-      <section className="editorial-list-section">
-        <div className="editorial-two-column">
-          <section style={{ display: 'grid', gap: '18px' }}>
-            {item.writeup && (
-              <div className="editorial-post-card" style={{ background: 'rgba(255, 255, 255, 0.58)' }}>
-                <p className="editorial-home-card-label">Writeup</p>
-                <div className="item-writeup" style={{ marginTop: '12px' }}>
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.writeup}</ReactMarkdown>
-                </div>
-              </div>
-            )}
-
-            <div style={codeBlockStyle}>
-              <div style={{ alignItems: 'center', display: 'flex', flexWrap: 'wrap', gap: '0.75rem', justifyContent: 'space-between', padding: '0.85rem 1rem' }}>
-                <div style={{ display: 'grid', gap: '0.18rem' }}>
-                  <div style={{ color: 'var(--editorial-ink)', fontFamily: 'IBM Plex Mono, Roboto Mono, monospace', fontSize: '0.78rem', fontWeight: 700, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
-                    {getCodeToolsLanguageLabel(item.language)}
-                  </div>
-                  <div style={{ color: 'var(--editorial-slate)', fontFamily: 'Inter, var(--font-body)', fontSize: '0.88rem' }}>
-                    {item.filename || 'Inline snippet'}
-                  </div>
-                </div>
-
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', justifyContent: 'flex-end' }}>
-                  {item.gistUrl && (
-                    <a href={item.gistUrl} target="_blank" rel="noopener noreferrer" style={codeActionStyle}>
-                      Gist
-                    </a>
-                  )}
-                  <span style={{ ...codeActionStyle, cursor: 'default' }}>{lineCount} lines</span>
-                </div>
+          <div className="flex flex-col justify-end lg:col-span-4">
+            <div className="space-y-6 rounded-xl bg-[#f8f3e9] p-8">
+              <div className="grid grid-cols-2 gap-6">
+                <DetailStat label="Language" value={languageLabel} />
+                <DetailStat label="Lines" value={lineCount} />
+                <DetailStat label="Tags" value={item.tags.length} />
+                <DetailStat label="Related" value={relatedItems.length} />
               </div>
 
-              <SyntaxHighlighter
-                language={normalizeCodeToolsLanguage(item.language)}
-                style={oneLight}
-                showLineNumbers
-                wrapLines
-                lineNumberStyle={{
-                  minWidth: '3em',
-                  paddingRight: '1em',
-                  textAlign: 'right',
-                  userSelect: 'none',
-                  opacity: 0.45,
-                }}
-                customStyle={syntaxStyle}
-                codeTagProps={{
-                  style: {
-                    fontFamily: "'IBM Plex Mono', 'Roboto Mono', 'Consolas', 'Monaco', monospace",
-                  },
-                }}
-              >
-                {item.content}
-              </SyntaxHighlighter>
+              <div className="flex flex-wrap gap-3">
+                <Link
+                  href="/code-ai"
+                  className="inline-flex flex-1 items-center justify-center gap-2 rounded-lg border border-[#c3c6d7] px-4 py-3 font-headline text-sm font-bold text-[#1d1c16] transition-colors hover:bg-white"
+                >
+                  <MaterialIcon name="arrow_back" className="text-sm" />
+                  Back to Code &amp; Tools
+                </Link>
+                {item.gistUrl && (
+                  <a
+                    href={item.gistUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex flex-1 items-center justify-center gap-2 rounded-lg bg-[#2563eb] px-4 py-3 font-headline text-sm font-bold text-white transition-opacity hover:opacity-90"
+                  >
+                    <MaterialIcon name="terminal" className="text-sm" />
+                    View on GitHub
+                  </a>
+                )}
+              </div>
             </div>
-          </section>
+          </div>
+        </section>
 
-          <aside style={{ display: 'grid', gap: '18px' }}>
-            <section className="editorial-page-aside">
-              <p className="editorial-home-card-label">Collection note</p>
-              <p className="editorial-post-summary" style={{ marginTop: '10px' }}>
-                This snippet stays in the editorial index alongside the rest of the collection, which keeps the browsing model stable as the presentation changes.
-              </p>
-            </section>
+        <section className="grid grid-cols-1 gap-16 lg:grid-cols-12">
+          <aside className="space-y-6 lg:col-span-3">
+            <SidebarBlock title="Overview">
+              <ul className="space-y-3 font-label text-sm text-[#1d1c16]">
+                <li className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[#004ac6]" />
+                  {categoryConfig?.label || item.category}
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[#004ac6]" />
+                  {languageLabel}
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[#004ac6]" />
+                  {dateLabel}
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[#004ac6]" />
+                  {lineCount} lines
+                </li>
+              </ul>
+            </SidebarBlock>
 
-            {relatedItems.length > 0 && (
-              <section className="editorial-page-aside">
-                <p className="editorial-home-card-label">Related snippets</p>
-                <div style={{ display: 'grid', gap: '14px', marginTop: '12px' }}>
-                  {relatedItems.map((relatedItem) => (
-                    <article key={relatedItem.id} style={{ paddingBottom: '14px', borderBottom: '1px solid rgba(16, 34, 54, 0.08)' }}>
-                      <h3 style={{ margin: 0, color: 'var(--editorial-ink)', fontFamily: 'Space Grotesk, Inter, sans-serif', fontSize: '1.2rem', letterSpacing: '-0.04em' }}>
-                        <Link href={getCodeToolsUrl(relatedItem.id)}>{relatedItem.title}</Link>
-                      </h3>
-                      <p className="editorial-post-summary" style={{ marginTop: '8px' }}>
-                        {relatedItem.description}
-                      </p>
-                    </article>
-                  ))}
-                </div>
-              </section>
-            )}
+            <SidebarBlock title="Source">
+              <div className="rounded-lg bg-[#e7e2d8] p-4 font-mono text-xs text-[#434655]">
+                <div>{item.filename || 'Inline snippet'}</div>
+                <div className="mt-2 break-all">{getCodeToolsUrl(item.id)}</div>
+              </div>
+            </SidebarBlock>
 
-            <section className="editorial-page-aside">
-              <p className="editorial-home-card-label">Tags</p>
-              <div className="editorial-chip-row" style={{ marginTop: '12px' }}>
+            <SidebarBlock title="Tags">
+              <div className="flex flex-wrap gap-2">
                 {item.tags.map((tag) => (
-                  <span key={tag} className="editorial-chip">
+                  <span
+                    key={tag}
+                    className="rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase tracking-widest text-[#555f70]"
+                  >
                     {tag}
                   </span>
                 ))}
               </div>
-            </section>
+            </SidebarBlock>
+
+            <SidebarBlock title="Collection note">
+              <p className="font-body text-sm leading-relaxed text-[#434655]">
+                This snippet stays in the same catalog as the rest of the workshop collection, so
+                browsing remains stable even as the presentation gets closer to the accepted Stitch
+                direction.
+              </p>
+            </SidebarBlock>
           </aside>
-        </div>
-      </section>
+
+          <div className="space-y-12 lg:col-span-9">
+            <article>
+              <h2 className="mb-6 font-headline text-3xl font-bold text-[#1d1c16]">
+                The implementation
+              </h2>
+              <p className="mb-8 font-body text-lg leading-relaxed text-[#434655]">
+                The detail page preserves the practical behavior of the original route: the writeup
+                stays readable, the source remains copyable and syntax highlighted, and the item can
+                still link back into the rest of the catalog.
+              </p>
+
+              {item.writeup && (
+                <div className="mb-10 rounded-xl bg-white/70 p-8 shadow-[0_16px_32px_rgba(24,36,49,0.08)]">
+                  <div className="item-writeup">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.writeup}</ReactMarkdown>
+                  </div>
+                </div>
+              )}
+
+              <div style={codeBlockStyle}>
+                <div className="flex items-center justify-between border-b border-[#d7d0c4] bg-[#f8f3e9] px-6 py-3">
+                  <div className="flex gap-2">
+                    <div className="h-3 w-3 rounded-full bg-[#ff5f56]" />
+                    <div className="h-3 w-3 rounded-full bg-[#ffbd2e]" />
+                    <div className="h-3 w-3 rounded-full bg-[#27c93f]" />
+                  </div>
+                  <span className="font-mono text-[10px] uppercase tracking-widest text-[#737686]">
+                    {item.filename || item.id}
+                  </span>
+                </div>
+                <SyntaxHighlighter
+                  language={normalizeCodeToolsLanguage(item.language)}
+                  style={oneLight}
+                  showLineNumbers
+                  wrapLines
+                  lineNumberStyle={{
+                    minWidth: '3em',
+                    paddingRight: '1em',
+                    textAlign: 'right',
+                    userSelect: 'none',
+                    opacity: 0.45,
+                  }}
+                  customStyle={syntaxStyle}
+                  codeTagProps={{
+                    style: {
+                      fontFamily:
+                        "'IBM Plex Mono', 'Roboto Mono', 'Consolas', 'Monaco', monospace",
+                    },
+                  }}
+                >
+                  {item.content}
+                </SyntaxHighlighter>
+              </div>
+            </article>
+
+            {relatedItems.length > 0 && (
+              <section className="mt-32 border-t border-[#1d1c16]/5 pt-16">
+                <div className="mb-12 flex items-end justify-between">
+                  <div>
+                    <h3 className="mb-2 font-headline text-xs font-black uppercase tracking-widest text-[#555f70]">
+                      More from the lab
+                    </h3>
+                    <h2 className="font-headline text-3xl font-bold text-[#1d1c16]">
+                      Related utilities
+                    </h2>
+                  </div>
+                  <Link
+                    href="/code-ai"
+                    className="inline-flex items-center gap-1 font-headline font-bold text-[#004ac6] hover:underline"
+                  >
+                    View full catalog
+                    <MaterialIcon name="arrow_forward" className="text-sm" />
+                  </Link>
+                </div>
+                <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
+                  {relatedItems.map((relatedItem) => (
+                    <Link
+                      key={relatedItem.id}
+                      href={getCodeToolsUrl(relatedItem.id)}
+                      className="rounded-xl bg-[#e7e2d8] p-8 transition-all hover:-translate-y-1"
+                    >
+                      <div className="mb-4 text-xs font-label font-bold uppercase tracking-widest text-[#004ac6]">
+                        {getCodeToolsCategoryMeta(relatedItem.category)?.label || relatedItem.category}
+                      </div>
+                      <h4 className="mb-2 font-headline text-xl font-bold text-[#1d1c16]">
+                        {relatedItem.title}
+                      </h4>
+                      <p className="mb-6 font-body text-sm text-[#434655]">
+                        {relatedItem.description}
+                      </p>
+                      <div className="flex items-center gap-4 font-label text-xs font-bold text-[#555f70]">
+                        <span className="flex items-center gap-1">
+                          <MaterialIcon name="code" className="text-xs" />
+                          {getCodeToolsLanguageLabel(relatedItem.language)}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <MaterialIcon name="history" className="text-xs" />
+                          {relatedItem.date ? formatCodeToolsDate(relatedItem.date) : 'Undated'}
+                        </span>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
+        </section>
+      </main>
     </EditorialPageFrame>
   );
 }

--- a/app/components/ClientLayout.tsx
+++ b/app/components/ClientLayout.tsx
@@ -14,6 +14,7 @@ interface ClientLayoutProps {
 const editorialShellRoutes = [
   '/',
   '/book',
+  '/code-ai',
   '/posts',
   '/publications',
   '/talks',
@@ -121,8 +122,12 @@ const ClientLayout: React.FC<ClientLayoutProps> = ({ children }) => {
     };
   }, [useEditorialShell]);
 
+  if (useEditorialShell) {
+    return <>{children}</>;
+  }
+
   // Don't render sidebar on mobile
-  if (isMobile || useEditorialShell) {
+  if (isMobile) {
     return (
       <>
         {children}

--- a/app/components/EditorialPageFrame.tsx
+++ b/app/components/EditorialPageFrame.tsx
@@ -31,14 +31,6 @@ const isCompactShell = (currentPath: string) => (
   currentPath === '/' || currentPath === '/posts' || currentPath === '/talks'
 );
 
-function MaterialIcon({ name, className = '' }: { name: string; className?: string }) {
-  return (
-    <span className={`material-symbols-outlined ${className}`.trim()} aria-hidden="true">
-      {name}
-    </span>
-  );
-}
-
 interface EditorialPageFrameProps {
   children: ReactNode;
   currentPath: string;
@@ -85,11 +77,10 @@ export function EditorialTopbar({ currentPath }: { currentPath: string }) {
         <Link
           href="/search"
           className={compactShell
-            ? 'flex items-center gap-2 font-label text-xs font-bold uppercase tracking-widest text-[#555f70] transition-colors duration-200 hover:text-[#004ac6]'
-            : 'flex items-center gap-2 text-[#555f70] transition-colors duration-200 hover:text-[#004ac6]'}
+            ? 'font-label text-xs font-bold uppercase tracking-widest text-[#555f70] transition-colors duration-200 hover:text-[#004ac6]'
+            : 'text-[#555f70] transition-colors duration-200 hover:text-[#004ac6]'}
         >
-          <MaterialIcon name="search" />
-          <span>Search</span>
+          Search
         </Link>
       </div>
     </header>

--- a/app/components/EditorialPageFrame.tsx
+++ b/app/components/EditorialPageFrame.tsx
@@ -49,6 +49,10 @@ export function EditorialTopbar({ currentPath }: { currentPath: string }) {
   const navClassName = compactShell
     ? 'hidden md:flex items-center gap-8 font-label text-xs font-bold uppercase tracking-widest'
     : 'hidden md:flex items-center gap-8 font-headline text-sm font-medium tracking-tight';
+  const mobileNavItemClassName = (active: boolean) =>
+    active
+      ? 'rounded-full bg-[#004ac6] px-3 py-2 text-[11px] font-bold uppercase tracking-widest text-white shadow-[0_8px_18px_rgba(0,74,198,0.18)]'
+      : 'rounded-full border border-[#1d1c16]/10 bg-[#f8f3e9]/90 px-3 py-2 text-[11px] font-bold uppercase tracking-widest text-[#555f70] transition-colors duration-200 hover:border-[#004ac6]/30 hover:text-[#004ac6]';
 
   return (
     <header className={headerClassName}>
@@ -83,6 +87,25 @@ export function EditorialTopbar({ currentPath }: { currentPath: string }) {
           Search
         </Link>
       </div>
+      <nav
+        className="mx-auto flex max-w-7xl flex-wrap gap-2 px-8 pb-4 md:hidden"
+        aria-label="Primary"
+      >
+        {navItems.map((item) => {
+          const active = isActivePath(currentPath, item.href);
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={mobileNavItemClassName(active)}
+              aria-current={active ? 'page' : undefined}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
     </header>
   );
 }

--- a/app/components/EditorialPageFrame.tsx
+++ b/app/components/EditorialPageFrame.tsx
@@ -7,6 +7,7 @@ const navItems = [
   { href: '/talks', label: 'Talks' },
   { href: '/publications', label: 'Publications' },
   { href: '/book', label: 'Book' },
+  { href: '/code-ai', label: 'Code & Tools' },
   { href: '/about', label: 'About' },
 ];
 

--- a/app/components/ShellHomePage.tsx
+++ b/app/components/ShellHomePage.tsx
@@ -159,7 +159,6 @@ export function ShellHomePage({ posts }: ShellHomePageProps) {
                 <div className="mt-8">
                   <Link href={`/posts/${featuredPost.slug}`} className="inline-flex items-center gap-2 font-label text-[11px] font-extrabold uppercase tracking-[0.22em] text-[#b4c5ff] transition-transform hover:translate-x-1">
                     Read the post
-                    <span className="material-symbols-outlined text-sm">arrow_forward</span>
                   </Link>
                 </div>
               </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,7 +2,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;500&family=Roboto:wght@400;500&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap');
 @import './styles/mobile-search-fixes.css';
 
 /* CSS Variables */
@@ -195,6 +195,18 @@ body.shell-editorial .dark-mode-toggle {
 }
 
 .material-symbols-outlined {
+	font-family: 'Material Symbols Outlined';
+	font-style: normal;
+	font-weight: 400;
+	line-height: 1;
+	letter-spacing: normal;
+	text-transform: none;
+	white-space: nowrap;
+	word-wrap: normal;
+	direction: ltr;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
 }
 


### PR DESCRIPTION
## Context

The accepted Stitch direction gives the site a clearer editorial shell and a stronger visual hierarchy, but the second-wave routes still needed the same treatment. In this branch, `/book` and `/code-ai/[id]` were still carrying the older presentation even as the shell and other routes moved toward the new reference.

These two routes also have practical constraints that the raw Stitch export does not solve by itself. The book page needs to stay grounded in the real in-progress O'Reilly project rather than a fake product launch, and the code detail page needs to keep working as an actual utility detail route backed by real tool data, markdown writeups, and syntax-highlighted examples.

This PR carries the accepted Stitch direction into those two pages without importing invented metadata or flattening the underlying route behavior. It keeps the editorial look and spacing from the preview branch, while preserving the real content model and code-detail expectations that already exist on the live route.

Refs #34.

## What changed

- **`app/book/page.tsx`**: Reworked the page into a Stitch-inspired editorial layout with a stronger hero, thesis section, chapter-insight structure, and factual metadata blocks while keeping the route tied to the real O'Reilly book work and a practical email CTA.
- **`app/code-ai/[id]/page.tsx`**: Rebuilt the code detail view with an editorial article layout, stat blocks, sidebar context, writeup section, and related-item treatment while preserving `generateStaticParams`, metadata generation, markdown rendering, syntax highlighting, and real `codeTools` data usage.

## Why this matters

Without this pass, the book and code-detail routes would lag behind the direction already accepted for the site, which makes the overall experience feel inconsistent and makes visual review harder. These are both important leaf pages: one establishes how the book fits into the site, and the other proves the new direction can support practical, content-rich detail views instead of only broad marketing layouts.

This PR closes some of the highest-visibility gaps in the second wave while keeping the branch safe to review in isolation. It gives us a better basis for deciding what should be generalized later into shared components versus what should remain route-specific.

## Next steps

- Review the visual fit of these pages against the shell/home baseline branch.
- Decide which layout patterns here should become shared route primitives after the broader second-wave review.

## Test plan

- [x] `npm run build`
- [x] Verified static generation still includes `/book` and `/code-ai/[id]`
- [ ] Manual browser review on the stacked branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)