### PR TITLE
feat(#32): integrate stitch discovery family routes

### DIFF
--- a/app/archive/page.tsx
+++ b/app/archive/page.tsx
@@ -1,119 +1,235 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { EditorialPageFrame } from '../components/EditorialPageFrame';
 import { postService } from '../services/PostService';
 
 export const metadata: Metadata = {
-  title: 'Archive | Ben Labaschin',
-  description: 'Browse the full writing archive by year and month.',
+  title: 'Archive | ECONOBEN.DEV',
+  description: 'Browse the writing archive by year and month.',
 };
 
 const monthFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'long',
 });
 
+const shortDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: '2-digit',
+});
+
+type ArchiveMonth = {
+  key: string;
+  year: number;
+  month: number;
+  monthLabel: string;
+  monthHref: string;
+  posts: Awaited<ReturnType<typeof postService.getAllPosts>>;
+};
+
 export default async function ArchivePage() {
   const posts = await postService.getAllPosts();
-  const postsByYearMonth = posts.reduce((acc, post) => {
+  const archiveByMonth = posts.reduce<Record<string, ArchiveMonth>>((acc, post) => {
     const year = post.date.getFullYear();
     const month = post.date.getMonth();
-    const monthKey = `${year}-${String(month + 1).padStart(2, '0')}`;
+    const key = `${year}-${String(month + 1).padStart(2, '0')}`;
 
-    if (!acc[monthKey]) {
-      acc[monthKey] = {
+    if (!acc[key]) {
+      acc[key] = {
+        key,
         year,
         month,
         monthLabel: monthFormatter.format(post.date),
-        monthHref: `/archives/${monthKey}`,
+        monthHref: `/archives/${key}`,
         posts: [],
       };
     }
 
-    acc[monthKey].posts.push(post);
+    acc[key].posts.push(post);
     return acc;
-  }, {} as Record<string, { year: number; month: number; monthLabel: string; monthHref: string; posts: typeof posts }>);
+  }, {});
 
-  const sortedEntries = Object.values(postsByYearMonth).sort((a, b) => {
-    if (a.year !== b.year) return b.year - a.year;
+  const months = Object.values(archiveByMonth).sort((a, b) => {
+    if (a.year !== b.year) {
+      return b.year - a.year;
+    }
+
     return b.month - a.month;
   });
 
-  const postsByYear = sortedEntries.reduce((acc, entry) => {
-    if (!acc[entry.year]) {
-      acc[entry.year] = [];
-    }
-    acc[entry.year].push(entry);
+  const monthsByYear = months.reduce<Record<number, ArchiveMonth[]>>((acc, month) => {
+    acc[month.year] ??= [];
+    acc[month.year].push(month);
     return acc;
-  }, {} as Record<number, typeof sortedEntries>);
+  }, {});
 
-  const years = Object.keys(postsByYear).map(Number).sort((a, b) => b - a);
+  const years = Object.keys(monthsByYear)
+    .map(Number)
+    .sort((a, b) => b - a);
+
   const uniqueTags = new Set(posts.flatMap((post) => post.tags)).size;
+  const latestMonth = months[0];
 
   return (
-    <EditorialPageFrame currentPath="/archive" pageClassName="editorial-book-page">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Archive</p>
-          <h1 className="editorial-page-title">Archive</h1>
-          <p className="editorial-page-copy">
-            Browse the full post history by year and month, with each month arranged like a compact table of contents rather than a flat index.
+    <EditorialPageFrame currentPath="/archive">
+      <main className="mx-auto max-w-7xl px-8 pb-32 pt-20">
+        <header className="mb-24 max-w-3xl">
+          <span className="mb-4 block font-label text-xs uppercase tracking-[0.2em] text-secondary">
+            Chronological Index
+          </span>
+          <h1 className="mb-8 font-headline text-6xl font-black tracking-tighter text-on-surface md:text-7xl">
+            Archive.
+          </h1>
+          <p className="font-body text-xl italic leading-relaxed text-on-surface-variant md:text-2xl">
+            Every post, grouped by year and month so the archive reads like a history of work instead of a flat directory.
           </p>
-          <div className="editorial-chip-row">
-            <span className="editorial-chip">By year</span>
-            <span className="editorial-chip">By month</span>
-            <span className="editorial-chip">Every post linked</span>
-          </div>
-        </div>
-        <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">Archive at a glance</p>
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">{posts.length}</span>
-              <span className="editorial-page-metric-label">total posts</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">{years.length}</span>
-              <span className="editorial-page-metric-label">years represented</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">{uniqueTags}</span>
-              <span className="editorial-page-metric-label">unique tags across the archive</span>
-            </div>
-          </div>
-        </aside>
-      </section>
+        </header>
 
-      {years.map((year) => (
-        <section key={year} className="editorial-list-section">
-          <div className="editorial-list-heading">
-            <p className="editorial-home-section-label">Year {year}</p>
-            <h2 className="editorial-page-section-title">Monthly index for {year}, with every post still available below each month.</h2>
-          </div>
-          <div className="months-grid">
-            {postsByYear[year].map(({ monthLabel, monthHref, posts: monthPosts }) => (
-              <article key={`${year}-${monthLabel}`} className="editorial-home-card">
-                <p className="editorial-home-card-label">{monthLabel}</p>
-                <h3>
-                  <Link href={monthHref}>{monthLabel}</Link>
-                </h3>
-                <p>{monthPosts.length} post{monthPosts.length !== 1 ? 's' : ''} in this month, linked by title below.</p>
-                <ul className="posts-list">
-                  {monthPosts.map((post) => (
-                    <li key={post.slug} className="archive-post">
-                      <Link href={`/posts/${post.slug}`}>
-                        <time className="archive-post-date">
-                          {post.date.getDate().toString().padStart(2, '0')}
-                        </time>
-                        <span className="archive-post-title">{post.title}</span>
-                      </Link>
+        <div className="grid grid-cols-1 gap-16 lg:grid-cols-12">
+          <aside className="lg:col-span-3">
+            <nav className="sticky top-32 space-y-10">
+              <div>
+                <h2 className="mb-6 font-label text-[10px] uppercase tracking-[0.3em] text-secondary">
+                  Filter by Year
+                </h2>
+                <ul className="space-y-3 font-label text-sm">
+                  {years.map((year, index) => (
+                    <li key={year}>
+                      <a
+                        href={`#year-${year}`}
+                        className={index === 0
+                          ? 'block border-l-2 border-primary pl-4 font-bold text-primary'
+                          : 'block pl-4 text-on-surface-variant transition-colors hover:text-on-surface'}
+                      >
+                        {year}
+                      </a>
                     </li>
                   ))}
                 </ul>
-              </article>
+              </div>
+
+              <div className="rounded-xl bg-surface-container-low p-6">
+                <h3 className="mb-2 font-headline text-sm font-bold text-on-surface">Archive Snapshot</h3>
+                <div className="space-y-4 font-label text-xs uppercase tracking-widest text-secondary">
+                  <div className="flex items-center justify-between gap-4">
+                    <span>Total posts</span>
+                    <span className="font-headline text-lg font-bold text-on-surface">{posts.length}</span>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <span>Years covered</span>
+                    <span className="font-headline text-lg font-bold text-on-surface">{years.length}</span>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <span>Unique tags</span>
+                    <span className="font-headline text-lg font-bold text-on-surface">{uniqueTags}</span>
+                  </div>
+                </div>
+                {latestMonth ? (
+                  <Link
+                    href={latestMonth.monthHref}
+                    className="mt-6 inline-flex items-center gap-2 font-label text-xs font-bold uppercase tracking-widest text-primary transition-colors hover:text-primary-container"
+                  >
+                    Latest month: {latestMonth.monthLabel} {latestMonth.year}
+                  </Link>
+                ) : null}
+              </div>
+            </nav>
+          </aside>
+
+          <div className="space-y-24 lg:col-span-9">
+            {years.map((year) => (
+              <section key={year} id={`year-${year}`} className="scroll-mt-32">
+                <div className="mb-12 flex items-baseline gap-4">
+                  <h2 className="font-headline text-4xl font-black tracking-tighter text-on-surface">{year}</h2>
+                  <div className="h-px flex-grow bg-outline-variant opacity-20" />
+                </div>
+
+                <div className="space-y-16">
+                  {monthsByYear[year].map((entry) => (
+                    <section key={entry.key}>
+                      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-baseline sm:justify-between">
+                        <div>
+                          <h3 className="font-headline text-2xl font-bold text-on-surface">{entry.monthLabel}</h3>
+                          <p className="mt-1 font-body text-base text-on-surface-variant">
+                            {entry.posts.length} post{entry.posts.length === 1 ? '' : 's'} published in {entry.monthLabel} {year}.
+                          </p>
+                        </div>
+                        <Link
+                          href={entry.monthHref}
+                          className="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary transition-colors hover:text-primary-container"
+                        >
+                          View month
+                        </Link>
+                      </div>
+
+                      <article className="rounded-xl bg-surface-container-low p-8">
+                        <div className="space-y-6">
+                          {entry.posts.map((post, index) => (
+                            <Link
+                              key={post.slug}
+                              href={`/posts/${post.slug}`}
+                              className={`block transition-colors hover:text-primary ${index > 0 ? 'border-t border-outline-variant/20 pt-6' : ''}`}
+                            >
+                              <div className="grid gap-3 md:grid-cols-[110px_minmax(0,1fr)] md:gap-6">
+                                <div className="font-label text-xs uppercase tracking-widest text-secondary">
+                                  {shortDateFormatter.format(post.date)}
+                                </div>
+                                <div>
+                                  <h4 className="font-headline text-xl font-bold text-on-surface">{post.title}</h4>
+                                  {post.summary ? (
+                                    <p className="mt-2 font-body text-base leading-relaxed text-on-surface-variant">
+                                      {post.summary}
+                                    </p>
+                                  ) : null}
+                                  {post.tags.length > 0 ? (
+                                    <div className="mt-4 flex flex-wrap gap-2">
+                                      {post.tags.slice(0, 4).map((tag) => (
+                                        <span
+                                          key={`${post.slug}-${tag}`}
+                                          className="rounded-sm bg-surface-container-highest px-2 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary"
+                                        >
+                                          {tag}
+                                        </span>
+                                      ))}
+                                    </div>
+                                  ) : null}
+                                </div>
+                              </div>
+                            </Link>
+                          ))}
+                        </div>
+                      </article>
+                    </section>
+                  ))}
+                </div>
+              </section>
             ))}
+
+            <section className="relative overflow-hidden rounded-xl bg-surface-container-highest p-12 lg:-ml-[10%] lg:mr-[10%]">
+              <div className="relative z-10 max-w-xl">
+                <h3 className="mb-4 font-headline text-3xl font-bold">Keep up with the archive.</h3>
+                <p className="mb-8 font-body text-lg leading-relaxed text-on-surface-variant">
+                  If you prefer browsing by subject instead of date, move from the archive into tags or search without losing your place.
+                </p>
+                <div className="flex flex-wrap gap-4">
+                  <Link
+                    href="/tags"
+                    className="rounded-md bg-primary-container px-6 py-3 font-label text-sm font-bold uppercase tracking-widest text-on-primary"
+                  >
+                    Browse tags
+                  </Link>
+                  <Link
+                    href="/search"
+                    className="rounded-md border border-outline-variant bg-surface px-6 py-3 font-label text-sm font-bold uppercase tracking-widest text-on-surface transition-colors hover:bg-surface-container-low"
+                  >
+                    Search archive
+                  </Link>
+                </div>
+              </div>
+              <div className="absolute right-[-10%] top-[-20%] h-64 w-64 rounded-full bg-primary opacity-5 blur-3xl" />
+            </section>
           </div>
-        </section>
-      ))}
+        </div>
+      </main>
     </EditorialPageFrame>
   );
 }

--- a/app/archives/[month]/page.tsx
+++ b/app/archives/[month]/page.tsx
@@ -19,7 +19,7 @@ const longDateFormatter = new Intl.DateTimeFormat('en-US', {
 function getMonthParts(month: string) {
   const [year, monthNum] = month.split('-');
 
-  if (!year || !monthNum || isNaN(parseInt(year)) || isNaN(parseInt(monthNum))) {
+  if (!year || !monthNum || Number.isNaN(Number.parseInt(year, 10)) || Number.isNaN(Number.parseInt(monthNum, 10))) {
     return null;
   }
 
@@ -35,153 +35,189 @@ async function getPostsForMonth(month: string) {
   const { year, monthNum } = parts;
   const allPosts = await postService.getAllPosts();
   const monthPosts = allPosts.filter((post) => {
-    const postDate = new Date(post.date);
-    const postYear = postDate.getFullYear().toString();
-    const postMonth = (postDate.getMonth() + 1).toString().padStart(2, '0');
-
+    const postYear = post.date.getFullYear().toString();
+    const postMonth = `${post.date.getMonth() + 1}`.padStart(2, '0');
     return postYear === year && postMonth === monthNum;
   });
 
   return { year, monthNum, monthPosts };
 }
 
-export default async function ArchivePage({ params }: ArchivePageProps) {
+export default async function ArchiveMonthPage({ params }: ArchivePageProps) {
   const { month } = await params;
   const monthData = await getPostsForMonth(month);
 
-  if (!monthData) {
+  if (!monthData || monthData.monthPosts.length === 0) {
     notFound();
   }
 
   const { year, monthNum, monthPosts } = monthData;
-
-  if (monthPosts.length === 0) {
-    notFound();
-  }
-
-  const monthName = new Date(parseInt(year), parseInt(monthNum) - 1).toLocaleDateString('en-US', {
+  const label = new Date(Number.parseInt(year, 10), Number.parseInt(monthNum, 10) - 1).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long',
   });
+  const [monthName, yearLabel] = label.split(' ');
+  const [featuredPost, ...remainingPosts] = monthPosts;
+  const uniqueTags = new Set(monthPosts.flatMap((post) => post.tags)).size;
 
   return (
-    <EditorialPageFrame currentPath="/archive" pageClassName="editorial-book-page">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Archive month</p>
-          <h1 className="editorial-page-title">{monthName}</h1>
-          <p className="editorial-page-copy">
-            Posts published in {monthName}, ordered newest first and framed as a single reading pass instead of a long list.
+    <EditorialPageFrame currentPath="/archive">
+      <main className="mx-auto max-w-7xl px-8 py-16">
+        <div className="mb-20">
+          <div className="mb-6 flex items-center gap-2 font-headline text-[10px] uppercase tracking-[0.2em] text-secondary">
+            <Link href="/archive" className="transition-colors hover:text-primary">Archive</Link>
+            <span>/</span>
+            <span className="font-bold text-on-surface">{yearLabel}</span>
+            <span>/</span>
+            <span className="font-bold text-on-surface">{monthName}</span>
+          </div>
+          <h1 className="mb-4 font-headline text-6xl font-black tracking-tighter text-on-surface md:text-8xl">
+            {monthName} <span className="font-body font-light italic text-primary">{yearLabel}</span>
+          </h1>
+          <p className="max-w-2xl font-body text-xl leading-relaxed text-on-surface-variant md:text-2xl">
+            A month view of the archive with the full set of posts preserved, but framed around the strongest entry first so the page reads like a curated issue.
           </p>
-          <div className="editorial-chip-row">
-            <span className="editorial-chip">{monthPosts.length} posts</span>
-            <span className="editorial-chip">Newest first</span>
-            <span className="editorial-chip">Archive link preserved</span>
-          </div>
         </div>
-        <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">Month at a glance</p>
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">{monthPosts.length}</span>
-              <span className="editorial-page-metric-label">posts in this month</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">
-                {new Set(monthPosts.flatMap((post) => post.tags)).size}
-              </span>
-              <span className="editorial-page-metric-label">unique tags in month</span>
-            </div>
-            <div>
-              <Link href="/archive" className="editorial-post-link">
-                Back to archive
-              </Link>
-            </div>
-          </div>
-        </aside>
-      </section>
 
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Posts</p>
-          <h2 className="editorial-page-section-title">Everything published during this month, kept in one readable stack.</h2>
-        </div>
-        <article className="editorial-home-card">
-          <p className="editorial-home-card-label">Month index</p>
-          <h3>{monthName}</h3>
-          <p>
-            {monthPosts.length} post{monthPosts.length !== 1 ? 's' : ''} arranged newest first, with summaries and topic links left visible for scanning.
-          </p>
-          {monthPosts[0] ? (
-            <div>
-              <p className="editorial-home-card-label">Featured post</p>
-              <Link href={`/posts/${monthPosts[0].slug}`} className="editorial-home-card-link">
-                {monthPosts[0].title}
-              </Link>
-              {monthPosts[0].summary && <p className="editorial-post-summary">{monthPosts[0].summary}</p>}
-              <div className="editorial-chip-row">
-                {monthPosts[0].tags.slice(0, 4).map((tag) => (
-                  <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
-                    {tag}
-                  </Link>
-                ))}
+        <div className="grid grid-cols-1 items-start gap-8 lg:grid-cols-12">
+          <article className="rounded-xl bg-surface-container-low p-8 transition-colors duration-300 hover:bg-surface-container-high lg:col-span-8 md:p-12">
+            <div className="flex flex-col gap-10 md:flex-row">
+              <div className="md:w-1/3">
+                <div className="rounded-lg bg-surface-container-highest p-6">
+                  <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Featured Post</p>
+                  <p className="mt-6 font-headline text-5xl font-black text-on-surface">{monthPosts.length}</p>
+                  <p className="mt-3 font-body text-sm leading-relaxed text-on-surface-variant">
+                    Post{monthPosts.length === 1 ? '' : 's'} published in {label}.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex flex-1 flex-col justify-center">
+                <time className="mb-4 font-headline text-xs font-bold uppercase tracking-widest text-secondary">
+                  {featuredPost ? longDateFormatter.format(featuredPost.date) : label}
+                </time>
+                <h2 className="mb-6 font-headline text-3xl font-extrabold leading-tight text-on-surface transition-colors hover:text-primary md:text-4xl">
+                  <Link href={`/posts/${featuredPost.slug}`}>{featuredPost.title}</Link>
+                </h2>
+                {featuredPost.summary ? (
+                  <p className="mb-8 font-body text-lg leading-relaxed text-on-surface-variant">
+                    {featuredPost.summary}
+                  </p>
+                ) : null}
+                <div className="flex flex-wrap gap-2">
+                  {featuredPost.tags.slice(0, 5).map((tag) => (
+                    <Link
+                      key={tag}
+                      href={`/tags/${encodeURIComponent(tag)}`}
+                      className="rounded-sm bg-surface px-3 py-1 font-label text-[10px] font-bold uppercase tracking-widest text-secondary transition-colors hover:bg-surface-container-highest hover:text-on-surface"
+                    >
+                      {tag}
+                    </Link>
+                  ))}
+                </div>
               </div>
             </div>
-          ) : null}
-          <ul className="posts-list">
-            {monthPosts.slice(1).map((post) => (
-              <li key={post.slug} className="archive-post">
-                <Link href={`/posts/${post.slug}`}>
-                  <time className="archive-post-date">{longDateFormatter.format(post.date)}</time>
-                  <span className="archive-post-title">{post.title}</span>
+          </article>
+
+          <aside className="space-y-8 lg:col-span-4 lg:sticky lg:top-32">
+            <div className="rounded-xl bg-surface-container-highest p-8">
+              <h3 className="mb-6 font-headline text-xs font-bold uppercase tracking-widest text-secondary">In This Month</h3>
+              <ul className="space-y-4">
+                {[
+                  ['Posts', `${monthPosts.length}`],
+                  ['Unique tags', `${uniqueTags}`],
+                  ['Year', yearLabel ?? year],
+                ].map(([labelText, value]) => (
+                  <li key={labelText} className="flex items-center justify-between border-b border-on-surface/5 pb-3">
+                    <span className="font-headline text-sm font-medium text-on-surface">{labelText}</span>
+                    <span className="font-body text-lg italic text-primary">{value}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="rounded-xl border border-outline-variant/20 bg-surface p-8">
+              <h3 className="mb-4 font-headline text-xs font-bold uppercase tracking-widest text-secondary">Navigate</h3>
+              <div className="flex flex-col gap-3">
+                <Link href="/archive" className="font-label text-xs font-bold uppercase tracking-widest text-primary">
+                  Back to archive
                 </Link>
-              </li>
-            ))}
-          </ul>
-          <Link href="/archive" className="editorial-home-card-link">
-            Back to archive
-          </Link>
-        </article>
-      </section>
+                <Link href="/tags" className="font-label text-xs font-bold uppercase tracking-widest text-primary">
+                  Browse tags
+                </Link>
+              </div>
+            </div>
+          </aside>
+
+          {remainingPosts.length > 0 ? (
+            <div className="grid grid-cols-1 gap-8 lg:col-span-8 md:grid-cols-2">
+              {remainingPosts.map((post) => (
+                <article
+                  key={post.slug}
+                  className="rounded-xl bg-surface-container-low p-8 transition-colors duration-300 hover:bg-surface-container-high"
+                >
+                  <time className="mb-3 block font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">
+                    {longDateFormatter.format(post.date)}
+                  </time>
+                  <h3 className="mb-3 font-headline text-2xl font-bold leading-tight text-on-surface">
+                    <Link href={`/posts/${post.slug}`} className="transition-colors hover:text-primary">
+                      {post.title}
+                    </Link>
+                  </h3>
+                  {post.summary ? (
+                    <p className="mb-5 font-body text-base leading-relaxed text-on-surface-variant">
+                      {post.summary}
+                    </p>
+                  ) : null}
+                  <div className="flex flex-wrap gap-2">
+                    {post.tags.slice(0, 4).map((tag) => (
+                      <Link
+                        key={`${post.slug}-${tag}`}
+                        href={`/tags/${encodeURIComponent(tag)}`}
+                        className="rounded-sm bg-surface px-2 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary transition-colors hover:bg-surface-container-highest hover:text-on-surface"
+                      >
+                        {tag}
+                      </Link>
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </main>
     </EditorialPageFrame>
   );
 }
 
 export async function generateStaticParams() {
   const allPosts = await postService.getAllPosts();
-
   const months = new Set<string>();
 
   allPosts.forEach((post) => {
-    const postDate = new Date(post.date);
-    const year = postDate.getFullYear();
-    const month = (postDate.getMonth() + 1).toString().padStart(2, '0');
+    const year = post.date.getFullYear();
+    const month = `${post.date.getMonth() + 1}`.padStart(2, '0');
     months.add(`${year}-${month}`);
   });
 
-  return Array.from(months).map((month) => ({
-    month,
-  }));
+  return Array.from(months).map((month) => ({ month }));
 }
 
 export async function generateMetadata({ params }: ArchivePageProps): Promise<Metadata> {
   const { month } = await params;
   const monthData = await getPostsForMonth(month);
 
-  if (!monthData) {
-    return {
-      title: 'Archive Not Found',
-    };
+  if (!monthData || monthData.monthPosts.length === 0) {
+    return { title: 'Archive Not Found | ECONOBEN.DEV' };
   }
 
-  const { year, monthNum, monthPosts } = monthData;
-  const monthName = new Date(parseInt(year), parseInt(monthNum) - 1).toLocaleDateString('en-US', {
+  const label = new Date(Number.parseInt(monthData.year, 10), Number.parseInt(monthData.monthNum, 10) - 1).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long',
   });
 
   return {
-    title: `Posts from ${monthName} | Ben Labaschin`,
-    description: `Browse ${monthPosts.length} post${monthPosts.length === 1 ? '' : 's'} from ${monthName}.`,
+    title: `${label} | Archive | ECONOBEN.DEV`,
+    description: `Browse ${monthData.monthPosts.length} post${monthData.monthPosts.length === 1 ? '' : 's'} from ${label}.`,
   };
 }

--- a/app/components/EditorialPageFrame.tsx
+++ b/app/components/EditorialPageFrame.tsx
@@ -49,6 +49,10 @@ export function EditorialTopbar({ currentPath }: { currentPath: string }) {
   const navClassName = compactShell
     ? 'hidden md:flex items-center gap-8 font-label text-xs font-bold uppercase tracking-widest'
     : 'hidden md:flex items-center gap-8 font-headline text-sm font-medium tracking-tight';
+  const mobileNavItemClassName = (active: boolean) =>
+    active
+      ? 'rounded-full bg-[#004ac6] px-3 py-2 text-[11px] font-bold uppercase tracking-widest text-white shadow-[0_8px_18px_rgba(0,74,198,0.18)]'
+      : 'rounded-full border border-[#1d1c16]/10 bg-[#f8f3e9]/90 px-3 py-2 text-[11px] font-bold uppercase tracking-widest text-[#555f70] transition-colors duration-200 hover:border-[#004ac6]/30 hover:text-[#004ac6]';
 
   return (
     <header className={headerClassName}>
@@ -83,6 +87,25 @@ export function EditorialTopbar({ currentPath }: { currentPath: string }) {
           Search
         </Link>
       </div>
+      <nav
+        className="mx-auto flex max-w-7xl flex-wrap gap-2 px-8 pb-4 md:hidden"
+        aria-label="Primary"
+      >
+        {navItems.map((item) => {
+          const active = isActivePath(currentPath, item.href);
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={mobileNavItemClassName(active)}
+              aria-current={active ? 'page' : undefined}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
     </header>
   );
 }

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -2,13 +2,15 @@
 
 import type { FormEvent } from 'react';
 import { Suspense, useEffect, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { EditorialPageFrame } from '../components/EditorialPageFrame';
 import type { SearchResult } from '../services/UnifiedSearchService';
 
-function formatResultDate(date?: Date) {
-  if (!date) return null;
+function formatResultDate(date?: Date | string) {
+  if (!date) {
+    return null;
+  }
 
   return new Intl.DateTimeFormat('en-US', {
     year: 'numeric',
@@ -19,7 +21,16 @@ function formatResultDate(date?: Date) {
 
 const resultTypeOrder: SearchResult['type'][] = ['post', 'publication', 'talk', 'code-ai'];
 
-const groupResultsByType = (results: SearchResult[]) => {
+const typeLabels: Record<SearchResult['type'], string> = {
+  post: 'Posts',
+  publication: 'Publications',
+  talk: 'Talks',
+  'code-ai': 'Code & Tools',
+};
+
+const quickQueries = ['memory', 'retrieval', 'economics', 'tooling'];
+
+function groupResultsByType(results: SearchResult[]) {
   const groups = new Map<SearchResult['type'], SearchResult[]>();
 
   results.forEach((result) => {
@@ -34,19 +45,13 @@ const groupResultsByType = (results: SearchResult[]) => {
       type,
       results: groups.get(type) ?? [],
     }));
-};
+}
 
 function SearchContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const query = searchParams.get('q') || '';
   const normalizedQuery = query.trim();
-  const typeLabels: Record<SearchResult['type'], string> = {
-    post: 'Blog post',
-    talk: 'Talk',
-    publication: 'Publication',
-    'code-ai': 'Code & tools',
-  };
 
   const [results, setResults] = useState<SearchResult[]>([]);
   const [loading, setLoading] = useState(false);
@@ -82,8 +87,8 @@ function SearchContent() {
     setResults([]);
   }, [query]);
 
-  const handleSearch = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const handleSearch = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
 
     const nextQuery = searchQuery.trim();
     if (!nextQuery) {
@@ -93,154 +98,196 @@ function SearchContent() {
 
     router.replace(`/search?q=${encodeURIComponent(nextQuery)}`);
   };
+
   const groupedResults = groupResultsByType(results);
 
   return (
-    <EditorialPageFrame currentPath="/search" pageClassName="editorial-book-page">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Search</p>
-          <h1 className="editorial-page-title">Search Results</h1>
-          <p className="editorial-page-copy">
-            Search posts, talks, publications, and code notes without leaving the editorial index, with results grouped so the page reads in sections instead of one long feed.
-          </p>
-          <p className="editorial-post-summary">
-            {normalizedQuery ? `Showing results for “${normalizedQuery}”.` : 'Search the archive by topic, title, or theme.'}
-          </p>
-        </div>
-        <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">Search status</p>
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">{loading ? '...' : results.length}</span>
-              <span className="editorial-page-metric-label">results on the current query</span>
+    <EditorialPageFrame currentPath="/search">
+      <main className="mx-auto min-h-screen max-w-7xl px-8 py-16">
+        <header className="mb-16 max-w-3xl">
+          <div className="mb-4 block font-label text-xs font-bold uppercase tracking-widest text-secondary">
+            Search &amp; Discovery
+          </div>
+          <h1 className="mb-8 font-headline text-5xl font-black tracking-tighter text-on-surface">
+            Search the archives.
+          </h1>
+
+          <form action="/search" className="group relative" onSubmit={handleSearch} role="search" aria-label="Site search">
+            <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-6">
+              <span className="material-symbols-outlined text-secondary" aria-hidden="true">search</span>
             </div>
-            <div>
-              <Link href="/archive" className="editorial-post-link">
-                Browse archive
+            <input
+              autoFocus
+              className="block w-full rounded-xl bg-surface-container-lowest py-6 pl-16 pr-6 font-body text-xl text-on-surface shadow-[0_2px_15px_rgba(0,0,0,0.02)] placeholder:text-secondary focus:outline-none"
+              name="q"
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder="Search for posts, talks, publications, or tools..."
+              type="text"
+              value={searchQuery}
+            />
+            <div className="absolute bottom-0 left-0 h-0.5 w-full origin-left scale-x-0 bg-primary transition-transform duration-500 group-focus-within:scale-x-100" />
+          </form>
+
+          <div className="mt-6 flex flex-wrap gap-3">
+            <span className="mr-2 self-center font-label text-[10px] uppercase tracking-widest text-secondary">
+              Quick Queries:
+            </span>
+            {quickQueries.map((term) => (
+              <Link
+                key={term}
+                href={`/search?q=${encodeURIComponent(term)}`}
+                className="rounded-full bg-surface-container-low px-4 py-1.5 font-label text-xs font-semibold text-secondary transition-colors hover:bg-secondary-container hover:text-on-secondary-container"
+              >
+                {term}
               </Link>
-              <span className="editorial-page-metric-label">archive index</span>
-            </div>
+            ))}
           </div>
-        </aside>
-      </section>
+        </header>
 
-      <section className="editorial-list-section">
-        <form onSubmit={handleSearch} className="search-input-container" role="search" aria-label="Site search">
-          <input
-            type="text"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Search posts, talks, publications, and tools"
-            className="search-input-large"
-            autoFocus
-          />
-        </form>
-
-        {!normalizedQuery ? (
-          <div className="editorial-page-aside">
-            <p className="editorial-home-card-label">Try searching for</p>
-            <div className="editorial-chip-row">
-              {['memory', 'retrieval', 'economics', 'forecasting'].map((term) => (
-                <Link key={term} href={`/search?q=${encodeURIComponent(term)}`} className="editorial-chip">
-                  {term}
-                </Link>
-              ))}
-            </div>
-            <div className="editorial-chip-row">
-              <Link href="/posts" className="editorial-chip">Posts</Link>
-              <Link href="/tags" className="editorial-chip">Tags</Link>
-              <Link href="/archive" className="editorial-chip">Archive</Link>
-            </div>
-          </div>
-        ) : loading ? (
-          <div className="search-loading">
-            <div className="loading-spinner"></div>
-            <p>Searching...</p>
-          </div>
-        ) : results.length === 0 ? (
-          <div className="editorial-page-aside">
-            <p className="editorial-home-card-label">No results</p>
-            <p className="editorial-post-summary">
-              No results found for “{normalizedQuery}”. Try a broader keyword or search one of the suggested topics below.
-            </p>
-            <div className="editorial-chip-row">
-              {['memory', 'llm', 'forecasting', 'tooling'].map((term) => (
-                <Link key={term} href={`/search?q=${encodeURIComponent(term)}`} className="editorial-chip">
-                  {term}
-                </Link>
-              ))}
-            </div>
-          </div>
-        ) : (
-          <>
-            <p className="results-count" aria-live="polite">
-              Found {results.length} result{results.length !== 1 ? 's' : ''} for “{normalizedQuery}”
-            </p>
-
-            {groupedResults.map(({ type, results: typeResults }) => {
-              const [featuredResult, ...moreResults] = typeResults;
-
-              return (
-                <section key={type} className="editorial-list-section">
-                  <div className="editorial-list-heading">
-                    <p className="editorial-home-section-label">{typeLabels[type]}</p>
-                    <h2 className="editorial-page-section-title">
-                      {typeResults.length} result{typeResults.length !== 1 ? 's' : ''} in this section.
+        <div className="grid grid-cols-1 gap-16 md:grid-cols-12">
+          <div className="space-y-12 md:col-span-8">
+            {!normalizedQuery ? (
+              <section className="rounded-xl bg-surface-container-highest p-10">
+                <h2 className="mb-4 font-headline text-2xl font-bold text-on-surface">Start with a topic or title.</h2>
+                <p className="mb-6 max-w-2xl font-body text-lg leading-relaxed text-on-surface-variant">
+                  Search across posts, talks, publications, and code notes without leaving the editorial surface.
+                </p>
+                <div className="flex flex-wrap gap-3">
+                  {quickQueries.concat(['forecasting', 'llm']).map((term) => (
+                    <Link
+                      key={term}
+                      href={`/search?q=${encodeURIComponent(term)}`}
+                      className="rounded-full bg-surface px-4 py-2 font-label text-xs font-bold uppercase tracking-widest text-secondary transition-colors hover:bg-surface-container-low hover:text-on-surface"
+                    >
+                      {term}
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            ) : loading ? (
+              <section className="rounded-xl bg-surface-container-highest p-10">
+                <p className="font-headline text-xl font-bold text-on-surface">Searching…</p>
+                <p className="mt-3 font-body text-base text-on-surface-variant">
+                  Gathering results for “{normalizedQuery}”.
+                </p>
+              </section>
+            ) : results.length === 0 ? (
+              <section className="rounded-xl bg-surface-container-highest p-10">
+                <h2 className="font-headline text-2xl font-bold text-on-surface">No results for “{normalizedQuery}”.</h2>
+                <p className="mt-4 max-w-2xl font-body text-lg leading-relaxed text-on-surface-variant">
+                  Try a broader phrase, a specific title fragment, or one of the suggested topics in the sidebar.
+                </p>
+              </section>
+            ) : (
+              groupedResults.map(({ type, results: typeResults }) => (
+                <section key={type}>
+                  <div className="mb-8 flex items-center justify-between">
+                    <h2 className="flex items-center gap-2 font-label text-xs font-bold uppercase tracking-[0.2em] text-secondary">
+                      <span className="h-px w-8 bg-outline-variant" />
+                      {typeLabels[type]}
                     </h2>
+                    <span className="text-xs italic text-secondary">
+                      Showing {typeResults.length} result{typeResults.length === 1 ? '' : 's'}
+                    </span>
                   </div>
 
-                  {featuredResult ? (
-                    <article className="editorial-home-card">
-                      <p className="editorial-home-card-label">{typeLabels[featuredResult.type]}</p>
-                      <h3>
-                        <Link href={featuredResult.url}>{featuredResult.title}</Link>
-                      </h3>
-                      {featuredResult.description && <p>{featuredResult.description}</p>}
-                      <div className="editorial-post-meta">
-                        {featuredResult.date ? (
-                          <span>{formatResultDate(featuredResult.date)}</span>
-                        ) : (
-                          <span>{typeLabels[featuredResult.type]}</span>
-                        )}
-                        <span>{featuredResult.tags?.length ? `${featuredResult.tags.length} tags` : 'No tags listed'}</span>
-                      </div>
-                      <div className="editorial-chip-row">
-                        {featuredResult.tags?.slice(0, 3).map((tag) => (
-                          <span key={tag} className="editorial-chip">
-                            {tag}
-                          </span>
-                        ))}
-                      </div>
-                      <Link href={featuredResult.url} className="editorial-home-card-link">
-                        Open result
-                      </Link>
-                    </article>
-                  ) : null}
-
-                  {moreResults.length > 0 ? (
-                    <article className="editorial-home-card">
-                      <p className="editorial-home-card-label">More {typeLabels[type]}</p>
-                      <ul className="posts-list">
-                        {moreResults.map((result) => (
-                          <li key={`${result.type}-${result.title}`} className="archive-post">
-                            <Link href={result.url}>
-                              <time className="archive-post-date">
-                                {result.date ? formatResultDate(result.date) ?? typeLabels[result.type] : typeLabels[result.type]}
-                              </time>
-                              <span className="archive-post-title">{result.title}</span>
-                            </Link>
-                          </li>
-                        ))}
-                      </ul>
-                    </article>
-                  ) : null}
+                  <div className="space-y-1">
+                    {typeResults.map((result) => (
+                      <article
+                        key={`${result.type}-${result.url}`}
+                        className="-mx-8 rounded-xl p-8 transition-all duration-300 hover:bg-surface-container-low"
+                      >
+                        <Link href={result.url} className="block">
+                          <div className="flex flex-col gap-3">
+                            <div className="flex flex-wrap items-center gap-3">
+                              <span className="rounded bg-primary-fixed px-2 py-0.5 font-label text-[10px] font-bold uppercase tracking-widest text-primary">
+                                {result.type}
+                              </span>
+                              {result.date ? (
+                                <time className="font-label text-xs text-secondary">
+                                  {formatResultDate(result.date)}
+                                </time>
+                              ) : null}
+                            </div>
+                            <h3 className="font-headline text-2xl font-bold tracking-tight text-on-surface transition-colors hover:text-primary">
+                              {result.title}
+                            </h3>
+                            {result.description ? (
+                              <p className="max-w-2xl text-lg leading-relaxed text-on-surface-variant">
+                                {result.description}
+                              </p>
+                            ) : null}
+                            {result.tags && result.tags.length > 0 ? (
+                              <div className="mt-2 flex flex-wrap gap-2">
+                                {result.tags.slice(0, 4).map((tag) => (
+                                  <span
+                                    key={`${result.url}-${tag}`}
+                                    className="rounded-sm bg-surface-container-highest px-2 py-1 font-label text-[10px] font-bold uppercase tracking-widest text-secondary"
+                                  >
+                                    {tag}
+                                  </span>
+                                ))}
+                              </div>
+                            ) : null}
+                          </div>
+                        </Link>
+                      </article>
+                    ))}
+                  </div>
                 </section>
-              );
-            })}
-          </>
-        )}
-      </section>
+              ))
+            )}
+          </div>
+
+          <aside className="space-y-12 md:col-span-4">
+            <div className="rounded-xl bg-surface-container-low p-8">
+              <h2 className="mb-6 font-headline text-lg font-bold">Search Status</h2>
+              <div className="space-y-4">
+                {[
+                  ['Query', normalizedQuery || 'None'],
+                  ['Results', loading ? '…' : `${results.length}`],
+                  ['Sections', `${groupedResults.length}`],
+                ].map(([label, value]) => (
+                  <div key={label} className="flex items-center justify-between border-b border-outline-variant/20 pb-3">
+                    <span className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">{label}</span>
+                    <span className="font-headline text-base font-bold text-on-surface">{value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl bg-surface p-8">
+              <h2 className="mb-4 font-headline text-lg font-bold">Try searching for</h2>
+              <div className="flex flex-wrap gap-2">
+                {quickQueries.concat(['openai', 'python']).map((term) => (
+                  <Link
+                    key={term}
+                    href={`/search?q=${encodeURIComponent(term)}`}
+                    className="rounded-md bg-surface-container-low px-3 py-2 font-label text-xs text-on-surface-variant transition-colors hover:bg-surface-container-high"
+                  >
+                    {term}
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-outline-variant/20 bg-surface p-8">
+              <h2 className="mb-4 font-headline text-lg font-bold">Browse instead</h2>
+              <div className="flex flex-col gap-3">
+                <Link href="/archive" className="font-label text-xs font-bold uppercase tracking-widest text-primary">
+                  Open archive
+                </Link>
+                <Link href="/tags" className="font-label text-xs font-bold uppercase tracking-widest text-primary">
+                  Browse tags
+                </Link>
+                <Link href="/code-ai" className="font-label text-xs font-bold uppercase tracking-widest text-primary">
+                  Code &amp; tools
+                </Link>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </main>
     </EditorialPageFrame>
   );
 }

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { EditorialPageFrame } from '../../components/EditorialPageFrame';
-import { postService } from '../../../services/PostService';
+import { postService } from '../../services/PostService';
 
 interface TagPageProps {
   params: Promise<{
@@ -36,19 +36,35 @@ const groupPostsByYear = (posts: Posts) => {
     }));
 };
 
+function getRelatedTags(posts: Posts, currentTag: string) {
+  const counts = new Map<string, number>();
+
+  posts.forEach((post) => {
+    post.tags
+      .filter((tag) => tag.toLowerCase() !== currentTag.toLowerCase())
+      .forEach((tag) => {
+        counts.set(tag, (counts.get(tag) ?? 0) + 1);
+      });
+  });
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 6);
+}
+
 export async function generateMetadata({ params }: TagPageProps): Promise<Metadata> {
   const { tag: encodedTag } = await params;
   const tag = decodeURIComponent(encodedTag);
 
   return {
-    title: `${tag} | Ben Labaschin`,
+    title: `${tag} | Tags | ECONOBEN.DEV`,
     description: `Browse all posts tagged with "${tag}".`,
   };
 }
 
 export async function generateStaticParams() {
   const tags = await postService.getAllTags();
-  return tags.map((tagData: any) => ({
+  return tags.map((tagData) => ({
     tag: encodeURIComponent(tagData.tag),
   }));
 }
@@ -57,114 +73,147 @@ export default async function TagPage({ params }: TagPageProps) {
   const { tag: encodedTag } = await params;
   const tag = decodeURIComponent(encodedTag);
   const posts = await postService.getPostsByTag(tag);
-  const postsByYear = groupPostsByYear(posts);
-  const featuredPost = posts[0];
 
   if (posts.length === 0) {
     notFound();
   }
 
-  return (
-    <EditorialPageFrame currentPath="/tags" pageClassName="editorial-book-page">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Tag archive</p>
-          <h1 className="editorial-page-title">{tag}</h1>
-          <p className="editorial-page-copy">
-            {posts.length} post{posts.length !== 1 ? 's' : ''} found for this topic, ordered newest first and arranged so the topic reads like a guided trail.
-          </p>
-          <div className="editorial-chip-row">
-            <span className="editorial-chip">{posts.length} posts</span>
-            <span className="editorial-chip">Newest first</span>
-            <span className="editorial-chip">Related tags linked</span>
-          </div>
-        </div>
-        <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">Browse links</p>
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">{posts.length}</span>
-              <span className="editorial-page-metric-label">posts in this tag</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">{postsByYear.length}</span>
-              <span className="editorial-page-metric-label">years represented</span>
-            </div>
-            <div>
-              <Link href="/tags" className="editorial-post-link">
-                Back to tags
-              </Link>
-            </div>
-          </div>
-        </aside>
-      </section>
+  const postsByYear = groupPostsByYear(posts);
+  const [featuredPost, ...remainingPosts] = posts;
+  const relatedTags = getRelatedTags(posts, tag);
 
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Featured match</p>
-          <h2 className="editorial-page-section-title">Start with the newest post, then move through the year-by-year trail.</h2>
-        </div>
-        {featuredPost ? (
-          <article className="editorial-home-card">
-            <p className="editorial-home-card-label">{longDateFormatter.format(featuredPost.date)}</p>
-            <h3>
-              <Link href={`/posts/${featuredPost.slug}`}>{featuredPost.title}</Link>
-            </h3>
-            {featuredPost.summary && <p>{featuredPost.summary}</p>}
-            <div className="editorial-post-meta">
-              <span>{featuredPost.readingTime ? `${featuredPost.readingTime} min read` : `${featuredPost.tags.length} tags`}</span>
-              <span>{featuredPost.tags.length} topic tag{featuredPost.tags.length !== 1 ? 's' : ''}</span>
+  return (
+    <EditorialPageFrame currentPath="/tags">
+      <main className="mx-auto max-w-7xl px-8 py-20">
+        <section className="mb-20">
+          <div className="flex flex-col gap-4">
+            <span className="font-label text-xs font-bold uppercase tracking-[0.2em] text-secondary">Category Archive</span>
+            <h1 className="mb-6 font-headline text-6xl font-black tracking-tighter text-on-surface">{tag}</h1>
+            <div className="max-w-2xl rounded-lg bg-surface-container-low p-8">
+              <p className="text-xl italic leading-relaxed text-on-surface-variant">
+                {posts.length} post{posts.length === 1 ? '' : 's'} collected under this topic, ordered newest first and left fully linked for browsing.
+              </p>
             </div>
-            <div className="editorial-chip-row">
-              {featuredPost.tags.map((postTag) => (
-                <Link key={postTag} href={`/tags/${encodeURIComponent(postTag)}`} className="editorial-chip">
-                  {postTag}
+          </div>
+        </section>
+
+        <section className="grid grid-cols-12 gap-12">
+          <div className="col-span-12 flex flex-col gap-16 md:col-span-8">
+            <article className="rounded-xl bg-surface-container-highest p-10">
+              <div className="mb-6 flex items-center gap-4 font-label text-xs uppercase tracking-widest text-secondary">
+                <span>{longDateFormatter.format(featuredPost.date)}</span>
+                <span className="h-1 w-1 rounded-full bg-outline-variant" />
+                <span>{featuredPost.readingTime ? `${featuredPost.readingTime} min read` : `${featuredPost.tags.length} tags`}</span>
+              </div>
+              <h2 className="mb-4 font-headline text-4xl font-bold tracking-tight text-on-surface">
+                <Link href={`/posts/${featuredPost.slug}`} className="transition-colors hover:text-primary">
+                  {featuredPost.title}
                 </Link>
+              </h2>
+              {featuredPost.summary ? (
+                <p className="max-w-2xl text-lg leading-relaxed text-on-surface-variant">{featuredPost.summary}</p>
+              ) : null}
+              <div className="mt-6 flex flex-wrap gap-2">
+                {featuredPost.tags.map((postTag) => (
+                  <Link
+                    key={postTag}
+                    href={`/tags/${encodeURIComponent(postTag)}`}
+                    className="rounded-sm bg-surface px-3 py-1 font-label text-[10px] font-bold uppercase tracking-widest text-secondary transition-colors hover:bg-surface-container-high hover:text-on-surface"
+                  >
+                    {postTag}
+                  </Link>
+                ))}
+              </div>
+            </article>
+
+            <div className="space-y-12">
+              {remainingPosts.map((post) => (
+                <article key={post.slug} className="border-b border-outline-variant/20 pb-12 last:border-b-0 last:pb-0">
+                  <div className="mb-4 flex items-center gap-4 font-label text-xs uppercase tracking-widest text-secondary">
+                    <span>{longDateFormatter.format(post.date)}</span>
+                    <span className="h-1 w-1 rounded-full bg-outline-variant" />
+                    <span>{post.readingTime ? `${post.readingTime} min read` : `${post.tags.length} tags`}</span>
+                  </div>
+                  <h3 className="font-headline text-3xl font-bold tracking-tight text-on-surface">
+                    <Link href={`/posts/${post.slug}`} className="transition-colors hover:text-primary">
+                      {post.title}
+                    </Link>
+                  </h3>
+                  {post.summary ? (
+                    <p className="mt-4 max-w-2xl text-lg leading-relaxed text-on-surface-variant">
+                      {post.summary}
+                    </p>
+                  ) : null}
+                  <div className="mt-5 flex flex-wrap gap-2">
+                    {post.tags.map((postTag) => (
+                      <Link
+                        key={`${post.slug}-${postTag}`}
+                        href={`/tags/${encodeURIComponent(postTag)}`}
+                        className="rounded-sm bg-surface-container-highest px-3 py-1 font-label text-[10px] font-bold uppercase tracking-widest text-secondary transition-colors hover:bg-secondary-container hover:text-on-secondary-container"
+                      >
+                        {postTag}
+                      </Link>
+                    ))}
+                  </div>
+                </article>
               ))}
             </div>
-            <Link href={`/posts/${featuredPost.slug}`} className="editorial-home-card-link">
-              Read post
-            </Link>
-          </article>
-        ) : null}
-      </section>
+          </div>
 
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">By year</p>
-          <h2 className="editorial-page-section-title">A lighter index that keeps every tagged post visible on mobile.</h2>
-        </div>
-        <div className="editorial-two-column">
-          {postsByYear.map(({ year, posts: yearPosts }) => (
-            <article key={year} className="editorial-home-card">
-              <p className="editorial-home-card-label">Year {year}</p>
-              <h3>{yearPosts.length} post{yearPosts.length !== 1 ? 's' : ''}</h3>
-              <p>Newest first, with titles and summaries kept together so the topic stays scannable.</p>
-              {yearPosts[0] ? (
-                <div>
-                  <p className="editorial-home-card-label">Featured post</p>
-                  <Link href={`/posts/${yearPosts[0].slug}`} className="editorial-home-card-link">
-                    {yearPosts[0].title}
-                  </Link>
-                  {yearPosts[0].summary && <p className="editorial-post-summary">{yearPosts[0].summary}</p>}
-                </div>
-              ) : null}
-              <ul className="posts-list">
-                {yearPosts.slice(1).map((post) => (
-                  <li key={post.slug} className="archive-post">
-                    <Link href={`/posts/${post.slug}`}>
-                      <time className="archive-post-date">
-                        {post.date.getDate().toString().padStart(2, '0')}
-                      </time>
-                      <span className="archive-post-title">{post.title}</span>
-                    </Link>
-                  </li>
+          <aside className="hidden flex-col gap-12 md:col-span-4 md:flex">
+            <div className="flex flex-col gap-6 rounded-xl bg-surface-container p-8">
+              <h3 className="font-headline text-lg font-bold">Topic Snapshot</h3>
+              <div className="space-y-4">
+                {[
+                  ['Posts', `${posts.length}`],
+                  ['Years covered', `${postsByYear.length}`],
+                  ['Related tags', `${relatedTags.length}`],
+                ].map(([label, value]) => (
+                  <div key={label} className="flex items-center justify-between border-b border-outline-variant/20 pb-3">
+                    <span className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">{label}</span>
+                    <span className="font-headline text-lg font-bold text-on-surface">{value}</span>
+                  </div>
                 ))}
-              </ul>
-            </article>
-          ))}
-        </div>
-      </section>
+              </div>
+              <Link href="/tags" className="inline-flex items-center gap-2 font-label text-xs font-bold uppercase tracking-widest text-primary">
+                Back to all tags
+              </Link>
+            </div>
+
+            {relatedTags.length > 0 ? (
+              <div className="flex flex-col gap-6 px-4">
+                <h3 className="font-label text-xs font-bold uppercase tracking-widest text-secondary">Related Tags</h3>
+                <div className="flex flex-wrap gap-2">
+                  {relatedTags.map(([relatedTag, count]) => (
+                    <Link
+                      key={relatedTag}
+                      href={`/tags/${encodeURIComponent(relatedTag)}`}
+                      className="rounded-md bg-surface-container-low px-3 py-2 font-label text-xs text-on-surface-variant transition-colors hover:bg-surface-container-high"
+                    >
+                      {relatedTag} ({count})
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            <div className="rounded-xl bg-surface-container-low p-8">
+              <h3 className="mb-4 font-headline text-lg font-bold text-on-surface">Browse Beyond This Topic</h3>
+              <p className="font-body text-sm leading-relaxed text-on-surface-variant">
+                Switch from this topic trail to the full archive or run a direct search if you want a broader slice of the same material.
+              </p>
+              <div className="mt-6 flex flex-col gap-3">
+                <Link href="/archive" className="font-label text-xs font-bold uppercase tracking-widest text-primary">
+                  Open archive
+                </Link>
+                <Link href={`/search?q=${encodeURIComponent(tag)}`} className="font-label text-xs font-bold uppercase tracking-widest text-primary">
+                  Search this topic
+                </Link>
+              </div>
+            </div>
+          </aside>
+        </section>
+      </main>
     </EditorialPageFrame>
   );
 }

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -4,123 +4,161 @@ import { EditorialPageFrame } from '../components/EditorialPageFrame';
 import { postService } from '../services/PostService';
 
 export const metadata: Metadata = {
-  title: 'Tags | Ben Labaschin',
-  description: 'Browse every topic covered across the writing archive.',
+  title: 'Tags | ECONOBEN.DEV',
+  description: 'Browse topics covered across the writing archive.',
 };
 
 export default async function TagsPage() {
   const posts = await postService.getAllPosts();
+  const allTags = await postService.getAllTags();
+  const sortedTags = [...allTags].sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+  const [primaryTag, secondaryTag, ...remainingTags] = sortedTags;
+  const topTags = sortedTags.slice(0, 8);
 
-  const tagCounts = new Map<string, number>();
-  posts.forEach((post) => {
-    post.tags.forEach((tag) => {
-      tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
-    });
-  });
+  const tagsByLetter = remainingTags.reduce<Record<string, typeof remainingTags>>((acc, tagEntry) => {
+    const letter = tagEntry.tag.charAt(0).toUpperCase();
+    acc[letter] ??= [];
+    acc[letter].push(tagEntry);
+    return acc;
+  }, {});
 
-  const sortedTags = Array.from(tagCounts.entries()).sort((a, b) => b[1] - a[1]);
-  const tagsByLetter = new Map<string, Array<[string, number]>>();
-
-  sortedTags.forEach(([tag, count]) => {
-    const firstLetter = tag[0].toUpperCase();
-    if (!tagsByLetter.has(firstLetter)) {
-      tagsByLetter.set(firstLetter, []);
-    }
-    tagsByLetter.get(firstLetter)!.push([tag, count]);
-  });
-
-  const sortedLetters = Array.from(tagsByLetter.keys()).sort();
-  const topTagCount = sortedTags[0]?.[1] || 0;
-  const topTags = sortedTags.slice(0, 6);
+  const sortedLetters = Object.keys(tagsByLetter).sort();
 
   return (
-    <EditorialPageFrame currentPath="/tags" pageClassName="editorial-book-page">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Topics</p>
-          <h1 className="editorial-page-title">Tags</h1>
-          <p className="editorial-page-copy">
-            Explore topics across {posts.length} posts, with links preserved to every tag-specific archive and the broadest themes surfaced first.
+    <EditorialPageFrame currentPath="/tags">
+      <main className="mx-auto min-h-screen max-w-7xl px-8 py-20">
+        <section className="mb-20 max-w-3xl">
+          <span className="mb-4 block font-label text-xs font-bold uppercase tracking-widest text-secondary">
+            Archive &amp; Taxonomy
+          </span>
+          <h1 className="mb-6 font-headline text-6xl font-black tracking-tight text-on-surface">
+            Topic Index
+          </h1>
+          <p className="text-xl leading-relaxed text-on-surface-variant">
+            Browse the archive by subject, with the most-used topics surfaced first and every tag still linking through to its own post trail.
           </p>
-          <div className="editorial-chip-row">
-            {topTags.map(([tag, count]) => (
-              <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
-                {tag} <span>({count})</span>
-              </Link>
-            ))}
-          </div>
-        </div>
-        <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">Tag index</p>
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">{sortedTags.length}</span>
-              <span className="editorial-page-metric-label">unique tags</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">{topTagCount}</span>
-              <span className="editorial-page-metric-label">posts for the most-used tag</span>
-            </div>
-          </div>
-          <p className="editorial-post-summary">
-            Every tag resolves to its own index, so topic browsing stays one click away from the underlying posts.
-          </p>
-        </aside>
-      </section>
+        </section>
 
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">All tags</p>
-          <h2 className="editorial-page-section-title">A weighted cloud for broad browsing.</h2>
-        </div>
-        <div className="tag-cloud">
-          <div className="tag-cloud-container">
-            {sortedTags.map(([tag, count]) => {
-              const maxCount = topTagCount || 1;
-              const minSize = 0.95;
-              const maxSize = 1.85;
-              const size = minSize + (count / maxCount) * (maxSize - minSize);
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-12">
+          {primaryTag ? (
+            <Link
+              href={`/tags/${encodeURIComponent(primaryTag.tag)}`}
+              className="cursor-pointer rounded-xl bg-surface-container-highest p-10 transition-colors hover:bg-surface-container-high md:col-span-8"
+            >
+              <div className="mb-8 flex items-start justify-between gap-6">
+                <span className="rounded-full bg-primary px-3 py-1 font-label text-xs font-bold text-on-primary">
+                  MOST USED
+                </span>
+                <span className="font-headline text-4xl font-bold text-on-surface">{primaryTag.count}</span>
+              </div>
+              <h2 className="mb-4 font-headline text-4xl font-extrabold transition-colors hover:text-primary">
+                {primaryTag.tag}
+              </h2>
+              <p className="max-w-xl text-lg text-on-surface-variant">
+                The densest topic cluster in the archive, currently spanning {primaryTag.count} post{primaryTag.count === 1 ? '' : 's'}.
+              </p>
+              <div className="mt-12 flex flex-wrap gap-3">
+                {posts
+                  .filter((post) => post.tags.includes(primaryTag.tag))
+                  .slice(0, 4)
+                  .map((post) => (
+                    <span
+                      key={post.slug}
+                      className="rounded bg-secondary-container px-2 py-1 font-label text-[10px] uppercase tracking-tighter text-on-secondary-container"
+                    >
+                      {post.title}
+                    </span>
+                  ))}
+              </div>
+            </Link>
+          ) : null}
 
-              return (
-                <Link
-                  key={tag}
-                  href={`/tags/${encodeURIComponent(tag)}`}
-                  className="tag-cloud-item"
-                  style={{ fontSize: `${size}rem` }}
-                  title={`${count} post${count !== 1 ? 's' : ''}`}
-                >
-                  {tag}
-                </Link>
-              );
-            })}
-          </div>
-        </div>
-      </section>
+          {secondaryTag ? (
+            <Link
+              href={`/tags/${encodeURIComponent(secondaryTag.tag)}`}
+              className="rounded-xl border border-outline-variant/10 bg-surface-container-low p-10 transition-colors hover:bg-surface-container-high md:col-span-4"
+            >
+              <div className="mb-8 flex justify-between">
+                <span className="font-headline text-3xl font-bold text-secondary">{secondaryTag.count}</span>
+              </div>
+              <h2 className="mb-4 font-headline text-3xl font-extrabold text-on-surface">
+                {secondaryTag.tag}
+              </h2>
+              <p className="text-on-surface-variant">
+                Another high-signal topic area that stays one click away from the underlying posts.
+              </p>
+              <span className="mt-8 inline-flex items-center gap-2 font-label text-xs font-bold uppercase tracking-widest text-primary">
+                Explore topic
+              </span>
+            </Link>
+          ) : null}
 
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Alphabetical</p>
-          <h2 className="editorial-page-section-title">The same index, re-sorted for precision.</h2>
-        </div>
-        <div className="tags-alphabetical">
-          {sortedLetters.map((letter) => (
-            <div key={letter} className="letter-group">
-              <h3 className="letter-heading">{letter}</h3>
-              <div className="letter-tags">
-                {tagsByLetter.get(letter)!.map(([tag, count]) => (
+          <div className="mt-12 md:col-span-12">
+            <div className="mb-8 flex flex-col gap-4 border-b border-outline-variant/10 pb-4 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h3 className="font-headline text-xl font-bold text-on-surface">Alphabetical Index</h3>
+                <p className="mt-2 font-body text-sm text-on-surface-variant">
+                  {sortedTags.length} tags across {posts.length} post{posts.length === 1 ? '' : 's'}.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {topTags.map((tagEntry) => (
                   <Link
-                    key={tag}
-                    href={`/tags/${encodeURIComponent(tag)}`}
-                    className="tag-link"
+                    key={tagEntry.tag}
+                    href={`/tags/${encodeURIComponent(tagEntry.tag)}`}
+                    className="rounded-full bg-surface-container-low px-3 py-1.5 font-label text-xs font-semibold text-secondary transition-colors hover:bg-secondary-container hover:text-on-secondary-container"
                   >
-                    {tag} <span className="tag-count">({count})</span>
+                    {tagEntry.tag}
                   </Link>
                 ))}
               </div>
             </div>
-          ))}
+
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+              {sortedLetters.map((letter) => (
+                <section key={letter} className="rounded-xl bg-surface p-6">
+                  <h4 className="mb-4 font-headline text-lg font-bold text-on-surface">{letter}</h4>
+                  <div className="space-y-3">
+                    {tagsByLetter[letter].map((tagEntry) => (
+                      <Link
+                        key={tagEntry.tag}
+                        href={`/tags/${encodeURIComponent(tagEntry.tag)}`}
+                        className="flex items-center justify-between border-b border-outline-variant/10 pb-3 transition-colors hover:text-primary"
+                      >
+                        <span className="font-headline font-semibold text-on-surface">{tagEntry.tag}</span>
+                        <span className="rounded bg-surface-container-highest px-2 py-1 font-label text-xs text-secondary">
+                          {tagEntry.count}
+                        </span>
+                      </Link>
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          </div>
         </div>
-      </section>
+
+        <section className="mx-auto mt-32 max-w-4xl rounded-xl border border-outline-variant/20 bg-surface-container-low p-12 text-center">
+          <h3 className="mb-4 font-headline text-2xl font-bold text-on-surface">Need a broader route in?</h3>
+          <p className="mb-8 font-body text-lg italic text-on-surface-variant">
+            Move from tags into the full archive or search the site directly if you know the subject already.
+          </p>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/archive"
+              className="rounded-md bg-primary-container px-6 py-3 font-label text-xs font-bold uppercase tracking-widest text-on-primary"
+            >
+              Browse archive
+            </Link>
+            <Link
+              href="/search"
+              className="rounded-md border border-outline-variant bg-surface px-6 py-3 font-label text-xs font-bold uppercase tracking-widest text-on-surface transition-colors hover:bg-surface-container-high"
+            >
+              Search site
+            </Link>
+          </div>
+        </section>
+      </main>
     </EditorialPageFrame>
   );
 }


### PR DESCRIPTION
## Context

The first Stitch integration wave established the shared editorial shell and several major route families, but the remaining discovery routes were still rendered in the older practical layout. That left a visible break in the site experience: archive, tags, and search still worked functionally, but they no longer matched the direction the accepted Stitch preview established.

These routes also carry a different risk profile from a purely visual mock translation. They depend on real archive grouping, real tag counts, real tag-detail browsing, and live search grouping across content types. The job here was to carry the accepted visual system into those routes without flattening them into placeholder marketing pages or losing navigation coverage.

This PR ports the discovery-family routes onto the new editorial direction while preserving their existing data behavior. Archive pages still group real posts by month and year, tag pages still derive from the actual post taxonomy, and search still uses the live API-backed query flow and result typing.

Refs #32.

## What changed

- **archive routes**: Rebuilt `/archive` and `/archives/[month]` around the Stitch editorial layout while keeping real chronological grouping, month links, metadata, and post navigation intact.
- **tag routes**: Reworked `/tags` and `/tags/[tag]` into the accepted topic-index style, preserving real tag counts, topic detail browsing, related tags, and post linking.
- **search route**: Restyled `/search` to match the new discovery direction without changing its live query-param flow, API-backed fetch behavior, typed grouping, or browse fallbacks.
- **discovery navigation**: Added route-to-route connective tissue so archive, tags, search, and code/tools remain cross-linked inside the editorial shell.

## Why this matters

Without this slice, the site still jumps between two visual systems as soon as a reader moves from the home or structured pages into discovery flows. That undercuts the point of the Stitch migration because the archive and search routes are core navigation surfaces, not edge pages.

Landing this separately also keeps the migration reviewable. The visual shift is isolated to the discovery family while preserving route behavior, which makes it easier to validate before any broader branch integration.

## Next steps

The remaining second-wave work is to reconcile the rest of the discovery/code-detail family and continue shell-level cleanup where route chrome still diverges from the accepted direction.

## Test plan

- [x] `npm run build`
- [x] Browser QA via Playwright against local `next dev` for `/archive`, `/archives/2026-01`, `/tags`, `/tags/AI`, and `/search?q=memory`
- [ ] Reviewer visual pass against the draft PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
