### PR TITLE
feat(posts): restack reading slice onto shell-home

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -74,8 +74,8 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 
 export default async function PostPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
-  const post = await postService.getPostBySlug(slug);
   const allPosts = await postService.getAllPosts();
+  const post = allPosts.find((item) => item.slug === slug);
 
   if (!post) {
     notFound();

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { EditorialPageFrame } from '../../components/EditorialPageFrame';
@@ -18,6 +18,13 @@ const monthYearFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'long',
 });
 
+type Post = Awaited<ReturnType<typeof postService.getAllPosts>>[number];
+
+const createDescription = (post: Post) => {
+  const content = post.summary || post.content.replace(/\s+/g, ' ').trim();
+  return content.slice(0, 180);
+};
+
 export async function generateStaticParams() {
   const posts = await postService.getAllPosts();
   return posts.map((post) => ({
@@ -31,34 +38,27 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 
   if (!post) {
     return {
-      title: 'Post Not Found | Ben Labaschin',
+      title: 'Post Not Found | ECONOBEN.DEV',
     };
   }
 
-  // Generate OG image URL
-  const imageUrl = post.coverImage
-    ? `https://econoben.dev${post.coverImage}`
-    : (() => {
-        const ogImageParams = new URLSearchParams({
-          title: post.title,
-          date: post.date.toISOString(),
-          tags: post.tags.join(','),
-          ...(post.summary && { summary: post.summary }),
-        });
-        return `https://econoben.dev/api/og?${ogImageParams.toString()}`;
-      })();
-  const description = post.summary || post.content.replace(/\s+/g, ' ').slice(0, 160);
+  const imageUrl = post.coverImage?.startsWith('http')
+    ? post.coverImage
+    : post.coverImage
+      ? `https://econoben.dev${post.coverImage}`
+      : undefined;
+  const description = createDescription(post);
 
   return {
-    title: `${post.title} | Ben Labaschin`,
+    title: `${post.title} | Posts | ECONOBEN.DEV`,
     description,
     openGraph: {
       type: 'article',
       title: post.title,
       description,
       url: `https://econoben.dev/posts/${slug}`,
-      images: [imageUrl],
-      siteName: 'Ben Labaschin',
+      images: imageUrl ? [imageUrl] : undefined,
+      siteName: 'ECONOBEN.DEV',
       publishedTime: post.date.toISOString(),
       authors: ['Benjamin Labaschin'],
       tags: post.tags,
@@ -67,7 +67,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
       card: 'summary_large_image',
       title: post.title,
       description,
-      images: [imageUrl],
+      images: imageUrl ? [imageUrl] : undefined,
     },
   };
 }
@@ -75,6 +75,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 export default async function PostPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const post = await postService.getPostBySlug(slug);
+  const allPosts = await postService.getAllPosts();
 
   if (!post) {
     notFound();
@@ -83,17 +84,22 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
   const primaryTag = post.tags[0];
   const audioUrl = audioManifest[slug as keyof typeof audioManifest];
   const archiveMonth = post.date.toISOString().slice(0, 7);
+  const currentIndex = allPosts.findIndex((item) => item.slug === post.slug);
+  const newerPost = currentIndex > 0 ? allPosts[currentIndex - 1] : undefined;
+  const olderPost = currentIndex >= 0 ? allPosts[currentIndex + 1] : undefined;
 
   return (
     <EditorialPageFrame currentPath="/posts">
       <section className="editorial-page-hero">
         <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">{primaryTag ?? 'Essay'}</p>
+          <p className="editorial-home-kicker">{primaryTag ?? 'Post'}</p>
           <h1 className="editorial-page-title">{post.title}</h1>
           {post.summary && <p className="editorial-page-copy">{post.summary}</p>}
-          <p className="editorial-post-summary">
-            Published {longDateFormatter.format(post.date)}{post.readingTime ? ` · ${post.readingTime} min read` : ''} and filed with the post archive.
-          </p>
+          <div className="editorial-post-meta">
+            <span>Published {longDateFormatter.format(post.date)}</span>
+            <span>{post.readingTime ? `${post.readingTime} min read` : 'Long-form post'}</span>
+            <span>Filed in {monthYearFormatter.format(post.date)}</span>
+          </div>
           <div className="editorial-home-actions">
             <Link href="/posts" className="editorial-home-button editorial-home-button-secondary">
               Back to posts
@@ -120,10 +126,19 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
               <span className="editorial-page-metric-label">reading length</span>
             </div>
             <div>
-              <span className="editorial-page-metric-value">{monthYearFormatter.format(post.date)}</span>
-              <span className="editorial-page-metric-label">filed in</span>
+              <span className="editorial-page-metric-value">{post.tags.length}</span>
+              <span className="editorial-page-metric-label">topics</span>
             </div>
           </div>
+          {audioUrl ? (
+            <AudioPlayer
+              audioUrl={audioUrl}
+              title="Listen to this post"
+              className="post-audio-player"
+            />
+          ) : (
+            <p className="editorial-post-summary">No audio version is available for this post yet.</p>
+          )}
           <div className="editorial-chip-row">
             {post.tags.length > 0
               ? post.tags.map((tag) => (
@@ -133,28 +148,66 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
                 ))
               : <span className="editorial-chip">Essay</span>}
           </div>
+          {post.coverImage ? (
+            <img
+              src={post.coverImage}
+              alt={post.title}
+              className="blog-image"
+            />
+          ) : null}
         </aside>
       </section>
 
-      <section className="editorial-home-proof-strip" aria-label="Post context">
-        <span>{primaryTag ?? 'Essay'}</span>
-        <span>/</span>
-        <span>{monthYearFormatter.format(post.date)}</span>
-        <span>/</span>
-        <span>{post.readingTime ? `${post.readingTime} minute read` : 'long-form note'}</span>
-      </section>
-
       <section className="editorial-list-section">
-        {audioUrl && (
-          <AudioPlayer
-            audioUrl={audioUrl}
-            title="Listen to this post"
-            className="post-audio-player"
-          />
-        )}
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Article</p>
+          <h2 className="editorial-page-section-title">Markdown, links, code blocks, and embedded media stay intact in the reading view.</h2>
+        </div>
 
         <div className="blog-content">
           <MarkdownRenderer content={post.content} />
+        </div>
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Related reading</p>
+          <h2 className="editorial-page-section-title">Move to the adjacent posts in the archive.</h2>
+        </div>
+        <div className="editorial-two-column">
+          {newerPost ? (
+            <article className="editorial-home-card">
+              <p className="editorial-home-card-label">Newer post</p>
+              <h3>
+                <Link href={`/posts/${newerPost.slug}`}>{newerPost.title}</Link>
+              </h3>
+              {newerPost.summary && <p>{newerPost.summary}</p>}
+              <div className="editorial-post-meta">
+                <span>{longDateFormatter.format(newerPost.date)}</span>
+                <span>{newerPost.readingTime ? `${newerPost.readingTime} min read` : 'Long-form post'}</span>
+              </div>
+              <Link href={`/posts/${newerPost.slug}`} className="editorial-home-card-link">
+                Read newer post
+              </Link>
+            </article>
+          ) : null}
+
+          {olderPost ? (
+            <article className="editorial-home-card">
+              <p className="editorial-home-card-label">Older post</p>
+              <h3>
+                <Link href={`/posts/${olderPost.slug}`}>{olderPost.title}</Link>
+              </h3>
+              {olderPost.summary && <p>{olderPost.summary}</p>}
+              <div className="editorial-post-meta">
+                <span>{longDateFormatter.format(olderPost.date)}</span>
+                <span>{olderPost.readingTime ? `${olderPost.readingTime} min read` : 'Long-form post'}</span>
+              </div>
+              <Link href={`/posts/${olderPost.slug}`} className="editorial-home-card-link">
+                Read older post
+              </Link>
+            </article>
+          ) : null}
         </div>
       </section>
     </EditorialPageFrame>

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -1,19 +1,24 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { EditorialPageFrame } from '../components/EditorialPageFrame';
 import { postService } from '../services/PostService';
 
 export const metadata: Metadata = {
-  title: 'Posts | Ben Labaschin',
-  description: 'Posts, field notes, and technical writing on AI systems, memory, engineering practice, and adjacent work.',
+  title: 'Posts | ECONOBEN.DEV',
+  description: 'A chronological archive of essays, reports, and field notes on AI systems, memory, engineering practice, and adjacent work.',
 };
 
 type Posts = Awaited<ReturnType<typeof postService.getAllPosts>>;
 
-const formatter = new Intl.DateTimeFormat('en-US', {
+const shortDateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'short',
   day: 'numeric',
+});
+
+const monthFormatter = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: 'long',
 });
 
 const countTags = (posts: Posts) => {
@@ -26,8 +31,7 @@ const countTags = (posts: Posts) => {
   });
 
   return Array.from(counts.entries())
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 4);
+    .sort((a, b) => b[1] - a[1]);
 };
 
 const groupPostsByYear = (posts: Posts) => {
@@ -51,18 +55,19 @@ const groupPostsByYear = (posts: Posts) => {
 export default async function PostsPage() {
   const posts = await postService.getAllPosts();
   const featuredPost = posts[0];
-  const topTags = countTags(posts);
+  const topTags = countTags(posts).slice(0, 4);
   const postsByYear = groupPostsByYear(posts);
-  const publicationYears = postsByYear.length;
+  const uniqueTagCount = new Set(posts.flatMap((post) => post.tags)).size;
+  const mostRecentMonth = featuredPost ? monthFormatter.format(featuredPost.date) : 'No posts yet';
 
   return (
     <EditorialPageFrame currentPath="/posts">
       <section className="editorial-page-hero">
         <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Writing archive</p>
+          <p className="editorial-home-kicker">Reading archive</p>
           <h1 className="editorial-page-title">Posts</h1>
           <p className="editorial-page-copy">
-            Posts, field notes, and working-throughs on agent memory, AI systems, engineering practice, and the occasional economics detour, arranged so the newest work stays easy to find.
+            A chronological archive of essays, reports, and field notes. Start with the newest post, then move backward by year when you want more context.
           </p>
           <div className="editorial-chip-row">
             {topTags.map(([tag, count]) => (
@@ -73,54 +78,51 @@ export default async function PostsPage() {
           </div>
         </div>
         <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">At a glance</p>
+          <p className="editorial-home-card-label">Archive details</p>
           <div className="editorial-page-metric-list">
             <div>
               <span className="editorial-page-metric-value">{posts.length}</span>
-              <span className="editorial-page-metric-label">posts in the archive</span>
+              <span className="editorial-page-metric-label">posts</span>
             </div>
             <div>
-              <span className="editorial-page-metric-value">{publicationYears}</span>
-              <span className="editorial-page-metric-label">years represented</span>
+              <span className="editorial-page-metric-value">{uniqueTagCount}</span>
+              <span className="editorial-page-metric-label">topics</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">{postsByYear.length}</span>
+              <span className="editorial-page-metric-label">years</span>
             </div>
           </div>
-          {featuredPost && (
-            <p className="editorial-post-summary">
-              Latest: {featuredPost.title} on {formatter.format(featuredPost.date)}.
-            </p>
-          )}
-          {featuredPost && (
+          <p className="editorial-post-summary">
+            Latest month: {mostRecentMonth}
+          </p>
+          {featuredPost ? (
             <Link href={`/posts/${featuredPost.slug}`} className="editorial-home-button editorial-home-button-secondary">
-              Start with the latest post
+              Read the latest post
             </Link>
-          )}
+          ) : null}
         </aside>
       </section>
 
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Latest post</p>
-          <h2 className="editorial-page-section-title">Start with the latest post, then move backward by year.</h2>
+          <p className="editorial-home-section-label">Featured post</p>
+          <h2 className="editorial-page-section-title">The newest post stays up front so you can jump straight into the current thread.</h2>
         </div>
+
         {featuredPost ? (
           <article className="editorial-home-card">
-            <p className="editorial-home-card-label">{formatter.format(featuredPost.date)}</p>
+            <p className="editorial-home-card-label">{shortDateFormatter.format(featuredPost.date)}</p>
             <h3>
               <Link href={`/posts/${featuredPost.slug}`}>{featuredPost.title}</Link>
             </h3>
             {featuredPost.summary && <p>{featuredPost.summary}</p>}
             <div className="editorial-post-meta">
-              {featuredPost.tags[0] ? (
-                <Link href={`/tags/${encodeURIComponent(featuredPost.tags[0])}`} className="editorial-chip">
-                  <span>{featuredPost.tags[0]}</span>
-                </Link>
-              ) : (
-                <span className="editorial-chip">Post</span>
-              )}
-              <span>{featuredPost.readingTime ? `${featuredPost.readingTime} min read` : 'Long-form note'}</span>
+              <span>{featuredPost.readingTime ? `${featuredPost.readingTime} min read` : 'Long-form post'}</span>
+              <span>{featuredPost.tags.length} topic{featuredPost.tags.length === 1 ? '' : 's'}</span>
             </div>
             <div className="editorial-chip-row">
-              {featuredPost.tags.slice(0, 3).map((tag) => (
+              {featuredPost.tags.slice(0, 4).map((tag) => (
                 <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
                   {tag}
                 </Link>
@@ -135,8 +137,8 @@ export default async function PostsPage() {
 
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">By year</p>
-          <h2 className="editorial-page-section-title">A compact index that keeps each year readable on mobile.</h2>
+          <p className="editorial-home-section-label">Archive by year</p>
+          <h2 className="editorial-page-section-title">Browse the rest of the archive in compact yearly groups.</h2>
         </div>
 
         <div className="editorial-two-column">
@@ -144,25 +146,24 @@ export default async function PostsPage() {
             <article key={year} className="editorial-home-card">
               <p className="editorial-home-card-label">Year {year}</p>
               <h3>{yearPosts.length} post{yearPosts.length !== 1 ? 's' : ''}</h3>
-              <p>Newest first, with each post left visible so the archive can be scanned without opening every page.</p>
-              {yearPosts[0] ? (
-                <div>
-                  <p className="editorial-home-card-label">Featured post</p>
-                  <Link href={`/posts/${yearPosts[0].slug}`} className="editorial-home-card-link">
-                    {yearPosts[0].title}
-                  </Link>
-                  {yearPosts[0].summary && <p className="editorial-post-summary">{yearPosts[0].summary}</p>}
-                </div>
-              ) : null}
+              <p>Newest first, with summaries and topics kept visible so the year stays easy to scan.</p>
               <ul className="posts-list">
-                {yearPosts.slice(1).map((post) => (
+                {yearPosts.map((post) => (
                   <li key={post.slug} className="archive-post">
                     <Link href={`/posts/${post.slug}`}>
                       <time className="archive-post-date">
-                        {post.date.getDate().toString().padStart(2, '0')}
+                        {shortDateFormatter.format(post.date)}
                       </time>
                       <span className="archive-post-title">{post.title}</span>
                     </Link>
+                    {post.summary && <p className="editorial-post-summary">{post.summary}</p>}
+                    <div className="editorial-chip-row">
+                      {post.tags.slice(0, 3).map((tag) => (
+                        <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
+                          {tag}
+                        </Link>
+                      ))}
+                    </div>
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Context

This branch replays the reading-specific route changes onto the shell-home base without bringing forward the older shell history from the source worktree. The source reading branch already had the exact two commits we wanted, so this PR ports only those route updates and keeps the stack clean.

This is the successor reading slice for issue #39. It preserves the shell-home integration point and adds the reading-focused posts archive and post detail behavior on top of it.

## What changed

- **app/posts/page.tsx**: Replayed the reading archive layout, archive stats, and year-grouped browsing behavior from the reading slice.
- **app/posts/[slug]/page.tsx**: Replayed the reading post detail route with the reading frame, metadata helpers, and adjacent-reading navigation cleanup.

## Why this matters

Without this replay, the shell-home branch stays intact but the reading experience never lands on top of it. This PR keeps the branch lineage intentional and isolates the reading changes to the two owned route files.

## Test plan

- [x] `npm run build`
- [x] `curl http://localhost:3005/posts`
- [x] `curl http://localhost:3005/posts/into-the-hopper-podcast-spec-driven-development`

Refs #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)