### PR TITLE
feat: port structured route slice

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -14,6 +14,11 @@ const experience = [
     period: '2022 to present',
     summary:
       'Founding engineer on enterprise GenAI and agent systems. I build async LLM infrastructure, retrieval, memory, and internal tools used in customer workflows.',
+    highlights: [
+      'Agent memory and retrieval systems',
+      'Production tooling for enterprise workflows',
+      'Technical writing on AI systems in practice',
+    ],
   },
   {
     role: 'Senior Data Scientist',
@@ -21,43 +26,51 @@ const experience = [
     period: '2021 to 2022',
     summary:
       'Led machine-learning work for Hopper Cloud partnerships and helped build platform systems for travel products and partner workflows.',
+    highlights: [
+      'Cloud partnership workflows',
+      'Travel product experimentation',
+      'Platform ML and analytics',
+    ],
   },
   {
-    role: 'Earlier data science work',
+    role: 'Data Science and economics roles',
     company: 'XPO Logistics, Revantage, Arity',
     period: '2017 to 2021',
     summary:
       'Worked across forecasting, experimentation, optimization, and business-facing ML systems, alongside economics and transportation writing.',
+    highlights: [
+      'Forecasting and optimization',
+      'Business-facing analytics',
+      'Writing across economics and transportation',
+    ],
   },
 ];
 
-const practicalCards = [
+const quickLinks = [
   {
     label: 'Resume',
-    title: 'Download the PDF first.',
-    summary:
-      'This is the fastest way to get the full CV, including work history and the usual contact details.',
     href: '/benjamin_labaschin_resume.pdf',
-    action: 'Download resume',
-    external: true,
+    action: 'Download PDF',
+    note: 'Fastest route to the full CV.',
+    download: true,
   },
   {
-    label: 'Work history',
-    title: 'Recent roles, kept short and readable.',
-    summary:
-      'A practical summary of where I’ve worked and what I’ve spent time building there.',
-    href: '#work-history',
-    action: 'Jump to work history',
-    external: false,
+    label: 'Publications',
+    href: '/publications',
+    action: 'View writing',
+    note: 'Books, reports, and papers.',
+  },
+  {
+    label: 'Talks',
+    href: '/talks',
+    action: 'View sessions',
+    note: 'Recordings and transcripts.',
   },
   {
     label: 'Contact',
-    title: 'Email or LinkedIn if you need to reach me.',
-    summary:
-      'For work, speaking, or writing, those two links are usually the quickest route.',
     href: 'mailto:benjaminlabaschin@gmail.com',
     action: 'Email me',
-    external: true,
+    note: 'Best for work or speaking inquiries.',
   },
 ];
 
@@ -87,127 +100,201 @@ const contactLinks = [
 export default function AboutPage() {
   return (
     <EditorialPageFrame currentPath="/about">
-      <section className="editorial-page-hero editorial-about-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">About / CV</p>
-          <h1 className="editorial-page-title">Ben Labaschin</h1>
-          <p className="editorial-page-copy">
+      <section className="mx-auto grid max-w-7xl grid-cols-1 gap-10 px-8 pb-14 pt-20 lg:grid-cols-12 lg:items-start">
+        <div className="lg:col-span-8">
+          <span className="mb-6 block font-label text-xs font-bold uppercase tracking-[0.2em] text-secondary">About / CV</span>
+          <h1 className="max-w-4xl font-headline text-5xl font-black tracking-tighter text-on-surface md:text-7xl">
+            Ben Labaschin
+          </h1>
+          <p className="mt-6 max-w-3xl font-body text-xl leading-relaxed text-secondary md:text-2xl">
             I build practical AI systems and write about the trade-offs that show up once they have to work in production.
-            If you need the short version, use the resume download or jump straight to the work history below.
+            The page keeps the CV readable, the links obvious, and the story tied to real work.
           </p>
-          <div className="editorial-home-actions">
-            <a href="/benjamin_labaschin_resume.pdf" download className="editorial-home-button editorial-home-button-primary">
+          <div className="mt-8 flex flex-wrap gap-4">
+            <a
+              href="/benjamin_labaschin_resume.pdf"
+              download
+              className="inline-flex items-center justify-center rounded-lg bg-primary-container px-8 py-4 font-label text-xs font-bold uppercase tracking-widest text-on-primary"
+            >
               Download resume
             </a>
-            <a href="#work-history" className="editorial-home-button editorial-home-button-secondary">
+            <a
+              href="#work-history"
+              className="inline-flex items-center justify-center rounded-lg bg-surface-container-high px-8 py-4 font-label text-xs font-bold uppercase tracking-widest text-on-surface"
+            >
               Work history
             </a>
-            <Link href="/publications" className="editorial-home-button editorial-home-button-secondary">
+            <Link
+              href="/publications"
+              className="inline-flex items-center justify-center rounded-lg bg-surface-container-high px-8 py-4 font-label text-xs font-bold uppercase tracking-widest text-on-surface"
+            >
               Publications
             </Link>
           </div>
         </div>
-        <aside className="editorial-page-aside editorial-about-photo-card">
-          <img src="/assets/atlas_and_I.jpg" alt="Ben Labaschin with Atlas" />
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">Principal ML</span>
-              <span className="editorial-page-metric-label">Workhelix and earlier product ML roles</span>
+
+        <aside className="overflow-hidden rounded-2xl bg-surface-container-highest shadow-[0_24px_60px_rgba(29,28,22,0.06)] lg:col-span-4">
+          <img src="/assets/atlas_and_I.jpg" alt="Ben Labaschin with Atlas" className="aspect-square w-full object-cover" />
+          <div className="space-y-4 p-8">
+            <div className="rounded-xl bg-surface-container-low p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Current role</p>
+              <p className="mt-2 font-headline text-lg font-bold text-on-surface">Principal Machine Learning Engineer at Workhelix</p>
             </div>
-            <div>
-              <span className="editorial-page-metric-value">Resume</span>
-              <span className="editorial-page-metric-label">Download the PDF or scan the work history</span>
+            <div className="rounded-xl bg-surface-container-low p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Resume</p>
+              <p className="mt-2 font-headline text-lg font-bold text-on-surface">Download the PDF or scan the work history below</p>
             </div>
-            <div>
-              <span className="editorial-page-metric-value">Contact</span>
-              <span className="editorial-page-metric-label">Email, LinkedIn, GitHub, publications, talks</span>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <StatCard label="Focus" value="AI systems, memory, and applied ML" />
+              <StatCard label="Contact" value="Email, LinkedIn, GitHub, talks" />
             </div>
           </div>
         </aside>
       </section>
 
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Practical summary</p>
-          <h2 className="editorial-page-section-title">What I do, in plain language.</h2>
-        </div>
-        <div className="editorial-two-column">
-          {practicalCards.map((item) => (
-            <article key={item.label} className="editorial-home-card">
-              <p className="editorial-home-card-label">{item.label}</p>
-              <h3>{item.title}</h3>
-              <p>{item.summary}</p>
-              {item.external ? (
-                <a href={item.href} className="editorial-post-link" {...(item.label === 'Resume' ? { download: true } : {})}>
-                  {item.action}
-                </a>
-              ) : (
-                <a href={item.href} className="editorial-post-link">
-                  {item.action}
-                </a>
-              )}
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section id="work-history" className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Work history</p>
-          <h2 className="editorial-page-section-title">Recent roles and the work attached to them.</h2>
-        </div>
-        <div className="editorial-timeline">
-          {experience.map((item) => (
-            <article key={`${item.company}-${item.role}`} className="editorial-timeline-item">
-              <div className="editorial-post-meta">
-                <span>{item.company}</span>
-                <span>{item.period}</span>
-              </div>
-              <h3>{item.role}</h3>
-              <p className="editorial-post-summary">{item.summary}</p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Useful links</p>
-          <h2 className="editorial-page-section-title">The rest of the profile, without hunting around the site.</h2>
-        </div>
-        <div className="editorial-two-column">
-          <article className="editorial-home-card">
-            <p className="editorial-home-card-label">Contact</p>
-            <h3>Reach out directly.</h3>
-            <p>Email works best. GitHub and LinkedIn are here if that is easier.</p>
-            <div className="editorial-link-row">
-              {contactLinks.slice(0, 3).map((link) => (
-                <a
-                  key={link.label}
-                  href={link.href}
-                  className="editorial-post-link"
-                  target={link.href.startsWith('http') ? '_blank' : undefined}
-                  rel={link.href.startsWith('http') ? 'noreferrer noopener' : undefined}
-                >
-                  {link.label}
-                </a>
+      <section className="mx-auto max-w-7xl px-8 pb-16">
+        <div className="grid gap-8 lg:grid-cols-12">
+          <article className="rounded-2xl bg-surface-container-low p-8 lg:col-span-7">
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">What I do</p>
+            <h2 className="mt-4 font-headline text-3xl font-bold tracking-tight text-on-surface">Practical summary.</h2>
+            <p className="mt-4 max-w-2xl font-body text-lg leading-relaxed text-secondary">
+              The work is usually some mix of agent memory, retrieval, evaluation, and the plumbing needed to make AI systems
+              usable for actual teams. I write because the implementation details matter.
+            </p>
+            <div className="mt-8 grid gap-4 sm:grid-cols-2">
+              {quickLinks.map((item) => (
+                <div key={item.label} className="rounded-xl bg-surface-container-highest p-5">
+                  <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">{item.label}</p>
+                  <p className="mt-2 font-headline text-lg font-bold text-on-surface">{item.note}</p>
+                  {item.download || item.href.startsWith('http') || item.href.startsWith('mailto:') ? (
+                    <a
+                      href={item.href}
+                      className="mt-4 inline-flex items-center justify-center rounded-lg bg-on-surface px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-surface"
+                      target={item.href.startsWith('http') ? '_blank' : undefined}
+                      rel={item.href.startsWith('http') ? 'noreferrer noopener' : undefined}
+                      download={item.download ? true : undefined}
+                    >
+                      {item.action}
+                    </a>
+                  ) : (
+                    <Link
+                      href={item.href}
+                      className="mt-4 inline-flex items-center justify-center rounded-lg bg-on-surface px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-surface"
+                    >
+                      {item.action}
+                    </Link>
+                  )}
+                </div>
               ))}
             </div>
           </article>
-          <article className="editorial-home-card">
-            <p className="editorial-home-card-label">More context</p>
-            <h3>Publications and talks.</h3>
-            <p>If you want the longer version of the profile, those pages show the writing and speaking side of the work.</p>
-            <div className="editorial-link-row">
-              {contactLinks.slice(3).map((link) => (
-                <Link key={link.label} href={link.href} className="editorial-post-link">
-                  {link.label}
+
+          <aside className="rounded-2xl bg-surface-container-low p-8 lg:col-span-5">
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">Contact</p>
+            <h2 className="mt-4 font-headline text-3xl font-bold tracking-tight text-on-surface">Reach out directly.</h2>
+            <p className="mt-4 font-body text-lg leading-relaxed text-secondary">
+              Email is usually the fastest path. GitHub and LinkedIn are here if that is easier.
+            </p>
+            <div className="mt-8 grid gap-3 sm:grid-cols-2">
+              {contactLinks.map((link) => {
+                const isExternal = link.href.startsWith('http') || link.href.startsWith('mailto:');
+
+                return isExternal ? (
+                  <a
+                    key={link.label}
+                    href={link.href}
+                    target={link.href.startsWith('http') ? '_blank' : undefined}
+                    rel={link.href.startsWith('http') ? 'noreferrer noopener' : undefined}
+                    className="rounded-xl bg-surface-container-highest px-4 py-4 font-label text-xs font-bold uppercase tracking-widest text-secondary transition-colors hover:bg-secondary-container hover:text-primary"
+                  >
+                    {link.label}
+                  </a>
+                ) : (
+                  <Link
+                    key={link.label}
+                    href={link.href}
+                    className="rounded-xl bg-surface-container-highest px-4 py-4 font-label text-xs font-bold uppercase tracking-widest text-secondary transition-colors hover:bg-secondary-container hover:text-primary"
+                  >
+                    {link.label}
+                  </Link>
+                );
+              })}
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-8 pb-16" id="work-history">
+        <div className="mb-8 grid gap-4 lg:grid-cols-12 lg:items-end">
+          <div className="lg:col-span-8">
+            <p className="font-label text-xs font-bold uppercase tracking-[0.2em] text-secondary">Work history</p>
+            <h2 className="mt-3 font-headline text-3xl font-bold tracking-tight text-on-surface">
+              Recent roles and the work attached to them.
+            </h2>
+          </div>
+          <div className="lg:col-span-4 lg:text-right">
+            <p className="font-body text-base italic text-secondary">Kept short enough to scan, but specific enough to be useful.</p>
+          </div>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-12">
+          <div className="lg:col-span-8">
+            <div className="space-y-8">
+              {experience.map((item) => (
+                <article key={`${item.company}-${item.role}`} className="rounded-2xl bg-surface-container-highest p-8">
+                  <div className="flex flex-col gap-4 border-b border-outline-variant/20 pb-6 md:flex-row md:items-baseline md:justify-between">
+                    <div>
+                      <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary">{item.company}</p>
+                      <h3 className="mt-2 font-headline text-2xl font-bold tracking-tight text-on-surface">{item.role}</h3>
+                    </div>
+                    <span className="font-label text-[10px] uppercase tracking-widest text-secondary">{item.period}</span>
+                  </div>
+                  <p className="mt-6 font-body text-lg leading-relaxed text-secondary">{item.summary}</p>
+                  <div className="mt-6 flex flex-wrap gap-2">
+                    {item.highlights.map((highlight) => (
+                      <span key={highlight} className="rounded-full bg-surface-container-low px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
+                        {highlight}
+                      </span>
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <aside className="space-y-6 lg:col-span-4">
+            <div className="rounded-2xl bg-surface-container-low p-8">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">Why this page exists</p>
+              <p className="mt-4 font-body text-lg leading-relaxed text-secondary">
+                The goal here is utility: quick contact paths, a readable CV, and enough context to understand what I work on.
+              </p>
+            </div>
+            <div className="rounded-2xl bg-surface-container-low p-8">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">Useful links</p>
+              <div className="mt-4 flex flex-wrap gap-3">
+                <Link href="/talks" className="rounded-full bg-surface-container-high px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-secondary">
+                  Talks
                 </Link>
-              ))}
+                <Link href="/publications" className="rounded-full bg-surface-container-high px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-secondary">
+                  Publications
+                </Link>
+                <a href="mailto:benjaminlabaschin@gmail.com" className="rounded-full bg-surface-container-high px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-secondary">
+                  Email
+                </a>
+              </div>
             </div>
-          </article>
+          </aside>
         </div>
       </section>
     </EditorialPageFrame>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl bg-surface-container-highest p-4">
+      <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">{label}</p>
+      <p className="mt-2 font-headline text-lg font-bold leading-tight text-on-surface">{value}</p>
+    </div>
   );
 }

--- a/app/publications/page.tsx
+++ b/app/publications/page.tsx
@@ -8,10 +8,12 @@ export const metadata: Metadata = {
 };
 
 export default function PublicationsPage() {
-  const { publications } = publicationsConfig;
+  const { publications, subtitle } = publicationsConfig;
   const sortedPublications = [...publications].sort(
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
   );
+  const featuredPublication =
+    sortedPublications.find((publication) => publication.featured) ?? sortedPublications[0];
   const publicationsByYear = sortedPublications.reduce<Record<number, Publication[]>>((groups, publication) => {
     if (!groups[publication.year]) {
       groups[publication.year] = [];
@@ -37,86 +39,198 @@ export default function PublicationsPage() {
       other: 0,
     }
   );
-  const latestPublication = sortedPublications[0];
-  const summaryItems = [
-    publicationTypeCounts.book > 0 ? `${publicationTypeCounts.book} books` : null,
-    publicationTypeCounts.journal > 0 ? `${publicationTypeCounts.journal} journal article${publicationTypeCounts.journal > 1 ? 's' : ''}` : null,
-    publicationTypeCounts.report > 0 ? `${publicationTypeCounts.report} reports` : null,
-    publicationTypeCounts.conference > 0 ? `${publicationTypeCounts.conference} conference paper${publicationTypeCounts.conference > 1 ? 's' : ''}` : null,
-    publicationTypeCounts.workshop > 0 ? `${publicationTypeCounts.workshop} workshop paper${publicationTypeCounts.workshop > 1 ? 's' : ''}` : null,
-    publicationTypeCounts.other > 0 ? `${publicationTypeCounts.other} other pieces` : null,
-  ].filter((item): item is string => Boolean(item));
 
   return (
     <EditorialPageFrame currentPath="/publications">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Writing</p>
-          <h1 className="editorial-page-title">Publications</h1>
-          <p className="editorial-page-copy">
-            Books, reports, and papers, newest first.
+      <section className="mx-auto grid max-w-7xl grid-cols-1 gap-10 px-8 pb-12 pt-20 lg:grid-cols-12 lg:items-end">
+        <div className="lg:col-span-8">
+          <span className="mb-6 block font-label text-xs font-bold uppercase tracking-[0.2em] text-secondary">
+            Archive and research
+          </span>
+          <h1 className="max-w-4xl font-headline text-5xl font-black tracking-tighter text-on-surface md:text-7xl">
+            Publications
+          </h1>
+          <p className="mt-6 max-w-3xl font-body text-xl leading-relaxed text-secondary md:text-2xl">
+            {subtitle}
           </p>
-          <div className="editorial-chip-row">
-            <span className="editorial-chip">Books</span>
-            <span className="editorial-chip">Papers</span>
-            <span className="editorial-chip">Reports</span>
-            <span className="editorial-chip">PDFs</span>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <span className="rounded-full bg-surface-container-low px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider text-secondary">
+              Books
+            </span>
+            <span className="rounded-full bg-surface-container-low px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider text-secondary">
+              Papers
+            </span>
+            <span className="rounded-full bg-surface-container-low px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider text-secondary">
+              Reports
+            </span>
+            <span className="rounded-full bg-surface-container-low px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider text-secondary">
+              PDFs and DOI records
+            </span>
           </div>
         </div>
-        <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">Quick access</p>
-          <p className="editorial-post-summary">
-            Jump by year or open the newest publication directly.
-          </p>
-          {latestPublication && (
-            <a href={getPublicationHref(latestPublication)} target="_blank" rel="noopener noreferrer" className="editorial-post-link">
-              Open latest: {latestPublication.title}
-            </a>
-          )}
-          <div className="editorial-chip-row" style={{ marginTop: '16px' }}>
-            {publicationYears.map((year) => (
-              <a key={year} href={`#publication-year-${year}`} className="editorial-chip" style={{ textDecoration: 'none' }}>
-                {year}
-              </a>
-            ))}
+
+        <aside className="rounded-2xl bg-surface-container-low p-8 lg:col-span-4">
+          <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">Quick access</p>
+          <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-1">
+            <div className="rounded-xl bg-surface-container-highest p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Entries</p>
+              <p className="mt-2 font-headline text-3xl font-bold text-on-surface">{publications.length}</p>
+            </div>
+            <div className="rounded-xl bg-surface-container-highest p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Books</p>
+              <p className="mt-2 font-headline text-3xl font-bold text-on-surface">{publicationTypeCounts.book}</p>
+            </div>
           </div>
-          <div style={{ display: 'grid', gap: '10px', marginTop: '18px' }}>
-            {sortedPublications.slice(0, 3).map((publication) => (
-              <a
-                key={publication.id}
-                href={`#${publication.id}`}
-                className="editorial-post-link"
-                style={{ marginTop: 0 }}
-              >
-                {formatPublicationDate(publication.date)} · {publication.title}
-              </a>
-            ))}
+          <div className="mt-6 space-y-3 border-t border-outline-variant/30 pt-6">
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary">Featured publication</p>
+            {featuredPublication && (
+              <>
+                <p className="font-headline text-xl font-bold leading-snug text-on-surface">{featuredPublication.title}</p>
+                <p className="font-body text-sm leading-relaxed text-secondary">{featuredPublication.venue ?? featuredPublication.authors}</p>
+              </>
+            )}
           </div>
         </aside>
       </section>
 
-      <section className="editorial-home-proof-strip" aria-label="Publications summary">
-        <span>{publications.length} publications</span>
-        <span>/</span>
-        <span>{summaryItems[0] ?? 'books'}</span>
-        <span>/</span>
-        <span>{summaryItems[1] ?? 'journal articles'}</span>
-        <span>/</span>
-        <span>{summaryItems[2] ?? 'reports'}</span>
+      {featuredPublication && (
+        <section className="mx-auto grid max-w-7xl grid-cols-1 gap-8 px-8 pb-8 lg:grid-cols-12">
+          <article className="overflow-hidden rounded-2xl bg-surface-container-highest shadow-[0_24px_60px_rgba(29,28,22,0.06)] lg:col-span-8">
+            <div className="grid gap-0 lg:grid-cols-[minmax(0,0.95fr)_minmax(320px,1.05fr)]">
+              <div className="bg-surface-container-low p-10">
+                {featuredPublication.coverImage ? (
+                  <img
+                    src={featuredPublication.coverImage}
+                    alt={featuredPublication.title}
+                    className="aspect-[4/5] w-full rounded-xl object-cover shadow-xl"
+                  />
+                ) : (
+                  <div className="flex aspect-[4/5] w-full items-center justify-center rounded-xl bg-[linear-gradient(135deg,_#1d1c16,_#32302a)] p-8 text-[#fef9ef]">
+                    <div className="max-w-xs space-y-3 text-center">
+                      <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary-fixed-dim">Featured</p>
+                      <p className="font-headline text-3xl font-bold leading-tight">{featuredPublication.title}</p>
+                    </div>
+                  </div>
+                )}
+              </div>
+              <div className="flex flex-col justify-between p-8 lg:p-10">
+                <div className="space-y-6">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <span className="rounded-sm bg-secondary-fixed-dim px-3 py-1 font-label text-[10px] font-bold uppercase tracking-[0.2em] text-on-secondary-fixed-variant">
+                      Featured work
+                    </span>
+                    <span className="font-label text-xs uppercase tracking-widest text-secondary">{formatPublicationDate(featuredPublication.date)}</span>
+                  </div>
+                  <div className="space-y-4">
+                    <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary">
+                      {getPublicationType(featuredPublication)}
+                    </p>
+                    <h2 className="max-w-2xl font-headline text-3xl font-bold tracking-tight text-on-surface lg:text-4xl">
+                      {featuredPublication.title}
+                    </h2>
+                    <p className="max-w-2xl font-body text-lg leading-relaxed text-secondary">
+                      {featuredPublication.abstract}
+                    </p>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <MetaCard label="Authors" value={featuredPublication.authors} />
+                    <MetaCard label="Venue" value={featuredPublication.venue ?? 'Unspecified'} />
+                    <MetaCard label="Year" value={String(featuredPublication.year)} />
+                    <MetaCard label="Topics" value={featuredPublication.topics.slice(0, 4).join(', ')} />
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {featuredPublication.topics.slice(0, 6).map((topic) => (
+                      <span key={topic} className="rounded-full bg-surface-container-low px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
+                        {topic}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <div className="mt-8 flex flex-wrap gap-3">
+                  {(() => {
+                    const href = getPublicationHref(featuredPublication);
+
+                    if (!href) {
+                      return null;
+                    }
+
+                    return (
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center justify-center rounded-lg bg-primary-container px-5 py-3 font-label text-xs font-bold uppercase tracking-widest text-on-primary"
+                      >
+                        {getPublicationActionLabel(featuredPublication)}
+                      </a>
+                    );
+                  })()}
+                  {featuredPublication.bibtex && (
+                    <a
+                      href={`data:text/plain;charset=utf-8,${encodeURIComponent(featuredPublication.bibtex)}`}
+                      download={`${featuredPublication.id}.bib`}
+                      className="inline-flex items-center justify-center rounded-lg bg-surface-container-low px-5 py-3 font-label text-xs font-bold uppercase tracking-widest text-on-surface"
+                    >
+                      Download BibTeX
+                    </a>
+                  )}
+                </div>
+              </div>
+            </div>
+          </article>
+
+          <aside className="flex flex-col gap-4 rounded-2xl bg-surface-container-low p-8 lg:col-span-4">
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">Index</p>
+            {publicationYears.map((year) => (
+              <a
+                key={year}
+                href={`#publication-year-${year}`}
+                className="flex items-center justify-between rounded-xl bg-surface-container-highest px-4 py-3 transition-colors hover:bg-secondary-container hover:text-primary"
+              >
+                <span className="font-headline text-base font-bold text-on-surface">{year}</span>
+                <span className="font-label text-[10px] font-bold uppercase tracking-widest text-secondary">
+                  {publicationsByYear[year].length} items
+                </span>
+              </a>
+            ))}
+          </aside>
+        </section>
+      )}
+
+      <section className="mx-auto grid max-w-7xl grid-cols-1 gap-10 px-8 pb-16 lg:grid-cols-12">
+        <div className="rounded-2xl bg-surface-container-low p-8 lg:col-span-12">
+          <div className="flex flex-wrap items-center gap-4 text-xs font-bold uppercase tracking-widest text-secondary">
+            <span>{publications.length} publications</span>
+            <span className="h-1 w-1 rounded-full bg-outline-variant" />
+            <span>{publicationTypeCounts.book} books</span>
+            <span className="h-1 w-1 rounded-full bg-outline-variant" />
+            <span>{publicationTypeCounts.journal} journal articles</span>
+            <span className="h-1 w-1 rounded-full bg-outline-variant" />
+            <span>{publicationTypeCounts.report} reports</span>
+          </div>
+        </div>
       </section>
 
       {publicationYears.map((year) => {
         const yearPublications = publicationsByYear[year];
 
         return (
-          <section key={year} className="editorial-list-section" id={`publication-year-${year}`}>
-            <div className="editorial-list-heading">
-              <p className="editorial-home-section-label">{year}</p>
-              <h2 className="editorial-page-section-title">Publications from {year}.</h2>
+          <section key={year} className="mx-auto max-w-7xl px-8 pb-16" id={`publication-year-${year}`}>
+            <div className="mb-8 grid gap-4 lg:grid-cols-12 lg:items-end">
+              <div className="lg:col-span-8">
+                <p className="font-label text-xs font-bold uppercase tracking-[0.2em] text-secondary">{year}</p>
+                <h2 className="mt-3 font-headline text-3xl font-bold tracking-tight text-on-surface">
+                  Publications from {year}
+                </h2>
+              </div>
+              <div className="lg:col-span-4 lg:text-right">
+                <p className="font-body text-base italic text-secondary">{yearPublications.length} item{yearPublications.length === 1 ? '' : 's'} in this section</p>
+              </div>
             </div>
-            <div className="editorial-timeline">
+
+            <div className="grid gap-8 md:grid-cols-2 xl:grid-cols-3">
               {yearPublications.map((publication) => (
-                <PublicationEntry key={publication.id} publication={publication} />
+                <PublicationCard key={publication.id} publication={publication} />
               ))}
             </div>
           </section>
@@ -168,10 +282,19 @@ function getPublicationActionLabel(publication: Publication) {
     return 'View DOI record';
   }
 
-  return undefined;
+  return 'Open record';
 }
 
-function PublicationEntry({
+function MetaCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl bg-surface-container-low p-4">
+      <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">{label}</p>
+      <p className="mt-2 font-body text-sm leading-relaxed text-on-surface">{value}</p>
+    </div>
+  );
+}
+
+function PublicationCard({
   publication,
 }: {
   publication: Publication;
@@ -180,30 +303,63 @@ function PublicationEntry({
   const actionLabel = getPublicationActionLabel(publication);
 
   return (
-    <article id={publication.id} className="editorial-timeline-item">
-      <div className="editorial-post-meta">
-        <span>{getPublicationType(publication)}</span>
-        <span>{formatPublicationDate(publication.date)}</span>
-      </div>
-
-      <h3>{publication.title}</h3>
-      <p className="editorial-publication-authors">{publication.authors}</p>
-      {publication.venue && <p className="editorial-publication-venue">{publication.venue}</p>}
-      {publication.abstract && <p className="editorial-post-summary">{publication.abstract}</p>}
-
-      <div className="editorial-chip-row">
-        {publication.topics.slice(0, 4).map((topic) => (
-          <span key={topic} className="editorial-chip">
-            {topic}
-          </span>
-        ))}
-      </div>
-
-      {actionHref && actionLabel && (
-        <a href={actionHref} target="_blank" rel="noopener noreferrer" className="editorial-post-link">
-          {actionLabel}
-        </a>
+    <article
+      id={publication.id}
+      className="group flex h-full flex-col overflow-hidden rounded-2xl bg-surface-container-highest shadow-[0_18px_50px_rgba(29,28,22,0.04)] transition-transform duration-300 hover:-translate-y-1"
+    >
+      {publication.coverImage ? (
+        <div className="aspect-[4/3] overflow-hidden bg-surface-container-low">
+          <img
+            src={publication.coverImage}
+            alt={publication.title}
+            className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
+          />
+        </div>
+      ) : (
+        <div className="flex aspect-[4/3] items-center justify-center bg-[radial-gradient(circle_at_top_left,_rgba(180,197,255,0.45),_transparent_30%),linear-gradient(135deg,_#1d1c16,_#32302a)] p-8 text-[#fef9ef]">
+          <div className="max-w-xs space-y-3 text-center">
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary-fixed-dim">Publication</p>
+            <h3 className="font-headline text-2xl font-bold leading-tight">{publication.title}</h3>
+          </div>
+        </div>
       )}
+
+      <div className="flex flex-1 flex-col space-y-4 p-8">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary">{getPublicationType(publication)}</p>
+            <h3 className="mt-2 font-headline text-2xl font-bold leading-snug text-on-surface transition-colors group-hover:text-primary">
+              {publication.title}
+            </h3>
+          </div>
+          <time className="shrink-0 font-label text-[10px] uppercase tracking-widest text-secondary">
+            {formatPublicationDate(publication.date)}
+          </time>
+        </div>
+
+        <p className="font-body text-sm leading-relaxed text-secondary">{publication.authors}</p>
+        {publication.venue && <p className="font-label text-[11px] font-bold uppercase tracking-widest text-secondary">{publication.venue}</p>}
+        {publication.abstract && <p className="font-body text-base leading-relaxed text-on-surface-variant">{publication.abstract}</p>}
+
+        <div className="mt-auto flex flex-wrap gap-2 pt-2">
+          {publication.topics.slice(0, 4).map((topic) => (
+            <span key={topic} className="rounded-full bg-surface-container-low px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
+              {topic}
+            </span>
+          ))}
+        </div>
+
+        {actionHref && (
+          <a
+            href={actionHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center justify-center rounded-lg bg-surface-container-low px-4 py-3 font-label text-[11px] font-bold uppercase tracking-widest text-on-surface transition-colors hover:bg-secondary-container hover:text-primary"
+          >
+            {actionLabel}
+          </a>
+        )}
+      </div>
     </article>
   );
 }

--- a/app/talks/TalksClient.tsx
+++ b/app/talks/TalksClient.tsx
@@ -17,7 +17,7 @@ const getYouTubeUrl = (talk: Talk): string | null => {
 
 const getYouTubeEmbedUrl = (talk: Talk): string | null => {
   if (!talk.youtubeId) return null;
-  return `https://www.youtube.com/embed/${talk.youtubeId}?autoplay=1`;
+  return `https://www.youtube.com/embed/${talk.youtubeId}`;
 };
 
 const getSpotifyEmbedUrl = (talk: Talk): string | null => {
@@ -29,6 +29,14 @@ const getSpotifyEmbedUrl = (talk: Talk): string | null => {
   return `https://open.spotify.com/embed/episode/${match[1]}?utm_source=generator&theme=0`;
 };
 
+const getPrimarySourceLabel = (talk: Talk): string => {
+  if (talk.spotifyUrl && !talk.youtubeId) {
+    return 'Listen on Spotify';
+  }
+
+  return 'Watch on YouTube';
+};
+
 const getPrimaryActionLabel = (talk: Talk): string => {
   if (talk.spotifyUrl && !talk.youtubeId) {
     return 'Open player';
@@ -37,13 +45,169 @@ const getPrimaryActionLabel = (talk: Talk): string => {
   return 'Play in page';
 };
 
-const getPrimarySourceLabel = (talk: Talk): string => {
-  if (talk.spotifyUrl && !talk.youtubeId) {
-    return 'Listen on Spotify';
+const getPrimarySourceUrl = (talk: Talk): string | null => talk.spotifyUrl ?? getYouTubeUrl(talk);
+
+function TalkMediaPreview({
+  talk,
+  isOpen,
+  onOpen,
+}: {
+  talk: Talk;
+  isOpen: boolean;
+  onOpen: () => void;
+}) {
+  const spotifyEmbedUrl = getSpotifyEmbedUrl(talk);
+  const youtubeEmbedUrl = getYouTubeEmbedUrl(talk);
+  const isSpotifyOnly = Boolean(talk.spotifyUrl && !talk.youtubeId);
+
+  if (isOpen && isSpotifyOnly && spotifyEmbedUrl) {
+    return (
+      <iframe
+        src={spotifyEmbedUrl}
+        title={talk.title}
+        frameBorder="0"
+        sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-presentation"
+        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+        allowFullScreen
+        referrerPolicy="strict-origin-when-cross-origin"
+        loading="lazy"
+        className="h-full w-full"
+      />
+    );
   }
 
-  return 'Watch on YouTube';
-};
+  if (isOpen && youtubeEmbedUrl) {
+    return (
+      <iframe
+        src={youtubeEmbedUrl}
+        title={talk.title}
+        frameBorder="0"
+        sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-presentation"
+        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+        referrerPolicy="strict-origin-when-cross-origin"
+        loading="lazy"
+        className="h-full w-full"
+      />
+    );
+  }
+
+  if (talk.youtubeId) {
+    return (
+      <button
+        type="button"
+        onClick={onOpen}
+        className="group relative block h-full w-full overflow-hidden text-left"
+        aria-label={`Open ${talk.title} in the inline player`}
+      >
+        <img
+          src={`https://img.youtube.com/vi/${talk.youtubeId}/hqdefault.jpg`}
+          alt={talk.title}
+          className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-on-surface/40 via-transparent to-transparent" />
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary-container text-on-primary shadow-xl transition-transform duration-300 group-hover:scale-105">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-7 w-7">
+              <path d="M8 5v14l11-7z" />
+            </svg>
+          </div>
+        </div>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex h-full w-full items-center justify-center bg-[radial-gradient(circle_at_top_left,_rgba(180,197,255,0.45),_transparent_34%),linear-gradient(135deg,_#1d1c16,_#32302a)] text-left"
+      aria-label={`Open ${talk.title} in the inline player`}
+    >
+      <div className="space-y-3 p-10 text-[#fef9ef]">
+        <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary-fixed-dim">Recording</p>
+        <p className="max-w-sm font-headline text-2xl font-bold leading-tight">{talk.event}</p>
+        <p className="max-w-sm font-body text-lg text-[#e7e2d8]">Open this session in the inline player or jump straight to the source.</p>
+        <span className="inline-flex items-center gap-2 rounded-full bg-[#fef9ef]/10 px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest">
+          Open player
+        </span>
+      </div>
+    </button>
+  );
+}
+
+function FeaturedTalk({
+  talk,
+  isOpen,
+  onOpen,
+}: {
+  talk: Talk;
+  isOpen: boolean;
+  onOpen: () => void;
+}) {
+  const primarySourceUrl = getPrimarySourceUrl(talk);
+
+  return (
+    <article className="overflow-hidden rounded-2xl bg-surface-container-highest shadow-[0_24px_60px_rgba(29,28,22,0.06)]">
+      <div className="grid h-full gap-0 lg:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
+        <div className="min-h-[340px] bg-surface-container-low">
+          <TalkMediaPreview talk={talk} isOpen={isOpen} onOpen={onOpen} />
+        </div>
+        <div className="flex flex-col justify-between p-8 lg:p-10">
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="rounded-sm bg-secondary-fixed-dim px-3 py-1 font-label text-[10px] font-bold uppercase tracking-[0.2em] text-on-secondary-fixed-variant">
+                Featured recording
+              </span>
+              <span className="font-label text-xs uppercase tracking-widest text-secondary">{formatDate(talk.date)}</span>
+            </div>
+            <div className="space-y-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary">{talk.event}</p>
+              <h2 className="max-w-xl font-headline text-3xl font-bold tracking-tight text-on-surface lg:text-4xl">{talk.title}</h2>
+              <p className="max-w-xl font-body text-lg leading-relaxed text-secondary">{talk.description}</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {talk.topics.slice(0, 6).map((topic) => (
+                <span key={topic} className="rounded-full bg-surface-container-low px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
+                  {topic}
+                </span>
+              ))}
+            </div>
+          </div>
+          <div className="mt-8 flex flex-wrap gap-3">
+            {primarySourceUrl && (
+              <a
+                href={primarySourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center rounded-lg bg-primary-container px-5 py-3 font-label text-xs font-bold uppercase tracking-widest text-on-primary"
+              >
+                {getPrimarySourceLabel(talk)}
+              </a>
+            )}
+            {talk.transcriptUrl && (
+              <a
+                href={talk.transcriptUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center rounded-lg bg-surface-container-low px-5 py-3 font-label text-xs font-bold uppercase tracking-widest text-on-surface"
+              >
+                Read transcript
+              </a>
+            )}
+            <button
+              type="button"
+              onClick={onOpen}
+              className="inline-flex items-center justify-center rounded-lg bg-on-surface px-5 py-3 font-label text-xs font-bold uppercase tracking-widest text-surface"
+            >
+              {getPrimaryActionLabel(talk)}
+            </button>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
 
 function TalkCard({
   talk,
@@ -56,130 +220,108 @@ function TalkCard({
   isOpen: boolean;
   onOpen: () => void;
 }) {
-  const [isHovered, setIsHovered] = useState(false);
   const spotifyEmbedUrl = getSpotifyEmbedUrl(talk);
   const youtubeEmbedUrl = getYouTubeEmbedUrl(talk);
-  const youtubeUrl = getYouTubeUrl(talk);
+  const primarySourceUrl = getPrimarySourceUrl(talk);
   const isSpotifyOnly = Boolean(talk.spotifyUrl && !talk.youtubeId);
-  const primarySourceUrl = talk.spotifyUrl ?? youtubeUrl;
 
   return (
     <article
-      className={`talk-card ${isHovered ? 'talk-card-hovered' : ''} ${
-        viewMode === 'grid' ? 'talk-card-grid' : ''
-      } ${isOpen ? 'is-open' : ''}`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      className={`group overflow-hidden rounded-2xl border border-outline-variant/15 bg-surface-container-highest shadow-[0_18px_50px_rgba(29,28,22,0.04)] transition-transform duration-300 hover:-translate-y-1 ${
+        viewMode === 'grid' ? 'h-full' : 'lg:grid lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]'
+      }`}
     >
-      <div className="talk-card-video">
-        {isSpotifyOnly ? (
-          isOpen && spotifyEmbedUrl ? (
-            <iframe
-              src={spotifyEmbedUrl}
-              title={talk.title}
-              frameBorder="0"
-              allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-              allowFullScreen
-              loading="lazy"
-              className="spotify-embed"
-            />
-          ) : (
-            <div
-              className="talk-thumbnail-container spotify-container"
-              role="button"
-              tabIndex={0}
-              onClick={onOpen}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' || event.key === ' ') {
-                  event.preventDefault();
-                  onOpen();
-                }
-              }}
-              aria-label={`Open ${talk.title} in the inline player`}
-            >
-              <div className="spotify-placeholder">
-                <span className="spotify-label">Spotify episode</span>
-                <div className="talk-play-button" aria-hidden="true">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M8 5v14l11-7z" />
-                  </svg>
-                </div>
-                <span className="spotify-label">Open player</span>
-              </div>
-            </div>
-          )
+      <div className={`min-h-[240px] bg-surface-container-low ${viewMode === 'grid' ? '' : 'lg:min-h-full'}`}>
+        {isOpen && isSpotifyOnly && spotifyEmbedUrl ? (
+          <iframe
+            src={spotifyEmbedUrl}
+            title={talk.title}
+            frameBorder="0"
+            sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-presentation"
+            allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+            allowFullScreen
+            referrerPolicy="strict-origin-when-cross-origin"
+            loading="lazy"
+            className="h-full w-full"
+          />
         ) : isOpen && youtubeEmbedUrl ? (
           <iframe
             src={youtubeEmbedUrl}
             title={talk.title}
             frameBorder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-presentation"
+            allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
+            referrerPolicy="strict-origin-when-cross-origin"
+            loading="lazy"
+            className="h-full w-full"
           />
         ) : (
-          <div
-            className="talk-thumbnail-container"
-            role="button"
-            tabIndex={0}
+          <button
+            type="button"
             onClick={onOpen}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' || event.key === ' ') {
-                event.preventDefault();
-                onOpen();
-              }
-            }}
+            className="group relative block h-full w-full text-left"
             aria-label={`Open ${talk.title} in the inline player`}
           >
             {talk.youtubeId ? (
               <img
                 src={`https://img.youtube.com/vi/${talk.youtubeId}/hqdefault.jpg`}
                 alt={talk.title}
-                className="talk-thumbnail"
+                className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
               />
             ) : (
-              <div className="spotify-placeholder">
-                <span className="spotify-label">Recording</span>
-                <span className="spotify-label">Open to play</span>
+              <div className="flex h-full min-h-[240px] items-center justify-center bg-[radial-gradient(circle_at_top_left,_rgba(255,219,205,0.65),_transparent_36%),linear-gradient(135deg,_#fef9ef,_#ede8de)] p-8">
+                <div className="max-w-xs space-y-3 text-center">
+                  <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">Recording</p>
+                  <p className="font-headline text-2xl font-bold text-on-surface">{talk.event}</p>
+                  <p className="font-body text-base leading-relaxed text-secondary">Open this session in the inline player to watch or listen in place.</p>
+                </div>
               </div>
             )}
-            <div className="talk-play-button" aria-hidden="true">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M8 5v14l11-7z" />
-              </svg>
+            <div className="absolute inset-0 bg-gradient-to-t from-on-surface/40 via-transparent to-transparent" />
+            <div className="absolute inset-0 flex items-center justify-center">
+              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary-container text-on-primary shadow-xl transition-transform duration-300 group-hover:scale-105">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-6 w-6">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+              </div>
             </div>
-          </div>
+          </button>
         )}
       </div>
 
-      <div className="talk-card-content">
-        <div className="talk-card-header">
-          <h3 className="talk-card-title">{talk.title}</h3>
-          <div className="talk-card-meta">
-            <span className="talk-card-event">{talk.event}</span>
-            <span className="talk-card-date">{formatDate(talk.date)}</span>
-            {isOpen && <span>Playing in page</span>}
+      <div className="space-y-5 p-8">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-2">
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary">{talk.event}</p>
+            <h3 className="font-headline text-2xl font-bold leading-snug text-on-surface transition-colors group-hover:text-primary">
+              {talk.title}
+            </h3>
           </div>
+          <time className="font-label text-[10px] uppercase tracking-widest text-secondary">{formatDate(talk.date)}</time>
         </div>
 
-        {viewMode !== 'grid' && <p className="talk-card-description">{talk.description}</p>}
+        <p className={`font-body text-secondary ${viewMode === 'grid' ? 'text-base' : 'text-lg leading-relaxed'}`}>
+          {talk.description}
+        </p>
 
-        <div className="talk-card-topics">
+        <div className="flex flex-wrap gap-2">
           {talk.topics.slice(0, viewMode === 'grid' ? 4 : 6).map((topic) => (
-            <span key={topic} className="talk-topic-tag">
+            <span key={topic} className="rounded-full bg-surface-container-low px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
               {topic}
             </span>
           ))}
         </div>
 
-        <div className="talk-card-actions">
+        <div className="flex flex-wrap gap-3 pt-1">
           {primarySourceUrl && (
             <a
               href={primarySourceUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="watch-talk-button"
+              className="inline-flex items-center justify-center rounded-lg bg-surface-container-low px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-on-surface transition-colors hover:bg-secondary-container hover:text-primary"
             >
-              <span>{getPrimarySourceLabel(talk)}</span>
+              {getPrimarySourceLabel(talk)}
             </a>
           )}
           {talk.transcriptUrl && (
@@ -187,13 +329,17 @@ function TalkCard({
               href={talk.transcriptUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="watch-talk-button transcript-button"
+              className="inline-flex items-center justify-center rounded-lg bg-surface-container-low px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-on-surface transition-colors hover:bg-secondary-container hover:text-primary"
             >
-              <span>Read transcript</span>
+              Transcript
             </a>
           )}
-          <button type="button" className="watch-talk-button" onClick={onOpen}>
-            <span>{getPrimaryActionLabel(talk)}</span>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-lg bg-on-surface px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-surface"
+            onClick={onOpen}
+          >
+            {isOpen ? 'Playing in page' : getPrimaryActionLabel(talk)}
           </button>
         </div>
       </div>
@@ -206,9 +352,7 @@ export default function TalksClient() {
   const [viewMode, setViewMode] = useState<'list' | 'grid'>('grid');
   const { talks } = talksConfig;
 
-  const sortedTalks = [...talks].sort(
-    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-  );
+  const sortedTalks = [...talks].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const topicCounts = new Map<string, number>();
   sortedTalks.forEach((talk) => {
@@ -240,14 +384,63 @@ export default function TalksClient() {
     }
   }, [activeTalkId, filteredTalks]);
 
+  const featuredTalk = filteredTalks.find((talk) => talk.id === activeTalkId) ?? filteredTalks[0] ?? null;
+
   return (
-    <div className="talks-page">
-      <div className="talks-controls">
-        <div className="talks-filter" aria-label="Talk topics">
+    <section className="mx-auto max-w-7xl px-8 pb-32">
+      {featuredTalk && (
+        <div className="mb-16 grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+          <FeaturedTalk talk={featuredTalk} isOpen={featuredTalk.id === activeTalkId} onOpen={() => setActiveTalkId(featuredTalk.id)} />
+          <aside className="rounded-2xl bg-surface-container-low p-8">
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">Browse recordings</p>
+            <h2 className="mt-4 font-headline text-3xl font-bold leading-tight text-on-surface">
+              {activeFilter === 'all' ? 'All talks, newest first.' : `Talks about ${activeFilter}.`}
+            </h2>
+            <p className="mt-4 font-body text-lg leading-relaxed text-secondary">
+              Open a card, play it in place, and use the source links that matter for that recording.
+            </p>
+            <div className="mt-8 flex flex-wrap gap-2">
+              <span className="rounded-full bg-surface-container-high px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
+                Inline playback
+              </span>
+              <span className="rounded-full bg-surface-container-high px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
+                Transcripts
+              </span>
+              <span className="rounded-full bg-surface-container-high px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
+                Source links
+              </span>
+            </div>
+            <div className="mt-8 space-y-3">
+              {filteredTalks.slice(0, 3).map((talk) => (
+                <button
+                  key={talk.id}
+                  type="button"
+                  onClick={() => setActiveTalkId(talk.id)}
+                  className="flex w-full items-start justify-between gap-4 rounded-xl bg-surface-container-high/60 px-4 py-3 text-left transition-colors hover:bg-surface-container-high"
+                >
+                  <span className="min-w-0">
+                    <span className="block font-label text-[10px] font-bold uppercase tracking-[0.2em] text-primary">{talk.event}</span>
+                    <span className="mt-1 block line-clamp-2 font-headline text-sm font-bold leading-snug text-on-surface">{talk.title}</span>
+                  </span>
+                  <span className="shrink-0 font-label text-[10px] uppercase tracking-widest text-secondary">{formatDate(talk.date)}</span>
+                </button>
+              ))}
+            </div>
+          </aside>
+        </div>
+      )}
+
+      <div className="mb-8 flex flex-col gap-6 border-b border-outline-variant/30 pb-8 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-wrap gap-3" aria-label="Talk topics">
           <button
             type="button"
-            className={`filter-button ${activeFilter === 'all' ? 'active' : ''}`}
+            className={`rounded-full px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider transition-colors ${
+              activeFilter === 'all'
+                ? 'bg-surface-container-highest text-on-surface'
+                : 'bg-surface-container-low text-secondary hover:bg-secondary-container hover:text-primary'
+            }`}
             onClick={() => setActiveFilter('all')}
+            aria-pressed={activeFilter === 'all'}
           >
             All talks
           </button>
@@ -255,79 +448,65 @@ export default function TalksClient() {
             <button
               type="button"
               key={topic}
-              className={`filter-button ${activeFilter === topic ? 'active' : ''}`}
+              className={`rounded-full px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider transition-colors ${
+                activeFilter === topic
+                  ? 'bg-surface-container-highest text-on-surface'
+                  : 'bg-surface-container-low text-secondary hover:bg-secondary-container hover:text-primary'
+              }`}
               onClick={() => setActiveFilter(topic)}
+              aria-pressed={activeFilter === topic}
             >
               {topic}
             </button>
           ))}
         </div>
-      </div>
 
-      <div className="talks-component-box">
-        <div className="talks-component-header">
-          <h2 className="talks-component-title">
-            {activeFilter === 'all' ? 'Browse recordings' : `Talks about ${activeFilter}`}
-          </h2>
-          <div className="view-toggle" aria-label="Talk view mode">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2 rounded-lg bg-surface-container-low p-1">
             <button
               type="button"
-              className={`view-button ${viewMode === 'grid' ? 'active' : ''}`}
+              className={`rounded-md px-3 py-2 font-label text-[11px] font-bold uppercase tracking-wider transition-colors ${
+                viewMode === 'grid' ? 'bg-surface-container-lowest text-on-surface shadow-sm' : 'text-secondary hover:text-on-surface'
+              }`}
               onClick={() => setViewMode('grid')}
-              aria-label="Grid view"
-              title="Grid view"
+              aria-pressed={viewMode === 'grid'}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <rect x="3" y="3" width="7" height="7" />
-                <rect x="14" y="3" width="7" height="7" />
-                <rect x="14" y="14" width="7" height="7" />
-                <rect x="3" y="14" width="7" height="7" />
-              </svg>
+              Grid
             </button>
             <button
               type="button"
-              className={`view-button ${viewMode === 'list' ? 'active' : ''}`}
+              className={`rounded-md px-3 py-2 font-label text-[11px] font-bold uppercase tracking-wider transition-colors ${
+                viewMode === 'list' ? 'bg-surface-container-lowest text-on-surface shadow-sm' : 'text-secondary hover:text-on-surface'
+              }`}
               onClick={() => setViewMode('list')}
-              aria-label="List view"
-              title="List view"
+              aria-pressed={viewMode === 'list'}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <line x1="8" y1="6" x2="21" y2="6" />
-                <line x1="8" y1="12" x2="21" y2="12" />
-                <line x1="8" y1="18" x2="21" y2="18" />
-                <line x1="3" y1="6" x2="3.01" y2="6" />
-                <line x1="3" y1="12" x2="3.01" y2="12" />
-                <line x1="3" y1="18" x2="3.01" y2="18" />
-              </svg>
+              List
             </button>
           </div>
-        </div>
-
-        <div className="talks-component-content">
-          <div className={`talks-container ${viewMode === 'list' ? 'talks-list' : 'talks-grid'}`}>
-            {filteredTalks.map((talk) => (
-              <TalkCard
-                key={talk.id}
-                talk={talk}
-                viewMode={viewMode}
-                isOpen={talk.id === activeTalkId}
-                onOpen={() => setActiveTalkId(talk.id)}
-              />
-            ))}
+          <div className="hidden font-label text-[11px] uppercase tracking-widest text-secondary md:block">
+            {filteredTalks.length} recordings
           </div>
-
-          {filteredTalks.length === 0 && (
-            <div className="no-talks-message">
-              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="12" cy="12" r="10" />
-                <line x1="12" y1="8" x2="12" y2="12" />
-                <line x1="12" y1="16" x2="12.01" y2="16" />
-              </svg>
-              <p>No talks found for that topic.</p>
-            </div>
-          )}
         </div>
       </div>
-    </div>
+
+      {filteredTalks.length === 0 ? (
+        <div className="rounded-2xl bg-surface-container-low p-10 text-center">
+          <p className="font-headline text-2xl font-bold text-on-surface">No talks found for that topic.</p>
+        </div>
+      ) : (
+        <div className={viewMode === 'grid' ? 'grid gap-8 md:grid-cols-2 xl:grid-cols-3' : 'space-y-8'}>
+          {filteredTalks.map((talk) => (
+            <TalkCard
+              key={talk.id}
+              talk={talk}
+              viewMode={viewMode}
+              isOpen={talk.id === activeTalkId}
+              onOpen={() => setActiveTalkId(talk.id)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
   );
 }

--- a/app/talks/page.tsx
+++ b/app/talks/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { EditorialPageFrame } from '../components/EditorialPageFrame';
+import { talksConfig } from '../config/talksConfig';
 import TalksClient from './TalksClient';
 
 export const metadata: Metadata = {
@@ -8,28 +9,81 @@ export const metadata: Metadata = {
 };
 
 export default function TalksPage() {
+  const { talks, subtitle } = talksConfig;
+  const sortedTalks = [...talks].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  const featuredTalk = sortedTalks[0];
+  const sourceCounts = sortedTalks.reduce(
+    (counts, talk) => {
+      if (talk.youtubeId) {
+        counts.video += 1;
+      }
+
+      if (talk.spotifyUrl) {
+        counts.audio += 1;
+      }
+
+      if (talk.transcriptUrl) {
+        counts.transcripts += 1;
+      }
+
+      return counts;
+    },
+    { video: 0, audio: 0, transcripts: 0 }
+  );
+
   return (
     <EditorialPageFrame currentPath="/talks">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Watch and listen</p>
-          <h1 className="editorial-page-title">Talks</h1>
-          <p className="editorial-page-copy">
-            Recorded talks, podcast conversations, and livestreams with inline playback, transcripts when available, and direct links back to the source.
+      <section className="mx-auto grid max-w-7xl grid-cols-1 gap-10 px-8 pb-12 pt-20 lg:grid-cols-12 lg:items-end">
+        <div className="lg:col-span-8">
+          <span className="mb-6 block font-label text-xs font-bold uppercase tracking-[0.2em] text-secondary">Watch and listen</span>
+          <h1 className="max-w-4xl font-headline text-5xl font-black tracking-tighter text-on-surface md:text-7xl">
+            Talks
+          </h1>
+          <p className="mt-6 max-w-3xl font-body text-xl leading-relaxed text-secondary md:text-2xl">
+            {subtitle}
           </p>
-          <div className="editorial-chip-row">
-            <span className="editorial-chip">Inline playback</span>
-            <span className="editorial-chip">Transcripts</span>
-            <span className="editorial-chip">Source links</span>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <span className="rounded-full bg-surface-container-low px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider text-secondary">
+              Inline playback
+            </span>
+            <span className="rounded-full bg-surface-container-low px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider text-secondary">
+              Transcripts
+            </span>
+            <span className="rounded-full bg-surface-container-low px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider text-secondary">
+              Source links
+            </span>
           </div>
         </div>
-        <aside className="editorial-page-aside">
-          <p className="editorial-post-summary">
-            Open a card, play it in place, and use the watch, listen, or transcript links that matter for that recording.
-          </p>
-          <p className="editorial-post-summary">
-            The page stays practical on purpose: no appearance counts, no latest-item badge, just a browsable set of recordings.
-          </p>
+
+        <aside className="rounded-2xl bg-surface-container-low p-8 lg:col-span-4">
+          <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">At a glance</p>
+          <div className="mt-6 grid gap-4 sm:grid-cols-3 lg:grid-cols-1">
+            <div className="rounded-xl bg-surface-container-highest p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Recordings</p>
+              <p className="mt-2 font-headline text-3xl font-bold text-on-surface">{sortedTalks.length}</p>
+            </div>
+            <div className="rounded-xl bg-surface-container-highest p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Video sessions</p>
+              <p className="mt-2 font-headline text-3xl font-bold text-on-surface">{sourceCounts.video}</p>
+            </div>
+            <div className="rounded-xl bg-surface-container-highest p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Audio sessions</p>
+              <p className="mt-2 font-headline text-3xl font-bold text-on-surface">{sourceCounts.audio}</p>
+            </div>
+            <div className="rounded-xl bg-surface-container-highest p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Transcript links</p>
+              <p className="mt-2 font-headline text-3xl font-bold text-on-surface">{sourceCounts.transcripts}</p>
+            </div>
+          </div>
+          {featuredTalk && (
+            <div className="mt-8 border-t border-outline-variant/30 pt-6">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary">Featured talk</p>
+              <p className="mt-3 font-headline text-xl font-bold leading-snug text-on-surface">{featuredTalk.title}</p>
+              <p className="mt-3 font-body text-base leading-relaxed text-secondary">
+                Open the newest session first, then use the filters to jump by topic.
+              </p>
+            </div>
+          )}
         </aside>
       </section>
 


### PR DESCRIPTION
## Context
This branch replays only the structured route work from feat/site-stitch-integrate-structured on top of feat/site-stitch-integrate-shell-home. It keeps the shell-home lineage intact and avoids carrying over unrelated history.

Refs #40.

## What changed
- app/about/page.tsx: Ported the structured About/CV layout with richer summary cards, contact shortcuts, and expanded work history cards.
- app/publications/page.tsx: Ported the structured publications landing page with featured content and year grouping.
- app/talks/page.tsx: Ported the structured talks overview with summary metrics and featured talk framing.
- app/talks/TalksClient.tsx: Ported the structured interactive talks browser with inline playback, filters, and refreshed card layout.

## Test plan
- Build passed with npm run build.
- Quick route check for /about returned 200 and rendered the updated About page.
- Quick route check for /talks returned 200 and rendered the updated Talks page.