### PR TITLE
feat: assemble non-main review stack

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -14,6 +14,11 @@ const experience = [
     period: '2022 to present',
     summary:
       'Founding engineer on enterprise GenAI and agent systems. I build async LLM infrastructure, retrieval, memory, and internal tools used in customer workflows.',
+    highlights: [
+      'Agent memory and retrieval systems',
+      'Production tooling for enterprise workflows',
+      'Technical writing on AI systems in practice',
+    ],
   },
   {
     role: 'Senior Data Scientist',
@@ -21,43 +26,51 @@ const experience = [
     period: '2021 to 2022',
     summary:
       'Led machine-learning work for Hopper Cloud partnerships and helped build platform systems for travel products and partner workflows.',
+    highlights: [
+      'Cloud partnership workflows',
+      'Travel product experimentation',
+      'Platform ML and analytics',
+    ],
   },
   {
-    role: 'Earlier data science work',
+    role: 'Data Science and economics roles',
     company: 'XPO Logistics, Revantage, Arity',
     period: '2017 to 2021',
     summary:
       'Worked across forecasting, experimentation, optimization, and business-facing ML systems, alongside economics and transportation writing.',
+    highlights: [
+      'Forecasting and optimization',
+      'Business-facing analytics',
+      'Writing across economics and transportation',
+    ],
   },
 ];
 
-const practicalCards = [
+const quickLinks = [
   {
     label: 'Resume',
-    title: 'Download the PDF first.',
-    summary:
-      'This is the fastest way to get the full CV, including work history and the usual contact details.',
     href: '/benjamin_labaschin_resume.pdf',
-    action: 'Download resume',
-    external: true,
+    action: 'Download PDF',
+    note: 'Fastest route to the full CV.',
+    download: true,
   },
   {
-    label: 'Work history',
-    title: 'Recent roles, kept short and readable.',
-    summary:
-      'A practical summary of where I’ve worked and what I’ve spent time building there.',
-    href: '#work-history',
-    action: 'Jump to work history',
-    external: false,
+    label: 'Publications',
+    href: '/publications',
+    action: 'View writing',
+    note: 'Books, reports, and papers.',
+  },
+  {
+    label: 'Talks',
+    href: '/talks',
+    action: 'View sessions',
+    note: 'Recordings and transcripts.',
   },
   {
     label: 'Contact',
-    title: 'Email or LinkedIn if you need to reach me.',
-    summary:
-      'For work, speaking, or writing, those two links are usually the quickest route.',
     href: 'mailto:benjaminlabaschin@gmail.com',
     action: 'Email me',
-    external: true,
+    note: 'Best for work or speaking inquiries.',
   },
 ];
 
@@ -87,127 +100,201 @@ const contactLinks = [
 export default function AboutPage() {
   return (
     <EditorialPageFrame currentPath="/about">
-      <section className="editorial-page-hero editorial-about-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">About / CV</p>
-          <h1 className="editorial-page-title">Ben Labaschin</h1>
-          <p className="editorial-page-copy">
+      <section className="mx-auto grid max-w-7xl grid-cols-1 gap-10 px-8 pb-14 pt-20 lg:grid-cols-12 lg:items-start">
+        <div className="lg:col-span-8">
+          <span className="mb-6 block font-label text-xs font-bold uppercase tracking-[0.2em] text-secondary">About / CV</span>
+          <h1 className="max-w-4xl font-headline text-5xl font-black tracking-tighter text-on-surface md:text-7xl">
+            Ben Labaschin
+          </h1>
+          <p className="mt-6 max-w-3xl font-body text-xl leading-relaxed text-secondary md:text-2xl">
             I build practical AI systems and write about the trade-offs that show up once they have to work in production.
-            If you need the short version, use the resume download or jump straight to the work history below.
+            The page keeps the CV readable, the links obvious, and the story tied to real work.
           </p>
-          <div className="editorial-home-actions">
-            <a href="/benjamin_labaschin_resume.pdf" download className="editorial-home-button editorial-home-button-primary">
+          <div className="mt-8 flex flex-wrap gap-4">
+            <a
+              href="/benjamin_labaschin_resume.pdf"
+              download
+              className="inline-flex items-center justify-center rounded-lg bg-primary-container px-8 py-4 font-label text-xs font-bold uppercase tracking-widest text-on-primary"
+            >
               Download resume
             </a>
-            <a href="#work-history" className="editorial-home-button editorial-home-button-secondary">
+            <a
+              href="#work-history"
+              className="inline-flex items-center justify-center rounded-lg bg-surface-container-high px-8 py-4 font-label text-xs font-bold uppercase tracking-widest text-on-surface"
+            >
               Work history
             </a>
-            <Link href="/publications" className="editorial-home-button editorial-home-button-secondary">
+            <Link
+              href="/publications"
+              className="inline-flex items-center justify-center rounded-lg bg-surface-container-high px-8 py-4 font-label text-xs font-bold uppercase tracking-widest text-on-surface"
+            >
               Publications
             </Link>
           </div>
         </div>
-        <aside className="editorial-page-aside editorial-about-photo-card">
-          <img src="/assets/atlas_and_I.jpg" alt="Ben Labaschin with Atlas" />
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">Principal ML</span>
-              <span className="editorial-page-metric-label">Workhelix and earlier product ML roles</span>
+
+        <aside className="overflow-hidden rounded-2xl bg-surface-container-highest shadow-[0_24px_60px_rgba(29,28,22,0.06)] lg:col-span-4">
+          <img src="/assets/atlas_and_I.jpg" alt="Ben Labaschin with Atlas" className="aspect-square w-full object-cover" />
+          <div className="space-y-4 p-8">
+            <div className="rounded-xl bg-surface-container-low p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Current role</p>
+              <p className="mt-2 font-headline text-lg font-bold text-on-surface">Principal Machine Learning Engineer at Workhelix</p>
             </div>
-            <div>
-              <span className="editorial-page-metric-value">Resume</span>
-              <span className="editorial-page-metric-label">Download the PDF or scan the work history</span>
+            <div className="rounded-xl bg-surface-container-low p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Resume</p>
+              <p className="mt-2 font-headline text-lg font-bold text-on-surface">Download the PDF or scan the work history below</p>
             </div>
-            <div>
-              <span className="editorial-page-metric-value">Contact</span>
-              <span className="editorial-page-metric-label">Email, LinkedIn, GitHub, publications, talks</span>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <StatCard label="Focus" value="AI systems, memory, and applied ML" />
+              <StatCard label="Contact" value="Email, LinkedIn, GitHub, talks" />
             </div>
           </div>
         </aside>
       </section>
 
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Practical summary</p>
-          <h2 className="editorial-page-section-title">What I do, in plain language.</h2>
-        </div>
-        <div className="editorial-two-column">
-          {practicalCards.map((item) => (
-            <article key={item.label} className="editorial-home-card">
-              <p className="editorial-home-card-label">{item.label}</p>
-              <h3>{item.title}</h3>
-              <p>{item.summary}</p>
-              {item.external ? (
-                <a href={item.href} className="editorial-post-link" {...(item.label === 'Resume' ? { download: true } : {})}>
-                  {item.action}
-                </a>
-              ) : (
-                <a href={item.href} className="editorial-post-link">
-                  {item.action}
-                </a>
-              )}
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section id="work-history" className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Work history</p>
-          <h2 className="editorial-page-section-title">Recent roles and the work attached to them.</h2>
-        </div>
-        <div className="editorial-timeline">
-          {experience.map((item) => (
-            <article key={`${item.company}-${item.role}`} className="editorial-timeline-item">
-              <div className="editorial-post-meta">
-                <span>{item.company}</span>
-                <span>{item.period}</span>
-              </div>
-              <h3>{item.role}</h3>
-              <p className="editorial-post-summary">{item.summary}</p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Useful links</p>
-          <h2 className="editorial-page-section-title">The rest of the profile, without hunting around the site.</h2>
-        </div>
-        <div className="editorial-two-column">
-          <article className="editorial-home-card">
-            <p className="editorial-home-card-label">Contact</p>
-            <h3>Reach out directly.</h3>
-            <p>Email works best. GitHub and LinkedIn are here if that is easier.</p>
-            <div className="editorial-link-row">
-              {contactLinks.slice(0, 3).map((link) => (
-                <a
-                  key={link.label}
-                  href={link.href}
-                  className="editorial-post-link"
-                  target={link.href.startsWith('http') ? '_blank' : undefined}
-                  rel={link.href.startsWith('http') ? 'noreferrer noopener' : undefined}
-                >
-                  {link.label}
-                </a>
+      <section className="mx-auto max-w-7xl px-8 pb-16">
+        <div className="grid gap-8 lg:grid-cols-12">
+          <article className="rounded-2xl bg-surface-container-low p-8 lg:col-span-7">
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">What I do</p>
+            <h2 className="mt-4 font-headline text-3xl font-bold tracking-tight text-on-surface">Practical summary.</h2>
+            <p className="mt-4 max-w-2xl font-body text-lg leading-relaxed text-secondary">
+              The work is usually some mix of agent memory, retrieval, evaluation, and the plumbing needed to make AI systems
+              usable for actual teams. I write because the implementation details matter.
+            </p>
+            <div className="mt-8 grid gap-4 sm:grid-cols-2">
+              {quickLinks.map((item) => (
+                <div key={item.label} className="rounded-xl bg-surface-container-highest p-5">
+                  <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">{item.label}</p>
+                  <p className="mt-2 font-headline text-lg font-bold text-on-surface">{item.note}</p>
+                  {item.download || item.href.startsWith('http') || item.href.startsWith('mailto:') ? (
+                    <a
+                      href={item.href}
+                      className="mt-4 inline-flex items-center justify-center rounded-lg bg-on-surface px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-surface"
+                      target={item.href.startsWith('http') ? '_blank' : undefined}
+                      rel={item.href.startsWith('http') ? 'noreferrer noopener' : undefined}
+                      download={item.download ? true : undefined}
+                    >
+                      {item.action}
+                    </a>
+                  ) : (
+                    <Link
+                      href={item.href}
+                      className="mt-4 inline-flex items-center justify-center rounded-lg bg-on-surface px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-surface"
+                    >
+                      {item.action}
+                    </Link>
+                  )}
+                </div>
               ))}
             </div>
           </article>
-          <article className="editorial-home-card">
-            <p className="editorial-home-card-label">More context</p>
-            <h3>Publications and talks.</h3>
-            <p>If you want the longer version of the profile, those pages show the writing and speaking side of the work.</p>
-            <div className="editorial-link-row">
-              {contactLinks.slice(3).map((link) => (
-                <Link key={link.label} href={link.href} className="editorial-post-link">
-                  {link.label}
+
+          <aside className="rounded-2xl bg-surface-container-low p-8 lg:col-span-5">
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">Contact</p>
+            <h2 className="mt-4 font-headline text-3xl font-bold tracking-tight text-on-surface">Reach out directly.</h2>
+            <p className="mt-4 font-body text-lg leading-relaxed text-secondary">
+              Email is usually the fastest path. GitHub and LinkedIn are here if that is easier.
+            </p>
+            <div className="mt-8 grid gap-3 sm:grid-cols-2">
+              {contactLinks.map((link) => {
+                const isExternal = link.href.startsWith('http') || link.href.startsWith('mailto:');
+
+                return isExternal ? (
+                  <a
+                    key={link.label}
+                    href={link.href}
+                    target={link.href.startsWith('http') ? '_blank' : undefined}
+                    rel={link.href.startsWith('http') ? 'noreferrer noopener' : undefined}
+                    className="rounded-xl bg-surface-container-highest px-4 py-4 font-label text-xs font-bold uppercase tracking-widest text-secondary transition-colors hover:bg-secondary-container hover:text-primary"
+                  >
+                    {link.label}
+                  </a>
+                ) : (
+                  <Link
+                    key={link.label}
+                    href={link.href}
+                    className="rounded-xl bg-surface-container-highest px-4 py-4 font-label text-xs font-bold uppercase tracking-widest text-secondary transition-colors hover:bg-secondary-container hover:text-primary"
+                  >
+                    {link.label}
+                  </Link>
+                );
+              })}
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-8 pb-16" id="work-history">
+        <div className="mb-8 grid gap-4 lg:grid-cols-12 lg:items-end">
+          <div className="lg:col-span-8">
+            <p className="font-label text-xs font-bold uppercase tracking-[0.2em] text-secondary">Work history</p>
+            <h2 className="mt-3 font-headline text-3xl font-bold tracking-tight text-on-surface">
+              Recent roles and the work attached to them.
+            </h2>
+          </div>
+          <div className="lg:col-span-4 lg:text-right">
+            <p className="font-body text-base italic text-secondary">Kept short enough to scan, but specific enough to be useful.</p>
+          </div>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-12">
+          <div className="lg:col-span-8">
+            <div className="space-y-8">
+              {experience.map((item) => (
+                <article key={`${item.company}-${item.role}`} className="rounded-2xl bg-surface-container-highest p-8">
+                  <div className="flex flex-col gap-4 border-b border-outline-variant/20 pb-6 md:flex-row md:items-baseline md:justify-between">
+                    <div>
+                      <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary">{item.company}</p>
+                      <h3 className="mt-2 font-headline text-2xl font-bold tracking-tight text-on-surface">{item.role}</h3>
+                    </div>
+                    <span className="font-label text-[10px] uppercase tracking-widest text-secondary">{item.period}</span>
+                  </div>
+                  <p className="mt-6 font-body text-lg leading-relaxed text-secondary">{item.summary}</p>
+                  <div className="mt-6 flex flex-wrap gap-2">
+                    {item.highlights.map((highlight) => (
+                      <span key={highlight} className="rounded-full bg-surface-container-low px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
+                        {highlight}
+                      </span>
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <aside className="space-y-6 lg:col-span-4">
+            <div className="rounded-2xl bg-surface-container-low p-8">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">Why this page exists</p>
+              <p className="mt-4 font-body text-lg leading-relaxed text-secondary">
+                The goal here is utility: quick contact paths, a readable CV, and enough context to understand what I work on.
+              </p>
+            </div>
+            <div className="rounded-2xl bg-surface-container-low p-8">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">Useful links</p>
+              <div className="mt-4 flex flex-wrap gap-3">
+                <Link href="/talks" className="rounded-full bg-surface-container-high px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-secondary">
+                  Talks
                 </Link>
-              ))}
+                <Link href="/publications" className="rounded-full bg-surface-container-high px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-secondary">
+                  Publications
+                </Link>
+                <a href="mailto:benjaminlabaschin@gmail.com" className="rounded-full bg-surface-container-high px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-secondary">
+                  Email
+                </a>
+              </div>
             </div>
-          </article>
+          </aside>
         </div>
       </section>
     </EditorialPageFrame>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl bg-surface-container-highest p-4">
+      <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">{label}</p>
+      <p className="mt-2 font-headline text-lg font-bold leading-tight text-on-surface">{value}</p>
+    </div>
   );
 }

--- a/app/archive/page.tsx
+++ b/app/archive/page.tsx
@@ -1,119 +1,235 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { EditorialPageFrame } from '../components/EditorialPageFrame';
 import { postService } from '../services/PostService';
 
 export const metadata: Metadata = {
-  title: 'Archive | Ben Labaschin',
-  description: 'Browse the full writing archive by year and month.',
+  title: 'Archive | ECONOBEN.DEV',
+  description: 'Browse the writing archive by year and month.',
 };
 
 const monthFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'long',
 });
 
+const shortDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: '2-digit',
+});
+
+type ArchiveMonth = {
+  key: string;
+  year: number;
+  month: number;
+  monthLabel: string;
+  monthHref: string;
+  posts: Awaited<ReturnType<typeof postService.getAllPosts>>;
+};
+
 export default async function ArchivePage() {
   const posts = await postService.getAllPosts();
-  const postsByYearMonth = posts.reduce((acc, post) => {
+  const archiveByMonth = posts.reduce<Record<string, ArchiveMonth>>((acc, post) => {
     const year = post.date.getFullYear();
     const month = post.date.getMonth();
-    const monthKey = `${year}-${String(month + 1).padStart(2, '0')}`;
+    const key = `${year}-${String(month + 1).padStart(2, '0')}`;
 
-    if (!acc[monthKey]) {
-      acc[monthKey] = {
+    if (!acc[key]) {
+      acc[key] = {
+        key,
         year,
         month,
         monthLabel: monthFormatter.format(post.date),
-        monthHref: `/archives/${monthKey}`,
+        monthHref: `/archives/${key}`,
         posts: [],
       };
     }
 
-    acc[monthKey].posts.push(post);
+    acc[key].posts.push(post);
     return acc;
-  }, {} as Record<string, { year: number; month: number; monthLabel: string; monthHref: string; posts: typeof posts }>);
+  }, {});
 
-  const sortedEntries = Object.values(postsByYearMonth).sort((a, b) => {
-    if (a.year !== b.year) return b.year - a.year;
+  const months = Object.values(archiveByMonth).sort((a, b) => {
+    if (a.year !== b.year) {
+      return b.year - a.year;
+    }
+
     return b.month - a.month;
   });
 
-  const postsByYear = sortedEntries.reduce((acc, entry) => {
-    if (!acc[entry.year]) {
-      acc[entry.year] = [];
-    }
-    acc[entry.year].push(entry);
+  const monthsByYear = months.reduce<Record<number, ArchiveMonth[]>>((acc, month) => {
+    acc[month.year] ??= [];
+    acc[month.year].push(month);
     return acc;
-  }, {} as Record<number, typeof sortedEntries>);
+  }, {});
 
-  const years = Object.keys(postsByYear).map(Number).sort((a, b) => b - a);
+  const years = Object.keys(monthsByYear)
+    .map(Number)
+    .sort((a, b) => b - a);
+
   const uniqueTags = new Set(posts.flatMap((post) => post.tags)).size;
+  const latestMonth = months[0];
 
   return (
-    <EditorialPageFrame currentPath="/archive" pageClassName="editorial-book-page">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Archive</p>
-          <h1 className="editorial-page-title">Archive</h1>
-          <p className="editorial-page-copy">
-            Browse the full post history by year and month, with each month arranged like a compact table of contents rather than a flat index.
+    <EditorialPageFrame currentPath="/archive">
+      <main className="mx-auto max-w-7xl px-8 pb-32 pt-20">
+        <header className="mb-24 max-w-3xl">
+          <span className="mb-4 block font-label text-xs uppercase tracking-[0.2em] text-secondary">
+            Chronological Index
+          </span>
+          <h1 className="mb-8 font-headline text-6xl font-black tracking-tighter text-on-surface md:text-7xl">
+            Archive.
+          </h1>
+          <p className="font-body text-xl italic leading-relaxed text-on-surface-variant md:text-2xl">
+            Every post, grouped by year and month so the archive reads like a history of work instead of a flat directory.
           </p>
-          <div className="editorial-chip-row">
-            <span className="editorial-chip">By year</span>
-            <span className="editorial-chip">By month</span>
-            <span className="editorial-chip">Every post linked</span>
-          </div>
-        </div>
-        <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">Archive at a glance</p>
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">{posts.length}</span>
-              <span className="editorial-page-metric-label">total posts</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">{years.length}</span>
-              <span className="editorial-page-metric-label">years represented</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">{uniqueTags}</span>
-              <span className="editorial-page-metric-label">unique tags across the archive</span>
-            </div>
-          </div>
-        </aside>
-      </section>
+        </header>
 
-      {years.map((year) => (
-        <section key={year} className="editorial-list-section">
-          <div className="editorial-list-heading">
-            <p className="editorial-home-section-label">Year {year}</p>
-            <h2 className="editorial-page-section-title">Monthly index for {year}, with every post still available below each month.</h2>
-          </div>
-          <div className="months-grid">
-            {postsByYear[year].map(({ monthLabel, monthHref, posts: monthPosts }) => (
-              <article key={`${year}-${monthLabel}`} className="editorial-home-card">
-                <p className="editorial-home-card-label">{monthLabel}</p>
-                <h3>
-                  <Link href={monthHref}>{monthLabel}</Link>
-                </h3>
-                <p>{monthPosts.length} post{monthPosts.length !== 1 ? 's' : ''} in this month, linked by title below.</p>
-                <ul className="posts-list">
-                  {monthPosts.map((post) => (
-                    <li key={post.slug} className="archive-post">
-                      <Link href={`/posts/${post.slug}`}>
-                        <time className="archive-post-date">
-                          {post.date.getDate().toString().padStart(2, '0')}
-                        </time>
-                        <span className="archive-post-title">{post.title}</span>
-                      </Link>
+        <div className="grid grid-cols-1 gap-16 lg:grid-cols-12">
+          <aside className="lg:col-span-3">
+            <nav className="sticky top-32 space-y-10">
+              <div>
+                <h2 className="mb-6 font-label text-[10px] uppercase tracking-[0.3em] text-secondary">
+                  Filter by Year
+                </h2>
+                <ul className="space-y-3 font-label text-sm">
+                  {years.map((year, index) => (
+                    <li key={year}>
+                      <a
+                        href={`#year-${year}`}
+                        className={index === 0
+                          ? 'block border-l-2 border-primary pl-4 font-bold text-primary'
+                          : 'block pl-4 text-on-surface-variant transition-colors hover:text-on-surface'}
+                      >
+                        {year}
+                      </a>
                     </li>
                   ))}
                 </ul>
-              </article>
+              </div>
+
+              <div className="rounded-xl bg-surface-container-low p-6">
+                <h3 className="mb-2 font-headline text-sm font-bold text-on-surface">Archive Snapshot</h3>
+                <div className="space-y-4 font-label text-xs uppercase tracking-widest text-secondary">
+                  <div className="flex items-center justify-between gap-4">
+                    <span>Total posts</span>
+                    <span className="font-headline text-lg font-bold text-on-surface">{posts.length}</span>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <span>Years covered</span>
+                    <span className="font-headline text-lg font-bold text-on-surface">{years.length}</span>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <span>Unique tags</span>
+                    <span className="font-headline text-lg font-bold text-on-surface">{uniqueTags}</span>
+                  </div>
+                </div>
+                {latestMonth ? (
+                  <Link
+                    href={latestMonth.monthHref}
+                    className="mt-6 inline-flex items-center gap-2 font-label text-xs font-bold uppercase tracking-widest text-primary transition-colors hover:text-primary-container"
+                  >
+                    Latest month: {latestMonth.monthLabel} {latestMonth.year}
+                  </Link>
+                ) : null}
+              </div>
+            </nav>
+          </aside>
+
+          <div className="space-y-24 lg:col-span-9">
+            {years.map((year) => (
+              <section key={year} id={`year-${year}`} className="scroll-mt-32">
+                <div className="mb-12 flex items-baseline gap-4">
+                  <h2 className="font-headline text-4xl font-black tracking-tighter text-on-surface">{year}</h2>
+                  <div className="h-px flex-grow bg-outline-variant opacity-20" />
+                </div>
+
+                <div className="space-y-16">
+                  {monthsByYear[year].map((entry) => (
+                    <section key={entry.key}>
+                      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-baseline sm:justify-between">
+                        <div>
+                          <h3 className="font-headline text-2xl font-bold text-on-surface">{entry.monthLabel}</h3>
+                          <p className="mt-1 font-body text-base text-on-surface-variant">
+                            {entry.posts.length} post{entry.posts.length === 1 ? '' : 's'} published in {entry.monthLabel} {year}.
+                          </p>
+                        </div>
+                        <Link
+                          href={entry.monthHref}
+                          className="font-label text-xs font-bold uppercase tracking-[0.2em] text-primary transition-colors hover:text-primary-container"
+                        >
+                          View month
+                        </Link>
+                      </div>
+
+                      <article className="rounded-xl bg-surface-container-low p-8">
+                        <div className="space-y-6">
+                          {entry.posts.map((post, index) => (
+                            <Link
+                              key={post.slug}
+                              href={`/posts/${post.slug}`}
+                              className={`block transition-colors hover:text-primary ${index > 0 ? 'border-t border-outline-variant/20 pt-6' : ''}`}
+                            >
+                              <div className="grid gap-3 md:grid-cols-[110px_minmax(0,1fr)] md:gap-6">
+                                <div className="font-label text-xs uppercase tracking-widest text-secondary">
+                                  {shortDateFormatter.format(post.date)}
+                                </div>
+                                <div>
+                                  <h4 className="font-headline text-xl font-bold text-on-surface">{post.title}</h4>
+                                  {post.summary ? (
+                                    <p className="mt-2 font-body text-base leading-relaxed text-on-surface-variant">
+                                      {post.summary}
+                                    </p>
+                                  ) : null}
+                                  {post.tags.length > 0 ? (
+                                    <div className="mt-4 flex flex-wrap gap-2">
+                                      {post.tags.slice(0, 4).map((tag) => (
+                                        <span
+                                          key={`${post.slug}-${tag}`}
+                                          className="rounded-sm bg-surface-container-highest px-2 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary"
+                                        >
+                                          {tag}
+                                        </span>
+                                      ))}
+                                    </div>
+                                  ) : null}
+                                </div>
+                              </div>
+                            </Link>
+                          ))}
+                        </div>
+                      </article>
+                    </section>
+                  ))}
+                </div>
+              </section>
             ))}
+
+            <section className="relative overflow-hidden rounded-xl bg-surface-container-highest p-12 lg:-ml-[10%] lg:mr-[10%]">
+              <div className="relative z-10 max-w-xl">
+                <h3 className="mb-4 font-headline text-3xl font-bold">Keep up with the archive.</h3>
+                <p className="mb-8 font-body text-lg leading-relaxed text-on-surface-variant">
+                  If you prefer browsing by subject instead of date, move from the archive into tags or search without losing your place.
+                </p>
+                <div className="flex flex-wrap gap-4">
+                  <Link
+                    href="/tags"
+                    className="rounded-md bg-primary-container px-6 py-3 font-label text-sm font-bold uppercase tracking-widest text-on-primary"
+                  >
+                    Browse tags
+                  </Link>
+                  <Link
+                    href="/search"
+                    className="rounded-md border border-outline-variant bg-surface px-6 py-3 font-label text-sm font-bold uppercase tracking-widest text-on-surface transition-colors hover:bg-surface-container-low"
+                  >
+                    Search archive
+                  </Link>
+                </div>
+              </div>
+              <div className="absolute right-[-10%] top-[-20%] h-64 w-64 rounded-full bg-primary opacity-5 blur-3xl" />
+            </section>
           </div>
-        </section>
-      ))}
+        </div>
+      </main>
     </EditorialPageFrame>
   );
 }

--- a/app/archives/[month]/page.tsx
+++ b/app/archives/[month]/page.tsx
@@ -19,7 +19,7 @@ const longDateFormatter = new Intl.DateTimeFormat('en-US', {
 function getMonthParts(month: string) {
   const [year, monthNum] = month.split('-');
 
-  if (!year || !monthNum || isNaN(parseInt(year)) || isNaN(parseInt(monthNum))) {
+  if (!year || !monthNum || Number.isNaN(Number.parseInt(year, 10)) || Number.isNaN(Number.parseInt(monthNum, 10))) {
     return null;
   }
 
@@ -35,153 +35,189 @@ async function getPostsForMonth(month: string) {
   const { year, monthNum } = parts;
   const allPosts = await postService.getAllPosts();
   const monthPosts = allPosts.filter((post) => {
-    const postDate = new Date(post.date);
-    const postYear = postDate.getFullYear().toString();
-    const postMonth = (postDate.getMonth() + 1).toString().padStart(2, '0');
-
+    const postYear = post.date.getFullYear().toString();
+    const postMonth = `${post.date.getMonth() + 1}`.padStart(2, '0');
     return postYear === year && postMonth === monthNum;
   });
 
   return { year, monthNum, monthPosts };
 }
 
-export default async function ArchivePage({ params }: ArchivePageProps) {
+export default async function ArchiveMonthPage({ params }: ArchivePageProps) {
   const { month } = await params;
   const monthData = await getPostsForMonth(month);
 
-  if (!monthData) {
+  if (!monthData || monthData.monthPosts.length === 0) {
     notFound();
   }
 
   const { year, monthNum, monthPosts } = monthData;
-
-  if (monthPosts.length === 0) {
-    notFound();
-  }
-
-  const monthName = new Date(parseInt(year), parseInt(monthNum) - 1).toLocaleDateString('en-US', {
+  const label = new Date(Number.parseInt(year, 10), Number.parseInt(monthNum, 10) - 1).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long',
   });
+  const [monthName, yearLabel] = label.split(' ');
+  const [featuredPost, ...remainingPosts] = monthPosts;
+  const uniqueTags = new Set(monthPosts.flatMap((post) => post.tags)).size;
 
   return (
-    <EditorialPageFrame currentPath="/archive" pageClassName="editorial-book-page">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Archive month</p>
-          <h1 className="editorial-page-title">{monthName}</h1>
-          <p className="editorial-page-copy">
-            Posts published in {monthName}, ordered newest first and framed as a single reading pass instead of a long list.
+    <EditorialPageFrame currentPath="/archive">
+      <main className="mx-auto max-w-7xl px-8 py-16">
+        <div className="mb-20">
+          <div className="mb-6 flex items-center gap-2 font-headline text-[10px] uppercase tracking-[0.2em] text-secondary">
+            <Link href="/archive" className="transition-colors hover:text-primary">Archive</Link>
+            <span>/</span>
+            <span className="font-bold text-on-surface">{yearLabel}</span>
+            <span>/</span>
+            <span className="font-bold text-on-surface">{monthName}</span>
+          </div>
+          <h1 className="mb-4 font-headline text-6xl font-black tracking-tighter text-on-surface md:text-8xl">
+            {monthName} <span className="font-body font-light italic text-primary">{yearLabel}</span>
+          </h1>
+          <p className="max-w-2xl font-body text-xl leading-relaxed text-on-surface-variant md:text-2xl">
+            A month view of the archive with the full set of posts preserved, but framed around the strongest entry first so the page reads like a curated issue.
           </p>
-          <div className="editorial-chip-row">
-            <span className="editorial-chip">{monthPosts.length} posts</span>
-            <span className="editorial-chip">Newest first</span>
-            <span className="editorial-chip">Archive link preserved</span>
-          </div>
         </div>
-        <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">Month at a glance</p>
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">{monthPosts.length}</span>
-              <span className="editorial-page-metric-label">posts in this month</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">
-                {new Set(monthPosts.flatMap((post) => post.tags)).size}
-              </span>
-              <span className="editorial-page-metric-label">unique tags in month</span>
-            </div>
-            <div>
-              <Link href="/archive" className="editorial-post-link">
-                Back to archive
-              </Link>
-            </div>
-          </div>
-        </aside>
-      </section>
 
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Posts</p>
-          <h2 className="editorial-page-section-title">Everything published during this month, kept in one readable stack.</h2>
-        </div>
-        <article className="editorial-home-card">
-          <p className="editorial-home-card-label">Month index</p>
-          <h3>{monthName}</h3>
-          <p>
-            {monthPosts.length} post{monthPosts.length !== 1 ? 's' : ''} arranged newest first, with summaries and topic links left visible for scanning.
-          </p>
-          {monthPosts[0] ? (
-            <div>
-              <p className="editorial-home-card-label">Featured post</p>
-              <Link href={`/posts/${monthPosts[0].slug}`} className="editorial-home-card-link">
-                {monthPosts[0].title}
-              </Link>
-              {monthPosts[0].summary && <p className="editorial-post-summary">{monthPosts[0].summary}</p>}
-              <div className="editorial-chip-row">
-                {monthPosts[0].tags.slice(0, 4).map((tag) => (
-                  <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
-                    {tag}
-                  </Link>
-                ))}
+        <div className="grid grid-cols-1 items-start gap-8 lg:grid-cols-12">
+          <article className="rounded-xl bg-surface-container-low p-8 transition-colors duration-300 hover:bg-surface-container-high lg:col-span-8 md:p-12">
+            <div className="flex flex-col gap-10 md:flex-row">
+              <div className="md:w-1/3">
+                <div className="rounded-lg bg-surface-container-highest p-6">
+                  <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Featured Post</p>
+                  <p className="mt-6 font-headline text-5xl font-black text-on-surface">{monthPosts.length}</p>
+                  <p className="mt-3 font-body text-sm leading-relaxed text-on-surface-variant">
+                    Post{monthPosts.length === 1 ? '' : 's'} published in {label}.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex flex-1 flex-col justify-center">
+                <time className="mb-4 font-headline text-xs font-bold uppercase tracking-widest text-secondary">
+                  {featuredPost ? longDateFormatter.format(featuredPost.date) : label}
+                </time>
+                <h2 className="mb-6 font-headline text-3xl font-extrabold leading-tight text-on-surface transition-colors hover:text-primary md:text-4xl">
+                  <Link href={`/posts/${featuredPost.slug}`}>{featuredPost.title}</Link>
+                </h2>
+                {featuredPost.summary ? (
+                  <p className="mb-8 font-body text-lg leading-relaxed text-on-surface-variant">
+                    {featuredPost.summary}
+                  </p>
+                ) : null}
+                <div className="flex flex-wrap gap-2">
+                  {featuredPost.tags.slice(0, 5).map((tag) => (
+                    <Link
+                      key={tag}
+                      href={`/tags/${encodeURIComponent(tag)}`}
+                      className="rounded-sm bg-surface px-3 py-1 font-label text-[10px] font-bold uppercase tracking-widest text-secondary transition-colors hover:bg-surface-container-highest hover:text-on-surface"
+                    >
+                      {tag}
+                    </Link>
+                  ))}
+                </div>
               </div>
             </div>
-          ) : null}
-          <ul className="posts-list">
-            {monthPosts.slice(1).map((post) => (
-              <li key={post.slug} className="archive-post">
-                <Link href={`/posts/${post.slug}`}>
-                  <time className="archive-post-date">{longDateFormatter.format(post.date)}</time>
-                  <span className="archive-post-title">{post.title}</span>
+          </article>
+
+          <aside className="space-y-8 lg:col-span-4 lg:sticky lg:top-32">
+            <div className="rounded-xl bg-surface-container-highest p-8">
+              <h3 className="mb-6 font-headline text-xs font-bold uppercase tracking-widest text-secondary">In This Month</h3>
+              <ul className="space-y-4">
+                {[
+                  ['Posts', `${monthPosts.length}`],
+                  ['Unique tags', `${uniqueTags}`],
+                  ['Year', yearLabel ?? year],
+                ].map(([labelText, value]) => (
+                  <li key={labelText} className="flex items-center justify-between border-b border-on-surface/5 pb-3">
+                    <span className="font-headline text-sm font-medium text-on-surface">{labelText}</span>
+                    <span className="font-body text-lg italic text-primary">{value}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="rounded-xl border border-outline-variant/20 bg-surface p-8">
+              <h3 className="mb-4 font-headline text-xs font-bold uppercase tracking-widest text-secondary">Navigate</h3>
+              <div className="flex flex-col gap-3">
+                <Link href="/archive" className="font-label text-xs font-bold uppercase tracking-widest text-primary">
+                  Back to archive
                 </Link>
-              </li>
-            ))}
-          </ul>
-          <Link href="/archive" className="editorial-home-card-link">
-            Back to archive
-          </Link>
-        </article>
-      </section>
+                <Link href="/tags" className="font-label text-xs font-bold uppercase tracking-widest text-primary">
+                  Browse tags
+                </Link>
+              </div>
+            </div>
+          </aside>
+
+          {remainingPosts.length > 0 ? (
+            <div className="grid grid-cols-1 gap-8 lg:col-span-8 md:grid-cols-2">
+              {remainingPosts.map((post) => (
+                <article
+                  key={post.slug}
+                  className="rounded-xl bg-surface-container-low p-8 transition-colors duration-300 hover:bg-surface-container-high"
+                >
+                  <time className="mb-3 block font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">
+                    {longDateFormatter.format(post.date)}
+                  </time>
+                  <h3 className="mb-3 font-headline text-2xl font-bold leading-tight text-on-surface">
+                    <Link href={`/posts/${post.slug}`} className="transition-colors hover:text-primary">
+                      {post.title}
+                    </Link>
+                  </h3>
+                  {post.summary ? (
+                    <p className="mb-5 font-body text-base leading-relaxed text-on-surface-variant">
+                      {post.summary}
+                    </p>
+                  ) : null}
+                  <div className="flex flex-wrap gap-2">
+                    {post.tags.slice(0, 4).map((tag) => (
+                      <Link
+                        key={`${post.slug}-${tag}`}
+                        href={`/tags/${encodeURIComponent(tag)}`}
+                        className="rounded-sm bg-surface px-2 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary transition-colors hover:bg-surface-container-highest hover:text-on-surface"
+                      >
+                        {tag}
+                      </Link>
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </main>
     </EditorialPageFrame>
   );
 }
 
 export async function generateStaticParams() {
   const allPosts = await postService.getAllPosts();
-
   const months = new Set<string>();
 
   allPosts.forEach((post) => {
-    const postDate = new Date(post.date);
-    const year = postDate.getFullYear();
-    const month = (postDate.getMonth() + 1).toString().padStart(2, '0');
+    const year = post.date.getFullYear();
+    const month = `${post.date.getMonth() + 1}`.padStart(2, '0');
     months.add(`${year}-${month}`);
   });
 
-  return Array.from(months).map((month) => ({
-    month,
-  }));
+  return Array.from(months).map((month) => ({ month }));
 }
 
 export async function generateMetadata({ params }: ArchivePageProps): Promise<Metadata> {
   const { month } = await params;
   const monthData = await getPostsForMonth(month);
 
-  if (!monthData) {
-    return {
-      title: 'Archive Not Found',
-    };
+  if (!monthData || monthData.monthPosts.length === 0) {
+    return { title: 'Archive Not Found | ECONOBEN.DEV' };
   }
 
-  const { year, monthNum, monthPosts } = monthData;
-  const monthName = new Date(parseInt(year), parseInt(monthNum) - 1).toLocaleDateString('en-US', {
+  const label = new Date(Number.parseInt(monthData.year, 10), Number.parseInt(monthData.monthNum, 10) - 1).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long',
   });
 
   return {
-    title: `Posts from ${monthName} | Ben Labaschin`,
-    description: `Browse ${monthPosts.length} post${monthPosts.length === 1 ? '' : 's'} from ${monthName}.`,
+    title: `${label} | Archive | ECONOBEN.DEV`,
+    description: `Browse ${monthData.monthPosts.length} post${monthData.monthPosts.length === 1 ? '' : 's'} from ${label}.`,
   };
 }

--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -1,86 +1,201 @@
 import Link from 'next/link';
 import { EditorialPageFrame } from '../components/EditorialPageFrame';
 
-const bookNotes = [
+const chapterInsights = [
   {
     label: 'What the book covers',
-    title: 'How AI systems remember, retrieve, compress, and decide what to act on.',
+    title: 'How memory, retrieval, compression, and action fit together in production agents.',
     summary:
       'The book is a practical guide to the mechanics behind durable agent behavior: storing useful context, retrieving it at the right time, and keeping the system understandable once it is in production.',
   },
   {
     label: 'Why it belongs here',
-    title: 'It extends the same practical arc as the posts, reports, and talks.',
+    title: 'It extends the same technical arc as the posts, reports, and talks.',
     summary:
-      'The page should make the book easy to understand before launch without turning it into a separate identity. The subject, audience, and technical point of view stay tied to the rest of the site.',
+      'The page should make the book easy to understand before launch without turning it into a separate identity. The subject, audience, and point of view stay tied to the rest of the site.',
+  },
+  {
+    label: 'What readers should take away',
+    title: 'Practical patterns for building memory systems people can trust.',
+    summary:
+      'The emphasis is on system design, operational trade-offs, and the architectural choices that determine whether long-running agents stay useful or become opaque.',
   },
 ];
+
+const bookFacts = [
+  ['Status', 'In progress'],
+  ['Publisher', "O'Reilly Media"],
+  ['Format', 'Print + digital'],
+  ['Focus', 'Agent memory systems'],
+] as const;
 
 export default function BookPage() {
   return (
     <EditorialPageFrame currentPath="/book">
-      <section className="editorial-book-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Forthcoming O&apos;Reilly book</p>
-          <h1 className="editorial-page-title">Agent Memory</h1>
-          <p className="editorial-page-copy">
-            A practical guide to how AI systems should remember, retrieve, compress, and act on information in production.
-          </p>
-          <div className="editorial-chip-row">
-            <span className="editorial-chip">Memory</span>
-            <span className="editorial-chip">Retrieval</span>
-            <span className="editorial-chip">Compression</span>
-            <span className="editorial-chip">Action</span>
+      <main className="mx-auto max-w-7xl px-8">
+        <header className="grid grid-cols-1 items-center gap-12 py-20 md:grid-cols-12 md:py-32">
+          <div className="space-y-8 md:col-span-7">
+            <div className="inline-block rounded-sm bg-[#bdc7db] px-3 py-1">
+              <span className="font-label text-xs font-bold uppercase tracking-widest text-[#121c2b]">
+                Forthcoming O&apos;Reilly Book
+              </span>
+            </div>
+            <h1 className="font-headline text-6xl font-black leading-none tracking-tighter text-[#1d1c16] md:text-8xl">
+              Agent
+              <br />
+              Memory.
+            </h1>
+            <p className="max-w-xl font-body text-2xl italic leading-relaxed text-[#555f70] md:text-3xl">
+              A practical guide to how AI systems should remember, retrieve, compress, and act on
+              information in production.
+            </p>
+            <div className="flex flex-wrap gap-6 pt-4">
+              <a
+                href="mailto:benjaminlabaschindev@gmail.com?subject=Agent%20Memory%20updates"
+                className="rounded-lg bg-[#2563eb] px-8 py-4 font-headline text-sm font-bold uppercase tracking-wider text-white shadow-[0_24px_40px_rgba(37,99,235,0.1)] transition-opacity hover:opacity-90"
+              >
+                Get book updates
+              </a>
+              <Link
+                href="/publications"
+                className="rounded-lg border border-[#c3c6d7] px-8 py-4 font-headline text-sm font-bold uppercase tracking-wider transition-colors hover:bg-[#f8f3e9]"
+              >
+                See related work
+              </Link>
+            </div>
           </div>
-          <div className="editorial-home-actions">
-            <a href="mailto:benjaminlabaschindev@gmail.com?subject=Agent%20Memory%20updates" className="editorial-home-button editorial-home-button-primary">
-              Get book updates
-            </a>
-            <Link href="/publications" className="editorial-home-button editorial-home-button-secondary">
-              See related work
-            </Link>
+
+          <div className="relative md:col-span-5">
+            <div className="relative flex aspect-[3/4] items-center justify-center overflow-hidden rounded-xl bg-[#e7e2d8] p-12 shadow-[0_24px_40px_rgba(29,28,22,0.05)]">
+              <div className="relative z-10 flex h-full w-full flex-col justify-between rounded-sm bg-[#1d1c16] p-8 text-[#fef9ef]">
+                <div className="space-y-1">
+                  <p className="font-headline text-[10px] uppercase tracking-[0.3em] opacity-60">
+                    Working Manuscript
+                  </p>
+                  <h2 className="font-headline text-4xl font-black leading-none">
+                    AGENT
+                    <br />
+                    MEMORY
+                  </h2>
+                </div>
+                <div className="space-y-4">
+                  <p className="font-body text-lg italic opacity-80">
+                    Practical memory systems for production agents.
+                  </p>
+                  <div className="h-px w-12 bg-[#fef9ef]/20" />
+                  <p className="font-headline text-xs font-bold uppercase tracking-widest">
+                    ECONOBEN.DEV
+                  </p>
+                </div>
+              </div>
+              <div className="pointer-events-none absolute inset-0 opacity-10 mix-blend-overlay">
+                <div className="absolute -mr-32 -mt-32 h-64 w-64 rounded-full border-[40px] border-[#004ac6]" />
+              </div>
+            </div>
           </div>
-        </div>
+        </header>
 
-        <aside className="editorial-home-book-card">
-          <p className="editorial-home-card-label">Working direction</p>
-          <h2>Practical memory systems for production agents.</h2>
-          <p>
-            One domain, one body of work, one list. The book should reinforce the site&apos;s technical arc, not split it into a second identity.
-          </p>
-          <div className="editorial-home-book-meta">
-            <span>in progress</span>
-            <span>O&apos;Reilly</span>
-            <span>agent memory</span>
+        <section className="py-20">
+          <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
+            <div className="flex min-h-[400px] flex-col justify-between rounded-xl bg-[#f8f3e9] p-12 md:col-span-2">
+              <div className="max-w-xl">
+                <span className="mb-4 block font-label text-xs font-bold uppercase tracking-widest text-[#004ac6]">
+                  Central Thesis
+                </span>
+                <h3 className="mb-6 font-headline text-4xl font-bold tracking-tight text-[#1d1c16]">
+                  The memory problem is really a systems problem.
+                </h3>
+                <p className="font-body text-xl leading-relaxed text-[#434655]">
+                  The book is about the mechanics that sit between a one-shot model call and a
+                  durable agent: what should be remembered, how it should be compressed, when it
+                  should be retrieved, and how those choices affect reliability once the system is
+                  live.
+                </p>
+              </div>
+              <div className="mt-8 flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#dbe1ff]">
+                  <span className="material-symbols-outlined text-[#00174b]" aria-hidden="true">
+                    psychology
+                  </span>
+                </div>
+                <span className="font-headline text-sm font-bold uppercase tracking-tight text-[#1d1c16]">
+                  Architectural Deep-Dive
+                </span>
+              </div>
+            </div>
+            <div className="flex flex-col justify-center rounded-xl bg-[#e7e2d8] p-10">
+              <h4 className="mb-6 font-headline text-5xl font-black text-[#1d1c16]/10">01.</h4>
+              <p className="font-body text-lg italic text-[#434655]">
+                Memory is not just storage. It is the structure that decides what historical intent
+                remains available to the agent when the next decision matters.
+              </p>
+            </div>
           </div>
-        </aside>
-      </section>
+        </section>
 
-      <section className="editorial-home-proof-strip" aria-label="Book summary">
-        <span>Memory systems</span>
-        <span>/</span>
-        <span>retrieval design</span>
-        <span>/</span>
-        <span>compression strategies</span>
-        <span>/</span>
-        <span>production AI</span>
-      </section>
+        <section className="border-t border-[#1d1c16]/5 py-20">
+          <div className="flex flex-col gap-16 md:flex-row">
+            <div className="md:w-1/3">
+              <h2 className="sticky top-32 font-headline text-4xl font-black tracking-tighter text-[#1d1c16]">
+                Chapter
+                <br />
+                Insights.
+              </h2>
+            </div>
+            <div className="space-y-16 md:w-2/3">
+              {chapterInsights.map((item) => (
+                <div key={item.label}>
+                  <span className="mb-2 block font-label text-xs uppercase tracking-widest text-[#555f70]">
+                    {item.label}
+                  </span>
+                  <h4 className="mb-4 font-headline text-2xl font-bold text-[#1d1c16] transition-colors hover:text-[#004ac6]">
+                    {item.title}
+                  </h4>
+                  <p className="max-w-2xl font-body text-lg leading-relaxed text-[#434655]">
+                    {item.summary}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
 
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Working notes</p>
-          <h2 className="editorial-page-section-title">The book page should answer three things quickly: what, why, and where it connects.</h2>
-        </div>
-        <div className="editorial-two-column">
-          {bookNotes.map((item) => (
-            <article key={item.label} className="editorial-home-card">
-              <p className="editorial-home-card-label">{item.label}</p>
-              <h3>{item.title}</h3>
-              <p>{item.summary}</p>
-            </article>
+        <section className="my-20 grid grid-cols-1 gap-12 rounded-xl bg-[#f8f3e9] p-12 md:grid-cols-4">
+          {bookFacts.map(([label, value]) => (
+            <div key={label} className="space-y-2">
+              <p className="font-label text-[10px] font-bold uppercase tracking-widest text-[#555f70]">
+                {label}
+              </p>
+              <p className="font-headline text-lg font-bold text-[#1d1c16]">{value}</p>
+            </div>
           ))}
-        </div>
-      </section>
+        </section>
+
+        <section className="flex justify-center py-32">
+          <div className="w-full max-w-3xl space-y-8 text-center">
+            <div className="space-y-4">
+              <h2 className="font-headline text-5xl font-black tracking-tighter text-[#1d1c16]">
+                Follow the research.
+              </h2>
+              <p className="font-body text-xl text-[#555f70]">
+                There is no fake signup form here. Email if you want updates on Agent Memory or
+                want to talk about the posts, talks, or publications that feed into it.
+              </p>
+            </div>
+            <div className="flex justify-center">
+              <a
+                href="mailto:benjaminlabaschindev@gmail.com?subject=Agent%20Memory%20updates"
+                className="rounded-md bg-[#1d1c16] px-8 py-4 font-headline text-xs font-bold uppercase tracking-widest text-[#fef9ef] transition-colors hover:bg-[#004ac6]"
+              >
+                Email for updates
+              </a>
+            </div>
+            <p className="font-label text-[10px] uppercase tracking-[0.2em] text-[#555f70]">
+              Posts, talks, and publications will keep carrying the work in the meantime.
+            </p>
+          </div>
+        </section>
+      </main>
     </EditorialPageFrame>
   );
 }

--- a/app/code-ai/[id]/page.tsx
+++ b/app/code-ai/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
@@ -35,23 +35,41 @@ const syntaxStyle = {
   background: 'transparent',
 } as const;
 
-const codeActionStyle = {
-  alignItems: 'center',
-  background: 'rgba(255, 255, 255, 0.72)',
-  border: '1px solid rgba(16, 34, 54, 0.08)',
-  borderRadius: '999px',
-  color: 'var(--editorial-ink)',
-  cursor: 'pointer',
-  display: 'inline-flex',
-  fontFamily: 'Inter, var(--font-body)',
-  fontSize: '0.82rem',
-  fontWeight: 700,
-  gap: '0.35rem',
-  justifyContent: 'center',
-  minHeight: '34px',
-  padding: '0 12px',
-  textDecoration: 'none',
-} as const;
+function MaterialIcon({ name, className = '' }: { name: string; className?: string }) {
+  return (
+    <span className={`material-symbols-outlined ${className}`.trim()} aria-hidden="true">
+      {name}
+    </span>
+  );
+}
+
+function DetailStat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <span className="block font-headline text-xl font-bold text-[#1d1c16]">{value}</span>
+      <span className="mt-1 block font-label text-[10px] font-bold uppercase tracking-widest text-[#555f70]">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function SidebarBlock({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-xl bg-[#f8f3e9] p-6">
+      <h3 className="mb-4 font-headline text-sm font-bold uppercase tracking-widest text-[#555f70]">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
 
 export async function generateStaticParams() {
   return getCodeToolsStaticParams();
@@ -70,7 +88,7 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   const canonicalUrl = `${getSiteUrl()}${getCodeToolsUrl(id)}`;
 
   return {
-    title: `${item.title} | Code & Tools | Ben Labaschin`,
+    title: `${item.title} | Code & Tools | ECONOBEN.DEV`,
     description: item.description,
     alternates: {
       canonical: canonicalUrl,
@@ -97,168 +115,227 @@ export default async function CodeAIDetailPage({ params }: { params: Promise<{ i
   const categoryConfig = getCodeToolsCategoryMeta(item.category);
   const relatedItems = getCodeToolsRelatedItems(item, 3);
   const lineCount = getCodeToolsItemLineCount(item);
-  const dateLabel = item.date ? formatCodeToolsDate(item.date, { year: 'numeric', month: 'long', day: 'numeric' }) : 'No date';
+  const dateLabel = item.date
+    ? formatCodeToolsDate(item.date, { year: 'numeric', month: 'long', day: 'numeric' })
+    : 'Undated';
+  const languageLabel = getCodeToolsLanguageLabel(item.language);
 
   return (
     <EditorialPageFrame currentPath="/code-ai" pageClassName="editorial-book-page">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Code & tools</p>
-          <h1 className="editorial-page-title">{item.title}</h1>
-          <p className="editorial-page-copy">{item.description}</p>
-          <p className="editorial-post-summary" style={{ marginTop: '14px', maxWidth: '58ch' }}>
-            The detail view keeps the writeup and code together, so the route behaves like the rest of the editorial site instead of a separate utility app.
-          </p>
-
-          <div className="editorial-home-actions">
-            <Link href="/code-ai" className="editorial-home-button editorial-home-button-secondary">
-              Back to Code & Tools
-            </Link>
-            {item.gistUrl && (
-              <a href={item.gistUrl} target="_blank" rel="noopener noreferrer" className="editorial-home-button editorial-home-button-primary">
-                View on GitHub
-              </a>
-            )}
+      <main className="mx-auto max-w-7xl px-8 py-16">
+        <section className="mb-20 grid grid-cols-1 gap-16 lg:grid-cols-12">
+          <div className="lg:col-span-8">
+            <div className="mb-6 flex flex-wrap items-center gap-3">
+              <span className="rounded-sm bg-[#bdc7db] px-3 py-1 font-label text-xs font-bold uppercase tracking-widest text-[#121c2b]">
+                {categoryConfig?.label || item.category}
+              </span>
+              <span className="font-label text-sm italic text-[#555f70]">{dateLabel}</span>
+            </div>
+            <h1 className="mb-6 font-headline text-5xl font-extrabold tracking-tight text-[#1d1c16]">
+              {item.title}
+            </h1>
+            <p className="max-w-2xl font-body text-xl italic leading-relaxed text-[#434655]">
+              {item.description}
+            </p>
+            <p className="mt-6 max-w-3xl font-body text-lg leading-relaxed text-[#555f70]">
+              The detail page keeps the writeup and source together, so the route behaves like the
+              rest of the editorial site instead of falling back to a disconnected tools surface.
+            </p>
           </div>
 
-          <div className="editorial-chip-row">
-            <span className="editorial-chip">{categoryConfig?.label || item.category}</span>
-            <span className="editorial-chip">{dateLabel}</span>
-            <span className="editorial-chip">{getCodeToolsLanguageLabel(item.language)}</span>
-            {item.filename && <span className="editorial-chip">{item.filename}</span>}
-            <span className="editorial-chip">{lineCount} lines</span>
-          </div>
-        </div>
-
-        <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">At a glance</p>
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">{categoryConfig?.label || item.category}</span>
-              <span className="editorial-page-metric-label">category</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">{getCodeToolsLanguageLabel(item.language)}</span>
-              <span className="editorial-page-metric-label">language</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">{item.filename || 'Inline snippet'}</span>
-              <span className="editorial-page-metric-label">source</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">{item.tags.length}</span>
-              <span className="editorial-page-metric-label">tags</span>
-            </div>
-          </div>
-        </aside>
-      </section>
-
-      <section className="editorial-home-proof-strip" aria-label="Code & Tools context">
-        <span>{categoryConfig?.label || item.category}</span>
-        <span>/</span>
-        <span>{dateLabel}</span>
-        <span>/</span>
-        <span>{lineCount} lines</span>
-        <span>/</span>
-        <span>{item.tags.length} tags</span>
-      </section>
-
-      <section className="editorial-list-section">
-        <div className="editorial-two-column">
-          <section style={{ display: 'grid', gap: '18px' }}>
-            {item.writeup && (
-              <div className="editorial-post-card" style={{ background: 'rgba(255, 255, 255, 0.58)' }}>
-                <p className="editorial-home-card-label">Writeup</p>
-                <div className="item-writeup" style={{ marginTop: '12px' }}>
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.writeup}</ReactMarkdown>
-                </div>
-              </div>
-            )}
-
-            <div style={codeBlockStyle}>
-              <div style={{ alignItems: 'center', display: 'flex', flexWrap: 'wrap', gap: '0.75rem', justifyContent: 'space-between', padding: '0.85rem 1rem' }}>
-                <div style={{ display: 'grid', gap: '0.18rem' }}>
-                  <div style={{ color: 'var(--editorial-ink)', fontFamily: 'IBM Plex Mono, Roboto Mono, monospace', fontSize: '0.78rem', fontWeight: 700, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
-                    {getCodeToolsLanguageLabel(item.language)}
-                  </div>
-                  <div style={{ color: 'var(--editorial-slate)', fontFamily: 'Inter, var(--font-body)', fontSize: '0.88rem' }}>
-                    {item.filename || 'Inline snippet'}
-                  </div>
-                </div>
-
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', justifyContent: 'flex-end' }}>
-                  {item.gistUrl && (
-                    <a href={item.gistUrl} target="_blank" rel="noopener noreferrer" style={codeActionStyle}>
-                      Gist
-                    </a>
-                  )}
-                  <span style={{ ...codeActionStyle, cursor: 'default' }}>{lineCount} lines</span>
-                </div>
+          <div className="flex flex-col justify-end lg:col-span-4">
+            <div className="space-y-6 rounded-xl bg-[#f8f3e9] p-8">
+              <div className="grid grid-cols-2 gap-6">
+                <DetailStat label="Language" value={languageLabel} />
+                <DetailStat label="Lines" value={lineCount} />
+                <DetailStat label="Tags" value={item.tags.length} />
+                <DetailStat label="Related" value={relatedItems.length} />
               </div>
 
-              <SyntaxHighlighter
-                language={normalizeCodeToolsLanguage(item.language)}
-                style={oneLight}
-                showLineNumbers
-                wrapLines
-                lineNumberStyle={{
-                  minWidth: '3em',
-                  paddingRight: '1em',
-                  textAlign: 'right',
-                  userSelect: 'none',
-                  opacity: 0.45,
-                }}
-                customStyle={syntaxStyle}
-                codeTagProps={{
-                  style: {
-                    fontFamily: "'IBM Plex Mono', 'Roboto Mono', 'Consolas', 'Monaco', monospace",
-                  },
-                }}
-              >
-                {item.content}
-              </SyntaxHighlighter>
+              <div className="flex flex-wrap gap-3">
+                <Link
+                  href="/code-ai"
+                  className="inline-flex flex-1 items-center justify-center gap-2 rounded-lg border border-[#c3c6d7] px-4 py-3 font-headline text-sm font-bold text-[#1d1c16] transition-colors hover:bg-white"
+                >
+                  <MaterialIcon name="arrow_back" className="text-sm" />
+                  Back to Code &amp; Tools
+                </Link>
+                {item.gistUrl && (
+                  <a
+                    href={item.gistUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex flex-1 items-center justify-center gap-2 rounded-lg bg-[#2563eb] px-4 py-3 font-headline text-sm font-bold text-white transition-opacity hover:opacity-90"
+                  >
+                    <MaterialIcon name="terminal" className="text-sm" />
+                    View on GitHub
+                  </a>
+                )}
+              </div>
             </div>
-          </section>
+          </div>
+        </section>
 
-          <aside style={{ display: 'grid', gap: '18px' }}>
-            <section className="editorial-page-aside">
-              <p className="editorial-home-card-label">Collection note</p>
-              <p className="editorial-post-summary" style={{ marginTop: '10px' }}>
-                This snippet stays in the editorial index alongside the rest of the collection, which keeps the browsing model stable as the presentation changes.
-              </p>
-            </section>
+        <section className="grid grid-cols-1 gap-16 lg:grid-cols-12">
+          <aside className="space-y-6 lg:col-span-3">
+            <SidebarBlock title="Overview">
+              <ul className="space-y-3 font-label text-sm text-[#1d1c16]">
+                <li className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[#004ac6]" />
+                  {categoryConfig?.label || item.category}
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[#004ac6]" />
+                  {languageLabel}
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[#004ac6]" />
+                  {dateLabel}
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[#004ac6]" />
+                  {lineCount} lines
+                </li>
+              </ul>
+            </SidebarBlock>
 
-            {relatedItems.length > 0 && (
-              <section className="editorial-page-aside">
-                <p className="editorial-home-card-label">Related snippets</p>
-                <div style={{ display: 'grid', gap: '14px', marginTop: '12px' }}>
-                  {relatedItems.map((relatedItem) => (
-                    <article key={relatedItem.id} style={{ paddingBottom: '14px', borderBottom: '1px solid rgba(16, 34, 54, 0.08)' }}>
-                      <h3 style={{ margin: 0, color: 'var(--editorial-ink)', fontFamily: 'Space Grotesk, Inter, sans-serif', fontSize: '1.2rem', letterSpacing: '-0.04em' }}>
-                        <Link href={getCodeToolsUrl(relatedItem.id)}>{relatedItem.title}</Link>
-                      </h3>
-                      <p className="editorial-post-summary" style={{ marginTop: '8px' }}>
-                        {relatedItem.description}
-                      </p>
-                    </article>
-                  ))}
-                </div>
-              </section>
-            )}
+            <SidebarBlock title="Source">
+              <div className="rounded-lg bg-[#e7e2d8] p-4 font-mono text-xs text-[#434655]">
+                <div>{item.filename || 'Inline snippet'}</div>
+                <div className="mt-2 break-all">{getCodeToolsUrl(item.id)}</div>
+              </div>
+            </SidebarBlock>
 
-            <section className="editorial-page-aside">
-              <p className="editorial-home-card-label">Tags</p>
-              <div className="editorial-chip-row" style={{ marginTop: '12px' }}>
+            <SidebarBlock title="Tags">
+              <div className="flex flex-wrap gap-2">
                 {item.tags.map((tag) => (
-                  <span key={tag} className="editorial-chip">
+                  <span
+                    key={tag}
+                    className="rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase tracking-widest text-[#555f70]"
+                  >
                     {tag}
                   </span>
                 ))}
               </div>
-            </section>
+            </SidebarBlock>
+
+            <SidebarBlock title="Collection note">
+              <p className="font-body text-sm leading-relaxed text-[#434655]">
+                This snippet stays in the same catalog as the rest of the workshop collection, so
+                browsing remains stable even as the presentation gets closer to the accepted Stitch
+                direction.
+              </p>
+            </SidebarBlock>
           </aside>
-        </div>
-      </section>
+
+          <div className="space-y-12 lg:col-span-9">
+            <article>
+              <h2 className="mb-6 font-headline text-3xl font-bold text-[#1d1c16]">
+                The implementation
+              </h2>
+              <p className="mb-8 font-body text-lg leading-relaxed text-[#434655]">
+                The detail page preserves the practical behavior of the original route: the writeup
+                stays readable, the source remains copyable and syntax highlighted, and the item can
+                still link back into the rest of the catalog.
+              </p>
+
+              {item.writeup && (
+                <div className="mb-10 rounded-xl bg-white/70 p-8 shadow-[0_16px_32px_rgba(24,36,49,0.08)]">
+                  <div className="item-writeup">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.writeup}</ReactMarkdown>
+                  </div>
+                </div>
+              )}
+
+              <div style={codeBlockStyle}>
+                <div className="flex items-center justify-between border-b border-[#d7d0c4] bg-[#f8f3e9] px-6 py-3">
+                  <div className="flex gap-2">
+                    <div className="h-3 w-3 rounded-full bg-[#ff5f56]" />
+                    <div className="h-3 w-3 rounded-full bg-[#ffbd2e]" />
+                    <div className="h-3 w-3 rounded-full bg-[#27c93f]" />
+                  </div>
+                  <span className="font-mono text-[10px] uppercase tracking-widest text-[#737686]">
+                    {item.filename || item.id}
+                  </span>
+                </div>
+                <SyntaxHighlighter
+                  language={normalizeCodeToolsLanguage(item.language)}
+                  style={oneLight}
+                  showLineNumbers
+                  wrapLines
+                  lineNumberStyle={{
+                    minWidth: '3em',
+                    paddingRight: '1em',
+                    textAlign: 'right',
+                    userSelect: 'none',
+                    opacity: 0.45,
+                  }}
+                  customStyle={syntaxStyle}
+                  codeTagProps={{
+                    style: {
+                      fontFamily:
+                        "'IBM Plex Mono', 'Roboto Mono', 'Consolas', 'Monaco', monospace",
+                    },
+                  }}
+                >
+                  {item.content}
+                </SyntaxHighlighter>
+              </div>
+            </article>
+
+            {relatedItems.length > 0 && (
+              <section className="mt-32 border-t border-[#1d1c16]/5 pt-16">
+                <div className="mb-12 flex items-end justify-between">
+                  <div>
+                    <h3 className="mb-2 font-headline text-xs font-black uppercase tracking-widest text-[#555f70]">
+                      More from the lab
+                    </h3>
+                    <h2 className="font-headline text-3xl font-bold text-[#1d1c16]">
+                      Related utilities
+                    </h2>
+                  </div>
+                  <Link
+                    href="/code-ai"
+                    className="inline-flex items-center gap-1 font-headline font-bold text-[#004ac6] hover:underline"
+                  >
+                    View full catalog
+                    <MaterialIcon name="arrow_forward" className="text-sm" />
+                  </Link>
+                </div>
+                <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
+                  {relatedItems.map((relatedItem) => (
+                    <Link
+                      key={relatedItem.id}
+                      href={getCodeToolsUrl(relatedItem.id)}
+                      className="rounded-xl bg-[#e7e2d8] p-8 transition-all hover:-translate-y-1"
+                    >
+                      <div className="mb-4 text-xs font-label font-bold uppercase tracking-widest text-[#004ac6]">
+                        {getCodeToolsCategoryMeta(relatedItem.category)?.label || relatedItem.category}
+                      </div>
+                      <h4 className="mb-2 font-headline text-xl font-bold text-[#1d1c16]">
+                        {relatedItem.title}
+                      </h4>
+                      <p className="mb-6 font-body text-sm text-[#434655]">
+                        {relatedItem.description}
+                      </p>
+                      <div className="flex items-center gap-4 font-label text-xs font-bold text-[#555f70]">
+                        <span className="flex items-center gap-1">
+                          <MaterialIcon name="code" className="text-xs" />
+                          {getCodeToolsLanguageLabel(relatedItem.language)}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <MaterialIcon name="history" className="text-xs" />
+                          {relatedItem.date ? formatCodeToolsDate(relatedItem.date) : 'Undated'}
+                        </span>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
+        </section>
+      </main>
     </EditorialPageFrame>
   );
 }

--- a/app/code-ai/page.tsx
+++ b/app/code-ai/page.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { EditorialPageFrame } from '../components/EditorialPageFrame';
 import { workshopConfig, type WorkshopItem } from '../config/workshopConfig';
 import {
   formatCodeToolsDate,
@@ -17,18 +18,6 @@ import {
   getCodeToolsUrl,
   normalizeCodeToolsLanguage,
 } from '../utils/codeTools';
-
-const editorialNavItems = [
-  { href: '/', label: 'Home' },
-  { href: '/posts', label: 'Posts' },
-  { href: '/talks', label: 'Talks' },
-  { href: '/publications', label: 'Publications' },
-  { href: '/book', label: 'Book' },
-  { href: '/archive', label: 'Archive' },
-  { href: '/search', label: 'Search' },
-  { href: '/about', label: 'About' },
-  { href: '/code-ai', label: 'Code & Tools' },
-];
 
 const codeBlockStyle = {
   background: 'rgba(246, 242, 233, 0.94)',
@@ -106,14 +95,6 @@ const compactCardStyle = {
   boxShadow: '0 16px 32px rgba(24, 36, 49, 0.08)',
   padding: '22px 24px 24px',
 } as const;
-
-function isActivePath(currentPath: string, href: string) {
-  if (href === '/') {
-    return currentPath === href;
-  }
-
-  return currentPath === href || currentPath.startsWith(`${href}/`);
-}
 
 function SnippetCodeBlock({ item, onCopy, copyLabel }: { item: WorkshopItem; onCopy: () => void; copyLabel: string }) {
   return (
@@ -225,33 +206,8 @@ export default function CodeAIPage() {
   };
 
   return (
-    <div className="editorial-home-page">
-      <div className="editorial-home-shell">
-        <header className="editorial-home-topbar">
-          <div className="editorial-home-brand">
-            <Link href="/" className="editorial-home-brand-link" aria-label="Go to home">
-              <p className="editorial-home-brand-name">BEN LABASCHIN</p>
-            </Link>
-            <p className="editorial-home-brand-note">AI systems, memory, and editorial writing</p>
-          </div>
-          <nav className="editorial-home-nav" aria-label="Primary">
-            {editorialNavItems.map((item) => {
-              const active = isActivePath('/code-ai', item.href);
-
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className={`editorial-home-nav-link ${active ? 'is-active' : ''}`}
-                  aria-current={active ? 'page' : undefined}
-                >
-                  {item.label}
-                </Link>
-              );
-            })}
-          </nav>
-        </header>
-
+    <EditorialPageFrame currentPath="/code-ai">
+      <div className="editorial-home-page">
         <main className="editorial-home-content">
           <section className="editorial-page-hero">
             <div className="editorial-page-hero-copy">
@@ -625,6 +581,6 @@ export default function CodeAIPage() {
           </section>
         </main>
       </div>
-    </div>
+    </EditorialPageFrame>
   );
 }

--- a/app/components/EditorialPageFrame.tsx
+++ b/app/components/EditorialPageFrame.tsx
@@ -99,6 +99,7 @@ export function EditorialTopbar({ currentPath }: { currentPath: string }) {
               key={item.href}
               href={item.href}
               className={mobileNavItemClassName(active)}
+              style={{ color: active ? '#fef9ef' : '#555f70' }}
               aria-current={active ? 'page' : undefined}
             >
               {item.label}

--- a/app/components/EditorialPageFrame.tsx
+++ b/app/components/EditorialPageFrame.tsx
@@ -51,8 +51,8 @@ export function EditorialTopbar({ currentPath }: { currentPath: string }) {
     : 'hidden md:flex items-center gap-8 font-headline text-sm font-medium tracking-tight';
   const mobileNavItemClassName = (active: boolean) =>
     active
-      ? 'rounded-full bg-[#004ac6] px-3 py-2 text-[11px] font-bold uppercase tracking-widest text-white shadow-[0_8px_18px_rgba(0,74,198,0.18)]'
-      : 'rounded-full border border-[#1d1c16]/10 bg-[#f8f3e9]/90 px-3 py-2 text-[11px] font-bold uppercase tracking-widest text-[#555f70] transition-colors duration-200 hover:border-[#004ac6]/30 hover:text-[#004ac6]';
+      ? 'inline-flex min-h-[34px] items-center justify-center rounded-full bg-[#004ac6] px-3 py-2 text-[11px] font-bold uppercase leading-none tracking-widest whitespace-nowrap text-[#fef9ef] shadow-[0_8px_18px_rgba(0,74,198,0.18)]'
+      : 'inline-flex min-h-[34px] items-center justify-center rounded-full border border-[#1d1c16]/10 bg-[#f8f3e9]/90 px-3 py-2 text-[11px] font-bold uppercase leading-none tracking-widest whitespace-nowrap text-[#555f70] transition-colors duration-200 hover:border-[#004ac6]/30 hover:text-[#004ac6]';
 
   return (
     <header className={headerClassName}>

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { EditorialPageFrame } from '../../components/EditorialPageFrame';
@@ -18,6 +18,13 @@ const monthYearFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'long',
 });
 
+type Post = Awaited<ReturnType<typeof postService.getAllPosts>>[number];
+
+const createDescription = (post: Post) => {
+  const content = post.summary || post.content.replace(/\s+/g, ' ').trim();
+  return content.slice(0, 180);
+};
+
 export async function generateStaticParams() {
   const posts = await postService.getAllPosts();
   return posts.map((post) => ({
@@ -31,34 +38,27 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 
   if (!post) {
     return {
-      title: 'Post Not Found | Ben Labaschin',
+      title: 'Post Not Found | ECONOBEN.DEV',
     };
   }
 
-  // Generate OG image URL
-  const imageUrl = post.coverImage
-    ? `https://econoben.dev${post.coverImage}`
-    : (() => {
-        const ogImageParams = new URLSearchParams({
-          title: post.title,
-          date: post.date.toISOString(),
-          tags: post.tags.join(','),
-          ...(post.summary && { summary: post.summary }),
-        });
-        return `https://econoben.dev/api/og?${ogImageParams.toString()}`;
-      })();
-  const description = post.summary || post.content.replace(/\s+/g, ' ').slice(0, 160);
+  const imageUrl = post.coverImage?.startsWith('http')
+    ? post.coverImage
+    : post.coverImage
+      ? `https://econoben.dev${post.coverImage}`
+      : undefined;
+  const description = createDescription(post);
 
   return {
-    title: `${post.title} | Ben Labaschin`,
+    title: `${post.title} | Posts | ECONOBEN.DEV`,
     description,
     openGraph: {
       type: 'article',
       title: post.title,
       description,
       url: `https://econoben.dev/posts/${slug}`,
-      images: [imageUrl],
-      siteName: 'Ben Labaschin',
+      images: imageUrl ? [imageUrl] : undefined,
+      siteName: 'ECONOBEN.DEV',
       publishedTime: post.date.toISOString(),
       authors: ['Benjamin Labaschin'],
       tags: post.tags,
@@ -67,7 +67,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
       card: 'summary_large_image',
       title: post.title,
       description,
-      images: [imageUrl],
+      images: imageUrl ? [imageUrl] : undefined,
     },
   };
 }
@@ -75,6 +75,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 export default async function PostPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const post = await postService.getPostBySlug(slug);
+  const allPosts = await postService.getAllPosts();
 
   if (!post) {
     notFound();
@@ -83,17 +84,22 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
   const primaryTag = post.tags[0];
   const audioUrl = audioManifest[slug as keyof typeof audioManifest];
   const archiveMonth = post.date.toISOString().slice(0, 7);
+  const currentIndex = allPosts.findIndex((item) => item.slug === post.slug);
+  const newerPost = currentIndex > 0 ? allPosts[currentIndex - 1] : undefined;
+  const olderPost = currentIndex >= 0 ? allPosts[currentIndex + 1] : undefined;
 
   return (
     <EditorialPageFrame currentPath="/posts">
       <section className="editorial-page-hero">
         <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">{primaryTag ?? 'Essay'}</p>
+          <p className="editorial-home-kicker">{primaryTag ?? 'Post'}</p>
           <h1 className="editorial-page-title">{post.title}</h1>
           {post.summary && <p className="editorial-page-copy">{post.summary}</p>}
-          <p className="editorial-post-summary">
-            Published {longDateFormatter.format(post.date)}{post.readingTime ? ` · ${post.readingTime} min read` : ''} and filed with the post archive.
-          </p>
+          <div className="editorial-post-meta">
+            <span>Published {longDateFormatter.format(post.date)}</span>
+            <span>{post.readingTime ? `${post.readingTime} min read` : 'Long-form post'}</span>
+            <span>Filed in {monthYearFormatter.format(post.date)}</span>
+          </div>
           <div className="editorial-home-actions">
             <Link href="/posts" className="editorial-home-button editorial-home-button-secondary">
               Back to posts
@@ -120,10 +126,19 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
               <span className="editorial-page-metric-label">reading length</span>
             </div>
             <div>
-              <span className="editorial-page-metric-value">{monthYearFormatter.format(post.date)}</span>
-              <span className="editorial-page-metric-label">filed in</span>
+              <span className="editorial-page-metric-value">{post.tags.length}</span>
+              <span className="editorial-page-metric-label">topics</span>
             </div>
           </div>
+          {audioUrl ? (
+            <AudioPlayer
+              audioUrl={audioUrl}
+              title="Listen to this post"
+              className="post-audio-player"
+            />
+          ) : (
+            <p className="editorial-post-summary">No audio version is available for this post yet.</p>
+          )}
           <div className="editorial-chip-row">
             {post.tags.length > 0
               ? post.tags.map((tag) => (
@@ -133,28 +148,66 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
                 ))
               : <span className="editorial-chip">Essay</span>}
           </div>
+          {post.coverImage ? (
+            <img
+              src={post.coverImage}
+              alt={post.title}
+              className="blog-image"
+            />
+          ) : null}
         </aside>
       </section>
 
-      <section className="editorial-home-proof-strip" aria-label="Post context">
-        <span>{primaryTag ?? 'Essay'}</span>
-        <span>/</span>
-        <span>{monthYearFormatter.format(post.date)}</span>
-        <span>/</span>
-        <span>{post.readingTime ? `${post.readingTime} minute read` : 'long-form note'}</span>
-      </section>
-
       <section className="editorial-list-section">
-        {audioUrl && (
-          <AudioPlayer
-            audioUrl={audioUrl}
-            title="Listen to this post"
-            className="post-audio-player"
-          />
-        )}
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Article</p>
+          <h2 className="editorial-page-section-title">Markdown, links, code blocks, and embedded media stay intact in the reading view.</h2>
+        </div>
 
         <div className="blog-content">
           <MarkdownRenderer content={post.content} />
+        </div>
+      </section>
+
+      <section className="editorial-list-section">
+        <div className="editorial-list-heading">
+          <p className="editorial-home-section-label">Related reading</p>
+          <h2 className="editorial-page-section-title">Move to the adjacent posts in the archive.</h2>
+        </div>
+        <div className="editorial-two-column">
+          {newerPost ? (
+            <article className="editorial-home-card">
+              <p className="editorial-home-card-label">Newer post</p>
+              <h3>
+                <Link href={`/posts/${newerPost.slug}`}>{newerPost.title}</Link>
+              </h3>
+              {newerPost.summary && <p>{newerPost.summary}</p>}
+              <div className="editorial-post-meta">
+                <span>{longDateFormatter.format(newerPost.date)}</span>
+                <span>{newerPost.readingTime ? `${newerPost.readingTime} min read` : 'Long-form post'}</span>
+              </div>
+              <Link href={`/posts/${newerPost.slug}`} className="editorial-home-card-link">
+                Read newer post
+              </Link>
+            </article>
+          ) : null}
+
+          {olderPost ? (
+            <article className="editorial-home-card">
+              <p className="editorial-home-card-label">Older post</p>
+              <h3>
+                <Link href={`/posts/${olderPost.slug}`}>{olderPost.title}</Link>
+              </h3>
+              {olderPost.summary && <p>{olderPost.summary}</p>}
+              <div className="editorial-post-meta">
+                <span>{longDateFormatter.format(olderPost.date)}</span>
+                <span>{olderPost.readingTime ? `${olderPost.readingTime} min read` : 'Long-form post'}</span>
+              </div>
+              <Link href={`/posts/${olderPost.slug}`} className="editorial-home-card-link">
+                Read older post
+              </Link>
+            </article>
+          ) : null}
         </div>
       </section>
     </EditorialPageFrame>

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -1,19 +1,24 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { EditorialPageFrame } from '../components/EditorialPageFrame';
 import { postService } from '../services/PostService';
 
 export const metadata: Metadata = {
-  title: 'Posts | Ben Labaschin',
-  description: 'Posts, field notes, and technical writing on AI systems, memory, engineering practice, and adjacent work.',
+  title: 'Posts | ECONOBEN.DEV',
+  description: 'A chronological archive of essays, reports, and field notes on AI systems, memory, engineering practice, and adjacent work.',
 };
 
 type Posts = Awaited<ReturnType<typeof postService.getAllPosts>>;
 
-const formatter = new Intl.DateTimeFormat('en-US', {
+const shortDateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'short',
   day: 'numeric',
+});
+
+const monthFormatter = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: 'long',
 });
 
 const countTags = (posts: Posts) => {
@@ -26,8 +31,7 @@ const countTags = (posts: Posts) => {
   });
 
   return Array.from(counts.entries())
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 4);
+    .sort((a, b) => b[1] - a[1]);
 };
 
 const groupPostsByYear = (posts: Posts) => {
@@ -51,18 +55,19 @@ const groupPostsByYear = (posts: Posts) => {
 export default async function PostsPage() {
   const posts = await postService.getAllPosts();
   const featuredPost = posts[0];
-  const topTags = countTags(posts);
+  const topTags = countTags(posts).slice(0, 4);
   const postsByYear = groupPostsByYear(posts);
-  const publicationYears = postsByYear.length;
+  const uniqueTagCount = new Set(posts.flatMap((post) => post.tags)).size;
+  const mostRecentMonth = featuredPost ? monthFormatter.format(featuredPost.date) : 'No posts yet';
 
   return (
     <EditorialPageFrame currentPath="/posts">
       <section className="editorial-page-hero">
         <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Writing archive</p>
+          <p className="editorial-home-kicker">Reading archive</p>
           <h1 className="editorial-page-title">Posts</h1>
           <p className="editorial-page-copy">
-            Posts, field notes, and working-throughs on agent memory, AI systems, engineering practice, and the occasional economics detour, arranged so the newest work stays easy to find.
+            A chronological archive of essays, reports, and field notes. Start with the newest post, then move backward by year when you want more context.
           </p>
           <div className="editorial-chip-row">
             {topTags.map(([tag, count]) => (
@@ -73,54 +78,51 @@ export default async function PostsPage() {
           </div>
         </div>
         <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">At a glance</p>
+          <p className="editorial-home-card-label">Archive details</p>
           <div className="editorial-page-metric-list">
             <div>
               <span className="editorial-page-metric-value">{posts.length}</span>
-              <span className="editorial-page-metric-label">posts in the archive</span>
+              <span className="editorial-page-metric-label">posts</span>
             </div>
             <div>
-              <span className="editorial-page-metric-value">{publicationYears}</span>
-              <span className="editorial-page-metric-label">years represented</span>
+              <span className="editorial-page-metric-value">{uniqueTagCount}</span>
+              <span className="editorial-page-metric-label">topics</span>
+            </div>
+            <div>
+              <span className="editorial-page-metric-value">{postsByYear.length}</span>
+              <span className="editorial-page-metric-label">years</span>
             </div>
           </div>
-          {featuredPost && (
-            <p className="editorial-post-summary">
-              Latest: {featuredPost.title} on {formatter.format(featuredPost.date)}.
-            </p>
-          )}
-          {featuredPost && (
+          <p className="editorial-post-summary">
+            Latest month: {mostRecentMonth}
+          </p>
+          {featuredPost ? (
             <Link href={`/posts/${featuredPost.slug}`} className="editorial-home-button editorial-home-button-secondary">
-              Start with the latest post
+              Read the latest post
             </Link>
-          )}
+          ) : null}
         </aside>
       </section>
 
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Latest post</p>
-          <h2 className="editorial-page-section-title">Start with the latest post, then move backward by year.</h2>
+          <p className="editorial-home-section-label">Featured post</p>
+          <h2 className="editorial-page-section-title">The newest post stays up front so you can jump straight into the current thread.</h2>
         </div>
+
         {featuredPost ? (
           <article className="editorial-home-card">
-            <p className="editorial-home-card-label">{formatter.format(featuredPost.date)}</p>
+            <p className="editorial-home-card-label">{shortDateFormatter.format(featuredPost.date)}</p>
             <h3>
               <Link href={`/posts/${featuredPost.slug}`}>{featuredPost.title}</Link>
             </h3>
             {featuredPost.summary && <p>{featuredPost.summary}</p>}
             <div className="editorial-post-meta">
-              {featuredPost.tags[0] ? (
-                <Link href={`/tags/${encodeURIComponent(featuredPost.tags[0])}`} className="editorial-chip">
-                  <span>{featuredPost.tags[0]}</span>
-                </Link>
-              ) : (
-                <span className="editorial-chip">Post</span>
-              )}
-              <span>{featuredPost.readingTime ? `${featuredPost.readingTime} min read` : 'Long-form note'}</span>
+              <span>{featuredPost.readingTime ? `${featuredPost.readingTime} min read` : 'Long-form post'}</span>
+              <span>{featuredPost.tags.length} topic{featuredPost.tags.length === 1 ? '' : 's'}</span>
             </div>
             <div className="editorial-chip-row">
-              {featuredPost.tags.slice(0, 3).map((tag) => (
+              {featuredPost.tags.slice(0, 4).map((tag) => (
                 <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
                   {tag}
                 </Link>
@@ -135,8 +137,8 @@ export default async function PostsPage() {
 
       <section className="editorial-list-section">
         <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">By year</p>
-          <h2 className="editorial-page-section-title">A compact index that keeps each year readable on mobile.</h2>
+          <p className="editorial-home-section-label">Archive by year</p>
+          <h2 className="editorial-page-section-title">Browse the rest of the archive in compact yearly groups.</h2>
         </div>
 
         <div className="editorial-two-column">
@@ -144,25 +146,24 @@ export default async function PostsPage() {
             <article key={year} className="editorial-home-card">
               <p className="editorial-home-card-label">Year {year}</p>
               <h3>{yearPosts.length} post{yearPosts.length !== 1 ? 's' : ''}</h3>
-              <p>Newest first, with each post left visible so the archive can be scanned without opening every page.</p>
-              {yearPosts[0] ? (
-                <div>
-                  <p className="editorial-home-card-label">Featured post</p>
-                  <Link href={`/posts/${yearPosts[0].slug}`} className="editorial-home-card-link">
-                    {yearPosts[0].title}
-                  </Link>
-                  {yearPosts[0].summary && <p className="editorial-post-summary">{yearPosts[0].summary}</p>}
-                </div>
-              ) : null}
+              <p>Newest first, with summaries and topics kept visible so the year stays easy to scan.</p>
               <ul className="posts-list">
-                {yearPosts.slice(1).map((post) => (
+                {yearPosts.map((post) => (
                   <li key={post.slug} className="archive-post">
                     <Link href={`/posts/${post.slug}`}>
                       <time className="archive-post-date">
-                        {post.date.getDate().toString().padStart(2, '0')}
+                        {shortDateFormatter.format(post.date)}
                       </time>
                       <span className="archive-post-title">{post.title}</span>
                     </Link>
+                    {post.summary && <p className="editorial-post-summary">{post.summary}</p>}
+                    <div className="editorial-chip-row">
+                      {post.tags.slice(0, 3).map((tag) => (
+                        <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
+                          {tag}
+                        </Link>
+                      ))}
+                    </div>
                   </li>
                 ))}
               </ul>

--- a/app/publications/page.tsx
+++ b/app/publications/page.tsx
@@ -8,10 +8,12 @@ export const metadata: Metadata = {
 };
 
 export default function PublicationsPage() {
-  const { publications } = publicationsConfig;
+  const { publications, subtitle } = publicationsConfig;
   const sortedPublications = [...publications].sort(
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
   );
+  const featuredPublication =
+    sortedPublications.find((publication) => publication.featured) ?? sortedPublications[0];
   const publicationsByYear = sortedPublications.reduce<Record<number, Publication[]>>((groups, publication) => {
     if (!groups[publication.year]) {
       groups[publication.year] = [];
@@ -37,86 +39,198 @@ export default function PublicationsPage() {
       other: 0,
     }
   );
-  const latestPublication = sortedPublications[0];
-  const summaryItems = [
-    publicationTypeCounts.book > 0 ? `${publicationTypeCounts.book} books` : null,
-    publicationTypeCounts.journal > 0 ? `${publicationTypeCounts.journal} journal article${publicationTypeCounts.journal > 1 ? 's' : ''}` : null,
-    publicationTypeCounts.report > 0 ? `${publicationTypeCounts.report} reports` : null,
-    publicationTypeCounts.conference > 0 ? `${publicationTypeCounts.conference} conference paper${publicationTypeCounts.conference > 1 ? 's' : ''}` : null,
-    publicationTypeCounts.workshop > 0 ? `${publicationTypeCounts.workshop} workshop paper${publicationTypeCounts.workshop > 1 ? 's' : ''}` : null,
-    publicationTypeCounts.other > 0 ? `${publicationTypeCounts.other} other pieces` : null,
-  ].filter((item): item is string => Boolean(item));
 
   return (
     <EditorialPageFrame currentPath="/publications">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Writing</p>
-          <h1 className="editorial-page-title">Publications</h1>
-          <p className="editorial-page-copy">
-            Books, reports, and papers, newest first.
+      <section className="mx-auto grid max-w-7xl grid-cols-1 gap-10 px-8 pb-12 pt-20 lg:grid-cols-12 lg:items-end">
+        <div className="lg:col-span-8">
+          <span className="mb-6 block font-label text-xs font-bold uppercase tracking-[0.2em] text-secondary">
+            Archive and research
+          </span>
+          <h1 className="max-w-4xl font-headline text-5xl font-black tracking-tighter text-on-surface md:text-7xl">
+            Publications
+          </h1>
+          <p className="mt-6 max-w-3xl font-body text-xl leading-relaxed text-secondary md:text-2xl">
+            {subtitle}
           </p>
-          <div className="editorial-chip-row">
-            <span className="editorial-chip">Books</span>
-            <span className="editorial-chip">Papers</span>
-            <span className="editorial-chip">Reports</span>
-            <span className="editorial-chip">PDFs</span>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <span className="rounded-full bg-surface-container-low px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider text-secondary">
+              Books
+            </span>
+            <span className="rounded-full bg-surface-container-low px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider text-secondary">
+              Papers
+            </span>
+            <span className="rounded-full bg-surface-container-low px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider text-secondary">
+              Reports
+            </span>
+            <span className="rounded-full bg-surface-container-low px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider text-secondary">
+              PDFs and DOI records
+            </span>
           </div>
         </div>
-        <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">Quick access</p>
-          <p className="editorial-post-summary">
-            Jump by year or open the newest publication directly.
-          </p>
-          {latestPublication && (
-            <a href={getPublicationHref(latestPublication)} target="_blank" rel="noopener noreferrer" className="editorial-post-link">
-              Open latest: {latestPublication.title}
-            </a>
-          )}
-          <div className="editorial-chip-row" style={{ marginTop: '16px' }}>
-            {publicationYears.map((year) => (
-              <a key={year} href={`#publication-year-${year}`} className="editorial-chip" style={{ textDecoration: 'none' }}>
-                {year}
-              </a>
-            ))}
+
+        <aside className="rounded-2xl bg-surface-container-low p-8 lg:col-span-4">
+          <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">Quick access</p>
+          <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-1">
+            <div className="rounded-xl bg-surface-container-highest p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Entries</p>
+              <p className="mt-2 font-headline text-3xl font-bold text-on-surface">{publications.length}</p>
+            </div>
+            <div className="rounded-xl bg-surface-container-highest p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Books</p>
+              <p className="mt-2 font-headline text-3xl font-bold text-on-surface">{publicationTypeCounts.book}</p>
+            </div>
           </div>
-          <div style={{ display: 'grid', gap: '10px', marginTop: '18px' }}>
-            {sortedPublications.slice(0, 3).map((publication) => (
-              <a
-                key={publication.id}
-                href={`#${publication.id}`}
-                className="editorial-post-link"
-                style={{ marginTop: 0 }}
-              >
-                {formatPublicationDate(publication.date)} · {publication.title}
-              </a>
-            ))}
+          <div className="mt-6 space-y-3 border-t border-outline-variant/30 pt-6">
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary">Featured publication</p>
+            {featuredPublication && (
+              <>
+                <p className="font-headline text-xl font-bold leading-snug text-on-surface">{featuredPublication.title}</p>
+                <p className="font-body text-sm leading-relaxed text-secondary">{featuredPublication.venue ?? featuredPublication.authors}</p>
+              </>
+            )}
           </div>
         </aside>
       </section>
 
-      <section className="editorial-home-proof-strip" aria-label="Publications summary">
-        <span>{publications.length} publications</span>
-        <span>/</span>
-        <span>{summaryItems[0] ?? 'books'}</span>
-        <span>/</span>
-        <span>{summaryItems[1] ?? 'journal articles'}</span>
-        <span>/</span>
-        <span>{summaryItems[2] ?? 'reports'}</span>
+      {featuredPublication && (
+        <section className="mx-auto grid max-w-7xl grid-cols-1 gap-8 px-8 pb-8 lg:grid-cols-12">
+          <article className="overflow-hidden rounded-2xl bg-surface-container-highest shadow-[0_24px_60px_rgba(29,28,22,0.06)] lg:col-span-8">
+            <div className="grid gap-0 lg:grid-cols-[minmax(0,0.95fr)_minmax(320px,1.05fr)]">
+              <div className="bg-surface-container-low p-10">
+                {featuredPublication.coverImage ? (
+                  <img
+                    src={featuredPublication.coverImage}
+                    alt={featuredPublication.title}
+                    className="aspect-[4/5] w-full rounded-xl object-cover shadow-xl"
+                  />
+                ) : (
+                  <div className="flex aspect-[4/5] w-full items-center justify-center rounded-xl bg-[linear-gradient(135deg,_#1d1c16,_#32302a)] p-8 text-[#fef9ef]">
+                    <div className="max-w-xs space-y-3 text-center">
+                      <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary-fixed-dim">Featured</p>
+                      <p className="font-headline text-3xl font-bold leading-tight">{featuredPublication.title}</p>
+                    </div>
+                  </div>
+                )}
+              </div>
+              <div className="flex flex-col justify-between p-8 lg:p-10">
+                <div className="space-y-6">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <span className="rounded-sm bg-secondary-fixed-dim px-3 py-1 font-label text-[10px] font-bold uppercase tracking-[0.2em] text-on-secondary-fixed-variant">
+                      Featured work
+                    </span>
+                    <span className="font-label text-xs uppercase tracking-widest text-secondary">{formatPublicationDate(featuredPublication.date)}</span>
+                  </div>
+                  <div className="space-y-4">
+                    <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary">
+                      {getPublicationType(featuredPublication)}
+                    </p>
+                    <h2 className="max-w-2xl font-headline text-3xl font-bold tracking-tight text-on-surface lg:text-4xl">
+                      {featuredPublication.title}
+                    </h2>
+                    <p className="max-w-2xl font-body text-lg leading-relaxed text-secondary">
+                      {featuredPublication.abstract}
+                    </p>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <MetaCard label="Authors" value={featuredPublication.authors} />
+                    <MetaCard label="Venue" value={featuredPublication.venue ?? 'Unspecified'} />
+                    <MetaCard label="Year" value={String(featuredPublication.year)} />
+                    <MetaCard label="Topics" value={featuredPublication.topics.slice(0, 4).join(', ')} />
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {featuredPublication.topics.slice(0, 6).map((topic) => (
+                      <span key={topic} className="rounded-full bg-surface-container-low px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
+                        {topic}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <div className="mt-8 flex flex-wrap gap-3">
+                  {(() => {
+                    const href = getPublicationHref(featuredPublication);
+
+                    if (!href) {
+                      return null;
+                    }
+
+                    return (
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center justify-center rounded-lg bg-primary-container px-5 py-3 font-label text-xs font-bold uppercase tracking-widest text-on-primary"
+                      >
+                        {getPublicationActionLabel(featuredPublication)}
+                      </a>
+                    );
+                  })()}
+                  {featuredPublication.bibtex && (
+                    <a
+                      href={`data:text/plain;charset=utf-8,${encodeURIComponent(featuredPublication.bibtex)}`}
+                      download={`${featuredPublication.id}.bib`}
+                      className="inline-flex items-center justify-center rounded-lg bg-surface-container-low px-5 py-3 font-label text-xs font-bold uppercase tracking-widest text-on-surface"
+                    >
+                      Download BibTeX
+                    </a>
+                  )}
+                </div>
+              </div>
+            </div>
+          </article>
+
+          <aside className="flex flex-col gap-4 rounded-2xl bg-surface-container-low p-8 lg:col-span-4">
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">Index</p>
+            {publicationYears.map((year) => (
+              <a
+                key={year}
+                href={`#publication-year-${year}`}
+                className="flex items-center justify-between rounded-xl bg-surface-container-highest px-4 py-3 transition-colors hover:bg-secondary-container hover:text-primary"
+              >
+                <span className="font-headline text-base font-bold text-on-surface">{year}</span>
+                <span className="font-label text-[10px] font-bold uppercase tracking-widest text-secondary">
+                  {publicationsByYear[year].length} items
+                </span>
+              </a>
+            ))}
+          </aside>
+        </section>
+      )}
+
+      <section className="mx-auto grid max-w-7xl grid-cols-1 gap-10 px-8 pb-16 lg:grid-cols-12">
+        <div className="rounded-2xl bg-surface-container-low p-8 lg:col-span-12">
+          <div className="flex flex-wrap items-center gap-4 text-xs font-bold uppercase tracking-widest text-secondary">
+            <span>{publications.length} publications</span>
+            <span className="h-1 w-1 rounded-full bg-outline-variant" />
+            <span>{publicationTypeCounts.book} books</span>
+            <span className="h-1 w-1 rounded-full bg-outline-variant" />
+            <span>{publicationTypeCounts.journal} journal articles</span>
+            <span className="h-1 w-1 rounded-full bg-outline-variant" />
+            <span>{publicationTypeCounts.report} reports</span>
+          </div>
+        </div>
       </section>
 
       {publicationYears.map((year) => {
         const yearPublications = publicationsByYear[year];
 
         return (
-          <section key={year} className="editorial-list-section" id={`publication-year-${year}`}>
-            <div className="editorial-list-heading">
-              <p className="editorial-home-section-label">{year}</p>
-              <h2 className="editorial-page-section-title">Publications from {year}.</h2>
+          <section key={year} className="mx-auto max-w-7xl px-8 pb-16" id={`publication-year-${year}`}>
+            <div className="mb-8 grid gap-4 lg:grid-cols-12 lg:items-end">
+              <div className="lg:col-span-8">
+                <p className="font-label text-xs font-bold uppercase tracking-[0.2em] text-secondary">{year}</p>
+                <h2 className="mt-3 font-headline text-3xl font-bold tracking-tight text-on-surface">
+                  Publications from {year}
+                </h2>
+              </div>
+              <div className="lg:col-span-4 lg:text-right">
+                <p className="font-body text-base italic text-secondary">{yearPublications.length} item{yearPublications.length === 1 ? '' : 's'} in this section</p>
+              </div>
             </div>
-            <div className="editorial-timeline">
+
+            <div className="grid gap-8 md:grid-cols-2 xl:grid-cols-3">
               {yearPublications.map((publication) => (
-                <PublicationEntry key={publication.id} publication={publication} />
+                <PublicationCard key={publication.id} publication={publication} />
               ))}
             </div>
           </section>
@@ -168,10 +282,19 @@ function getPublicationActionLabel(publication: Publication) {
     return 'View DOI record';
   }
 
-  return undefined;
+  return 'Open record';
 }
 
-function PublicationEntry({
+function MetaCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl bg-surface-container-low p-4">
+      <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">{label}</p>
+      <p className="mt-2 font-body text-sm leading-relaxed text-on-surface">{value}</p>
+    </div>
+  );
+}
+
+function PublicationCard({
   publication,
 }: {
   publication: Publication;
@@ -180,30 +303,63 @@ function PublicationEntry({
   const actionLabel = getPublicationActionLabel(publication);
 
   return (
-    <article id={publication.id} className="editorial-timeline-item">
-      <div className="editorial-post-meta">
-        <span>{getPublicationType(publication)}</span>
-        <span>{formatPublicationDate(publication.date)}</span>
-      </div>
-
-      <h3>{publication.title}</h3>
-      <p className="editorial-publication-authors">{publication.authors}</p>
-      {publication.venue && <p className="editorial-publication-venue">{publication.venue}</p>}
-      {publication.abstract && <p className="editorial-post-summary">{publication.abstract}</p>}
-
-      <div className="editorial-chip-row">
-        {publication.topics.slice(0, 4).map((topic) => (
-          <span key={topic} className="editorial-chip">
-            {topic}
-          </span>
-        ))}
-      </div>
-
-      {actionHref && actionLabel && (
-        <a href={actionHref} target="_blank" rel="noopener noreferrer" className="editorial-post-link">
-          {actionLabel}
-        </a>
+    <article
+      id={publication.id}
+      className="group flex h-full flex-col overflow-hidden rounded-2xl bg-surface-container-highest shadow-[0_18px_50px_rgba(29,28,22,0.04)] transition-transform duration-300 hover:-translate-y-1"
+    >
+      {publication.coverImage ? (
+        <div className="aspect-[4/3] overflow-hidden bg-surface-container-low">
+          <img
+            src={publication.coverImage}
+            alt={publication.title}
+            className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
+          />
+        </div>
+      ) : (
+        <div className="flex aspect-[4/3] items-center justify-center bg-[radial-gradient(circle_at_top_left,_rgba(180,197,255,0.45),_transparent_30%),linear-gradient(135deg,_#1d1c16,_#32302a)] p-8 text-[#fef9ef]">
+          <div className="max-w-xs space-y-3 text-center">
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary-fixed-dim">Publication</p>
+            <h3 className="font-headline text-2xl font-bold leading-tight">{publication.title}</h3>
+          </div>
+        </div>
       )}
+
+      <div className="flex flex-1 flex-col space-y-4 p-8">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary">{getPublicationType(publication)}</p>
+            <h3 className="mt-2 font-headline text-2xl font-bold leading-snug text-on-surface transition-colors group-hover:text-primary">
+              {publication.title}
+            </h3>
+          </div>
+          <time className="shrink-0 font-label text-[10px] uppercase tracking-widest text-secondary">
+            {formatPublicationDate(publication.date)}
+          </time>
+        </div>
+
+        <p className="font-body text-sm leading-relaxed text-secondary">{publication.authors}</p>
+        {publication.venue && <p className="font-label text-[11px] font-bold uppercase tracking-widest text-secondary">{publication.venue}</p>}
+        {publication.abstract && <p className="font-body text-base leading-relaxed text-on-surface-variant">{publication.abstract}</p>}
+
+        <div className="mt-auto flex flex-wrap gap-2 pt-2">
+          {publication.topics.slice(0, 4).map((topic) => (
+            <span key={topic} className="rounded-full bg-surface-container-low px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
+              {topic}
+            </span>
+          ))}
+        </div>
+
+        {actionHref && (
+          <a
+            href={actionHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center justify-center rounded-lg bg-surface-container-low px-4 py-3 font-label text-[11px] font-bold uppercase tracking-widest text-on-surface transition-colors hover:bg-secondary-container hover:text-primary"
+          >
+            {actionLabel}
+          </a>
+        )}
+      </div>
     </article>
   );
 }

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -2,13 +2,15 @@
 
 import type { FormEvent } from 'react';
 import { Suspense, useEffect, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { EditorialPageFrame } from '../components/EditorialPageFrame';
 import type { SearchResult } from '../services/UnifiedSearchService';
 
-function formatResultDate(date?: Date) {
-  if (!date) return null;
+function formatResultDate(date?: Date | string) {
+  if (!date) {
+    return null;
+  }
 
   return new Intl.DateTimeFormat('en-US', {
     year: 'numeric',
@@ -19,7 +21,16 @@ function formatResultDate(date?: Date) {
 
 const resultTypeOrder: SearchResult['type'][] = ['post', 'publication', 'talk', 'code-ai'];
 
-const groupResultsByType = (results: SearchResult[]) => {
+const typeLabels: Record<SearchResult['type'], string> = {
+  post: 'Posts',
+  publication: 'Publications',
+  talk: 'Talks',
+  'code-ai': 'Code & Tools',
+};
+
+const quickQueries = ['memory', 'retrieval', 'economics', 'tooling'];
+
+function groupResultsByType(results: SearchResult[]) {
   const groups = new Map<SearchResult['type'], SearchResult[]>();
 
   results.forEach((result) => {
@@ -34,19 +45,13 @@ const groupResultsByType = (results: SearchResult[]) => {
       type,
       results: groups.get(type) ?? [],
     }));
-};
+}
 
 function SearchContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const query = searchParams.get('q') || '';
   const normalizedQuery = query.trim();
-  const typeLabels: Record<SearchResult['type'], string> = {
-    post: 'Blog post',
-    talk: 'Talk',
-    publication: 'Publication',
-    'code-ai': 'Code & tools',
-  };
 
   const [results, setResults] = useState<SearchResult[]>([]);
   const [loading, setLoading] = useState(false);
@@ -82,8 +87,8 @@ function SearchContent() {
     setResults([]);
   }, [query]);
 
-  const handleSearch = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const handleSearch = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
 
     const nextQuery = searchQuery.trim();
     if (!nextQuery) {
@@ -93,154 +98,196 @@ function SearchContent() {
 
     router.replace(`/search?q=${encodeURIComponent(nextQuery)}`);
   };
+
   const groupedResults = groupResultsByType(results);
 
   return (
-    <EditorialPageFrame currentPath="/search" pageClassName="editorial-book-page">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Search</p>
-          <h1 className="editorial-page-title">Search Results</h1>
-          <p className="editorial-page-copy">
-            Search posts, talks, publications, and code notes without leaving the editorial index, with results grouped so the page reads in sections instead of one long feed.
-          </p>
-          <p className="editorial-post-summary">
-            {normalizedQuery ? `Showing results for “${normalizedQuery}”.` : 'Search the archive by topic, title, or theme.'}
-          </p>
-        </div>
-        <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">Search status</p>
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">{loading ? '...' : results.length}</span>
-              <span className="editorial-page-metric-label">results on the current query</span>
+    <EditorialPageFrame currentPath="/search">
+      <main className="mx-auto min-h-screen max-w-7xl px-8 py-16">
+        <header className="mb-16 max-w-3xl">
+          <div className="mb-4 block font-label text-xs font-bold uppercase tracking-widest text-secondary">
+            Search &amp; Discovery
+          </div>
+          <h1 className="mb-8 font-headline text-5xl font-black tracking-tighter text-on-surface">
+            Search the archives.
+          </h1>
+
+          <form action="/search" className="group relative" onSubmit={handleSearch} role="search" aria-label="Site search">
+            <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-6">
+              <span className="material-symbols-outlined text-secondary" aria-hidden="true">search</span>
             </div>
-            <div>
-              <Link href="/archive" className="editorial-post-link">
-                Browse archive
+            <input
+              autoFocus
+              className="block w-full rounded-xl bg-surface-container-lowest py-6 pl-16 pr-6 font-body text-xl text-on-surface shadow-[0_2px_15px_rgba(0,0,0,0.02)] placeholder:text-secondary focus:outline-none"
+              name="q"
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder="Search for posts, talks, publications, or tools..."
+              type="text"
+              value={searchQuery}
+            />
+            <div className="absolute bottom-0 left-0 h-0.5 w-full origin-left scale-x-0 bg-primary transition-transform duration-500 group-focus-within:scale-x-100" />
+          </form>
+
+          <div className="mt-6 flex flex-wrap gap-3">
+            <span className="mr-2 self-center font-label text-[10px] uppercase tracking-widest text-secondary">
+              Quick Queries:
+            </span>
+            {quickQueries.map((term) => (
+              <Link
+                key={term}
+                href={`/search?q=${encodeURIComponent(term)}`}
+                className="rounded-full bg-surface-container-low px-4 py-1.5 font-label text-xs font-semibold text-secondary transition-colors hover:bg-secondary-container hover:text-on-secondary-container"
+              >
+                {term}
               </Link>
-              <span className="editorial-page-metric-label">archive index</span>
-            </div>
+            ))}
           </div>
-        </aside>
-      </section>
+        </header>
 
-      <section className="editorial-list-section">
-        <form onSubmit={handleSearch} className="search-input-container" role="search" aria-label="Site search">
-          <input
-            type="text"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Search posts, talks, publications, and tools"
-            className="search-input-large"
-            autoFocus
-          />
-        </form>
-
-        {!normalizedQuery ? (
-          <div className="editorial-page-aside">
-            <p className="editorial-home-card-label">Try searching for</p>
-            <div className="editorial-chip-row">
-              {['memory', 'retrieval', 'economics', 'forecasting'].map((term) => (
-                <Link key={term} href={`/search?q=${encodeURIComponent(term)}`} className="editorial-chip">
-                  {term}
-                </Link>
-              ))}
-            </div>
-            <div className="editorial-chip-row">
-              <Link href="/posts" className="editorial-chip">Posts</Link>
-              <Link href="/tags" className="editorial-chip">Tags</Link>
-              <Link href="/archive" className="editorial-chip">Archive</Link>
-            </div>
-          </div>
-        ) : loading ? (
-          <div className="search-loading">
-            <div className="loading-spinner"></div>
-            <p>Searching...</p>
-          </div>
-        ) : results.length === 0 ? (
-          <div className="editorial-page-aside">
-            <p className="editorial-home-card-label">No results</p>
-            <p className="editorial-post-summary">
-              No results found for “{normalizedQuery}”. Try a broader keyword or search one of the suggested topics below.
-            </p>
-            <div className="editorial-chip-row">
-              {['memory', 'llm', 'forecasting', 'tooling'].map((term) => (
-                <Link key={term} href={`/search?q=${encodeURIComponent(term)}`} className="editorial-chip">
-                  {term}
-                </Link>
-              ))}
-            </div>
-          </div>
-        ) : (
-          <>
-            <p className="results-count" aria-live="polite">
-              Found {results.length} result{results.length !== 1 ? 's' : ''} for “{normalizedQuery}”
-            </p>
-
-            {groupedResults.map(({ type, results: typeResults }) => {
-              const [featuredResult, ...moreResults] = typeResults;
-
-              return (
-                <section key={type} className="editorial-list-section">
-                  <div className="editorial-list-heading">
-                    <p className="editorial-home-section-label">{typeLabels[type]}</p>
-                    <h2 className="editorial-page-section-title">
-                      {typeResults.length} result{typeResults.length !== 1 ? 's' : ''} in this section.
+        <div className="grid grid-cols-1 gap-16 md:grid-cols-12">
+          <div className="space-y-12 md:col-span-8">
+            {!normalizedQuery ? (
+              <section className="rounded-xl bg-surface-container-highest p-10">
+                <h2 className="mb-4 font-headline text-2xl font-bold text-on-surface">Start with a topic or title.</h2>
+                <p className="mb-6 max-w-2xl font-body text-lg leading-relaxed text-on-surface-variant">
+                  Search across posts, talks, publications, and code notes without leaving the editorial surface.
+                </p>
+                <div className="flex flex-wrap gap-3">
+                  {quickQueries.concat(['forecasting', 'llm']).map((term) => (
+                    <Link
+                      key={term}
+                      href={`/search?q=${encodeURIComponent(term)}`}
+                      className="rounded-full bg-surface px-4 py-2 font-label text-xs font-bold uppercase tracking-widest text-secondary transition-colors hover:bg-surface-container-low hover:text-on-surface"
+                    >
+                      {term}
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            ) : loading ? (
+              <section className="rounded-xl bg-surface-container-highest p-10">
+                <p className="font-headline text-xl font-bold text-on-surface">Searching…</p>
+                <p className="mt-3 font-body text-base text-on-surface-variant">
+                  Gathering results for “{normalizedQuery}”.
+                </p>
+              </section>
+            ) : results.length === 0 ? (
+              <section className="rounded-xl bg-surface-container-highest p-10">
+                <h2 className="font-headline text-2xl font-bold text-on-surface">No results for “{normalizedQuery}”.</h2>
+                <p className="mt-4 max-w-2xl font-body text-lg leading-relaxed text-on-surface-variant">
+                  Try a broader phrase, a specific title fragment, or one of the suggested topics in the sidebar.
+                </p>
+              </section>
+            ) : (
+              groupedResults.map(({ type, results: typeResults }) => (
+                <section key={type}>
+                  <div className="mb-8 flex items-center justify-between">
+                    <h2 className="flex items-center gap-2 font-label text-xs font-bold uppercase tracking-[0.2em] text-secondary">
+                      <span className="h-px w-8 bg-outline-variant" />
+                      {typeLabels[type]}
                     </h2>
+                    <span className="text-xs italic text-secondary">
+                      Showing {typeResults.length} result{typeResults.length === 1 ? '' : 's'}
+                    </span>
                   </div>
 
-                  {featuredResult ? (
-                    <article className="editorial-home-card">
-                      <p className="editorial-home-card-label">{typeLabels[featuredResult.type]}</p>
-                      <h3>
-                        <Link href={featuredResult.url}>{featuredResult.title}</Link>
-                      </h3>
-                      {featuredResult.description && <p>{featuredResult.description}</p>}
-                      <div className="editorial-post-meta">
-                        {featuredResult.date ? (
-                          <span>{formatResultDate(featuredResult.date)}</span>
-                        ) : (
-                          <span>{typeLabels[featuredResult.type]}</span>
-                        )}
-                        <span>{featuredResult.tags?.length ? `${featuredResult.tags.length} tags` : 'No tags listed'}</span>
-                      </div>
-                      <div className="editorial-chip-row">
-                        {featuredResult.tags?.slice(0, 3).map((tag) => (
-                          <span key={tag} className="editorial-chip">
-                            {tag}
-                          </span>
-                        ))}
-                      </div>
-                      <Link href={featuredResult.url} className="editorial-home-card-link">
-                        Open result
-                      </Link>
-                    </article>
-                  ) : null}
-
-                  {moreResults.length > 0 ? (
-                    <article className="editorial-home-card">
-                      <p className="editorial-home-card-label">More {typeLabels[type]}</p>
-                      <ul className="posts-list">
-                        {moreResults.map((result) => (
-                          <li key={`${result.type}-${result.title}`} className="archive-post">
-                            <Link href={result.url}>
-                              <time className="archive-post-date">
-                                {result.date ? formatResultDate(result.date) ?? typeLabels[result.type] : typeLabels[result.type]}
-                              </time>
-                              <span className="archive-post-title">{result.title}</span>
-                            </Link>
-                          </li>
-                        ))}
-                      </ul>
-                    </article>
-                  ) : null}
+                  <div className="space-y-1">
+                    {typeResults.map((result) => (
+                      <article
+                        key={`${result.type}-${result.url}`}
+                        className="-mx-8 rounded-xl p-8 transition-all duration-300 hover:bg-surface-container-low"
+                      >
+                        <Link href={result.url} className="block">
+                          <div className="flex flex-col gap-3">
+                            <div className="flex flex-wrap items-center gap-3">
+                              <span className="rounded bg-primary-fixed px-2 py-0.5 font-label text-[10px] font-bold uppercase tracking-widest text-primary">
+                                {result.type}
+                              </span>
+                              {result.date ? (
+                                <time className="font-label text-xs text-secondary">
+                                  {formatResultDate(result.date)}
+                                </time>
+                              ) : null}
+                            </div>
+                            <h3 className="font-headline text-2xl font-bold tracking-tight text-on-surface transition-colors hover:text-primary">
+                              {result.title}
+                            </h3>
+                            {result.description ? (
+                              <p className="max-w-2xl text-lg leading-relaxed text-on-surface-variant">
+                                {result.description}
+                              </p>
+                            ) : null}
+                            {result.tags && result.tags.length > 0 ? (
+                              <div className="mt-2 flex flex-wrap gap-2">
+                                {result.tags.slice(0, 4).map((tag) => (
+                                  <span
+                                    key={`${result.url}-${tag}`}
+                                    className="rounded-sm bg-surface-container-highest px-2 py-1 font-label text-[10px] font-bold uppercase tracking-widest text-secondary"
+                                  >
+                                    {tag}
+                                  </span>
+                                ))}
+                              </div>
+                            ) : null}
+                          </div>
+                        </Link>
+                      </article>
+                    ))}
+                  </div>
                 </section>
-              );
-            })}
-          </>
-        )}
-      </section>
+              ))
+            )}
+          </div>
+
+          <aside className="space-y-12 md:col-span-4">
+            <div className="rounded-xl bg-surface-container-low p-8">
+              <h2 className="mb-6 font-headline text-lg font-bold">Search Status</h2>
+              <div className="space-y-4">
+                {[
+                  ['Query', normalizedQuery || 'None'],
+                  ['Results', loading ? '…' : `${results.length}`],
+                  ['Sections', `${groupedResults.length}`],
+                ].map(([label, value]) => (
+                  <div key={label} className="flex items-center justify-between border-b border-outline-variant/20 pb-3">
+                    <span className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">{label}</span>
+                    <span className="font-headline text-base font-bold text-on-surface">{value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl bg-surface p-8">
+              <h2 className="mb-4 font-headline text-lg font-bold">Try searching for</h2>
+              <div className="flex flex-wrap gap-2">
+                {quickQueries.concat(['openai', 'python']).map((term) => (
+                  <Link
+                    key={term}
+                    href={`/search?q=${encodeURIComponent(term)}`}
+                    className="rounded-md bg-surface-container-low px-3 py-2 font-label text-xs text-on-surface-variant transition-colors hover:bg-surface-container-high"
+                  >
+                    {term}
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-outline-variant/20 bg-surface p-8">
+              <h2 className="mb-4 font-headline text-lg font-bold">Browse instead</h2>
+              <div className="flex flex-col gap-3">
+                <Link href="/archive" className="font-label text-xs font-bold uppercase tracking-widest text-primary">
+                  Open archive
+                </Link>
+                <Link href="/tags" className="font-label text-xs font-bold uppercase tracking-widest text-primary">
+                  Browse tags
+                </Link>
+                <Link href="/code-ai" className="font-label text-xs font-bold uppercase tracking-widest text-primary">
+                  Code &amp; tools
+                </Link>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </main>
     </EditorialPageFrame>
   );
 }

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { EditorialPageFrame } from '../../components/EditorialPageFrame';
-import { postService } from '../../../services/PostService';
+import { postService } from '../../services/PostService';
 
 interface TagPageProps {
   params: Promise<{
@@ -36,19 +36,35 @@ const groupPostsByYear = (posts: Posts) => {
     }));
 };
 
+function getRelatedTags(posts: Posts, currentTag: string) {
+  const counts = new Map<string, number>();
+
+  posts.forEach((post) => {
+    post.tags
+      .filter((tag) => tag.toLowerCase() !== currentTag.toLowerCase())
+      .forEach((tag) => {
+        counts.set(tag, (counts.get(tag) ?? 0) + 1);
+      });
+  });
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 6);
+}
+
 export async function generateMetadata({ params }: TagPageProps): Promise<Metadata> {
   const { tag: encodedTag } = await params;
   const tag = decodeURIComponent(encodedTag);
 
   return {
-    title: `${tag} | Ben Labaschin`,
+    title: `${tag} | Tags | ECONOBEN.DEV`,
     description: `Browse all posts tagged with "${tag}".`,
   };
 }
 
 export async function generateStaticParams() {
   const tags = await postService.getAllTags();
-  return tags.map((tagData: any) => ({
+  return tags.map((tagData) => ({
     tag: encodeURIComponent(tagData.tag),
   }));
 }
@@ -57,114 +73,147 @@ export default async function TagPage({ params }: TagPageProps) {
   const { tag: encodedTag } = await params;
   const tag = decodeURIComponent(encodedTag);
   const posts = await postService.getPostsByTag(tag);
-  const postsByYear = groupPostsByYear(posts);
-  const featuredPost = posts[0];
 
   if (posts.length === 0) {
     notFound();
   }
 
-  return (
-    <EditorialPageFrame currentPath="/tags" pageClassName="editorial-book-page">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Tag archive</p>
-          <h1 className="editorial-page-title">{tag}</h1>
-          <p className="editorial-page-copy">
-            {posts.length} post{posts.length !== 1 ? 's' : ''} found for this topic, ordered newest first and arranged so the topic reads like a guided trail.
-          </p>
-          <div className="editorial-chip-row">
-            <span className="editorial-chip">{posts.length} posts</span>
-            <span className="editorial-chip">Newest first</span>
-            <span className="editorial-chip">Related tags linked</span>
-          </div>
-        </div>
-        <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">Browse links</p>
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">{posts.length}</span>
-              <span className="editorial-page-metric-label">posts in this tag</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">{postsByYear.length}</span>
-              <span className="editorial-page-metric-label">years represented</span>
-            </div>
-            <div>
-              <Link href="/tags" className="editorial-post-link">
-                Back to tags
-              </Link>
-            </div>
-          </div>
-        </aside>
-      </section>
+  const postsByYear = groupPostsByYear(posts);
+  const [featuredPost, ...remainingPosts] = posts;
+  const relatedTags = getRelatedTags(posts, tag);
 
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Featured match</p>
-          <h2 className="editorial-page-section-title">Start with the newest post, then move through the year-by-year trail.</h2>
-        </div>
-        {featuredPost ? (
-          <article className="editorial-home-card">
-            <p className="editorial-home-card-label">{longDateFormatter.format(featuredPost.date)}</p>
-            <h3>
-              <Link href={`/posts/${featuredPost.slug}`}>{featuredPost.title}</Link>
-            </h3>
-            {featuredPost.summary && <p>{featuredPost.summary}</p>}
-            <div className="editorial-post-meta">
-              <span>{featuredPost.readingTime ? `${featuredPost.readingTime} min read` : `${featuredPost.tags.length} tags`}</span>
-              <span>{featuredPost.tags.length} topic tag{featuredPost.tags.length !== 1 ? 's' : ''}</span>
+  return (
+    <EditorialPageFrame currentPath="/tags">
+      <main className="mx-auto max-w-7xl px-8 py-20">
+        <section className="mb-20">
+          <div className="flex flex-col gap-4">
+            <span className="font-label text-xs font-bold uppercase tracking-[0.2em] text-secondary">Category Archive</span>
+            <h1 className="mb-6 font-headline text-6xl font-black tracking-tighter text-on-surface">{tag}</h1>
+            <div className="max-w-2xl rounded-lg bg-surface-container-low p-8">
+              <p className="text-xl italic leading-relaxed text-on-surface-variant">
+                {posts.length} post{posts.length === 1 ? '' : 's'} collected under this topic, ordered newest first and left fully linked for browsing.
+              </p>
             </div>
-            <div className="editorial-chip-row">
-              {featuredPost.tags.map((postTag) => (
-                <Link key={postTag} href={`/tags/${encodeURIComponent(postTag)}`} className="editorial-chip">
-                  {postTag}
+          </div>
+        </section>
+
+        <section className="grid grid-cols-12 gap-12">
+          <div className="col-span-12 flex flex-col gap-16 md:col-span-8">
+            <article className="rounded-xl bg-surface-container-highest p-10">
+              <div className="mb-6 flex items-center gap-4 font-label text-xs uppercase tracking-widest text-secondary">
+                <span>{longDateFormatter.format(featuredPost.date)}</span>
+                <span className="h-1 w-1 rounded-full bg-outline-variant" />
+                <span>{featuredPost.readingTime ? `${featuredPost.readingTime} min read` : `${featuredPost.tags.length} tags`}</span>
+              </div>
+              <h2 className="mb-4 font-headline text-4xl font-bold tracking-tight text-on-surface">
+                <Link href={`/posts/${featuredPost.slug}`} className="transition-colors hover:text-primary">
+                  {featuredPost.title}
                 </Link>
+              </h2>
+              {featuredPost.summary ? (
+                <p className="max-w-2xl text-lg leading-relaxed text-on-surface-variant">{featuredPost.summary}</p>
+              ) : null}
+              <div className="mt-6 flex flex-wrap gap-2">
+                {featuredPost.tags.map((postTag) => (
+                  <Link
+                    key={postTag}
+                    href={`/tags/${encodeURIComponent(postTag)}`}
+                    className="rounded-sm bg-surface px-3 py-1 font-label text-[10px] font-bold uppercase tracking-widest text-secondary transition-colors hover:bg-surface-container-high hover:text-on-surface"
+                  >
+                    {postTag}
+                  </Link>
+                ))}
+              </div>
+            </article>
+
+            <div className="space-y-12">
+              {remainingPosts.map((post) => (
+                <article key={post.slug} className="border-b border-outline-variant/20 pb-12 last:border-b-0 last:pb-0">
+                  <div className="mb-4 flex items-center gap-4 font-label text-xs uppercase tracking-widest text-secondary">
+                    <span>{longDateFormatter.format(post.date)}</span>
+                    <span className="h-1 w-1 rounded-full bg-outline-variant" />
+                    <span>{post.readingTime ? `${post.readingTime} min read` : `${post.tags.length} tags`}</span>
+                  </div>
+                  <h3 className="font-headline text-3xl font-bold tracking-tight text-on-surface">
+                    <Link href={`/posts/${post.slug}`} className="transition-colors hover:text-primary">
+                      {post.title}
+                    </Link>
+                  </h3>
+                  {post.summary ? (
+                    <p className="mt-4 max-w-2xl text-lg leading-relaxed text-on-surface-variant">
+                      {post.summary}
+                    </p>
+                  ) : null}
+                  <div className="mt-5 flex flex-wrap gap-2">
+                    {post.tags.map((postTag) => (
+                      <Link
+                        key={`${post.slug}-${postTag}`}
+                        href={`/tags/${encodeURIComponent(postTag)}`}
+                        className="rounded-sm bg-surface-container-highest px-3 py-1 font-label text-[10px] font-bold uppercase tracking-widest text-secondary transition-colors hover:bg-secondary-container hover:text-on-secondary-container"
+                      >
+                        {postTag}
+                      </Link>
+                    ))}
+                  </div>
+                </article>
               ))}
             </div>
-            <Link href={`/posts/${featuredPost.slug}`} className="editorial-home-card-link">
-              Read post
-            </Link>
-          </article>
-        ) : null}
-      </section>
+          </div>
 
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">By year</p>
-          <h2 className="editorial-page-section-title">A lighter index that keeps every tagged post visible on mobile.</h2>
-        </div>
-        <div className="editorial-two-column">
-          {postsByYear.map(({ year, posts: yearPosts }) => (
-            <article key={year} className="editorial-home-card">
-              <p className="editorial-home-card-label">Year {year}</p>
-              <h3>{yearPosts.length} post{yearPosts.length !== 1 ? 's' : ''}</h3>
-              <p>Newest first, with titles and summaries kept together so the topic stays scannable.</p>
-              {yearPosts[0] ? (
-                <div>
-                  <p className="editorial-home-card-label">Featured post</p>
-                  <Link href={`/posts/${yearPosts[0].slug}`} className="editorial-home-card-link">
-                    {yearPosts[0].title}
-                  </Link>
-                  {yearPosts[0].summary && <p className="editorial-post-summary">{yearPosts[0].summary}</p>}
-                </div>
-              ) : null}
-              <ul className="posts-list">
-                {yearPosts.slice(1).map((post) => (
-                  <li key={post.slug} className="archive-post">
-                    <Link href={`/posts/${post.slug}`}>
-                      <time className="archive-post-date">
-                        {post.date.getDate().toString().padStart(2, '0')}
-                      </time>
-                      <span className="archive-post-title">{post.title}</span>
-                    </Link>
-                  </li>
+          <aside className="hidden flex-col gap-12 md:col-span-4 md:flex">
+            <div className="flex flex-col gap-6 rounded-xl bg-surface-container p-8">
+              <h3 className="font-headline text-lg font-bold">Topic Snapshot</h3>
+              <div className="space-y-4">
+                {[
+                  ['Posts', `${posts.length}`],
+                  ['Years covered', `${postsByYear.length}`],
+                  ['Related tags', `${relatedTags.length}`],
+                ].map(([label, value]) => (
+                  <div key={label} className="flex items-center justify-between border-b border-outline-variant/20 pb-3">
+                    <span className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">{label}</span>
+                    <span className="font-headline text-lg font-bold text-on-surface">{value}</span>
+                  </div>
                 ))}
-              </ul>
-            </article>
-          ))}
-        </div>
-      </section>
+              </div>
+              <Link href="/tags" className="inline-flex items-center gap-2 font-label text-xs font-bold uppercase tracking-widest text-primary">
+                Back to all tags
+              </Link>
+            </div>
+
+            {relatedTags.length > 0 ? (
+              <div className="flex flex-col gap-6 px-4">
+                <h3 className="font-label text-xs font-bold uppercase tracking-widest text-secondary">Related Tags</h3>
+                <div className="flex flex-wrap gap-2">
+                  {relatedTags.map(([relatedTag, count]) => (
+                    <Link
+                      key={relatedTag}
+                      href={`/tags/${encodeURIComponent(relatedTag)}`}
+                      className="rounded-md bg-surface-container-low px-3 py-2 font-label text-xs text-on-surface-variant transition-colors hover:bg-surface-container-high"
+                    >
+                      {relatedTag} ({count})
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            <div className="rounded-xl bg-surface-container-low p-8">
+              <h3 className="mb-4 font-headline text-lg font-bold text-on-surface">Browse Beyond This Topic</h3>
+              <p className="font-body text-sm leading-relaxed text-on-surface-variant">
+                Switch from this topic trail to the full archive or run a direct search if you want a broader slice of the same material.
+              </p>
+              <div className="mt-6 flex flex-col gap-3">
+                <Link href="/archive" className="font-label text-xs font-bold uppercase tracking-widest text-primary">
+                  Open archive
+                </Link>
+                <Link href={`/search?q=${encodeURIComponent(tag)}`} className="font-label text-xs font-bold uppercase tracking-widest text-primary">
+                  Search this topic
+                </Link>
+              </div>
+            </div>
+          </aside>
+        </section>
+      </main>
     </EditorialPageFrame>
   );
 }

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -4,123 +4,161 @@ import { EditorialPageFrame } from '../components/EditorialPageFrame';
 import { postService } from '../services/PostService';
 
 export const metadata: Metadata = {
-  title: 'Tags | Ben Labaschin',
-  description: 'Browse every topic covered across the writing archive.',
+  title: 'Tags | ECONOBEN.DEV',
+  description: 'Browse topics covered across the writing archive.',
 };
 
 export default async function TagsPage() {
   const posts = await postService.getAllPosts();
+  const allTags = await postService.getAllTags();
+  const sortedTags = [...allTags].sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+  const [primaryTag, secondaryTag, ...remainingTags] = sortedTags;
+  const topTags = sortedTags.slice(0, 8);
 
-  const tagCounts = new Map<string, number>();
-  posts.forEach((post) => {
-    post.tags.forEach((tag) => {
-      tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
-    });
-  });
+  const tagsByLetter = remainingTags.reduce<Record<string, typeof remainingTags>>((acc, tagEntry) => {
+    const letter = tagEntry.tag.charAt(0).toUpperCase();
+    acc[letter] ??= [];
+    acc[letter].push(tagEntry);
+    return acc;
+  }, {});
 
-  const sortedTags = Array.from(tagCounts.entries()).sort((a, b) => b[1] - a[1]);
-  const tagsByLetter = new Map<string, Array<[string, number]>>();
-
-  sortedTags.forEach(([tag, count]) => {
-    const firstLetter = tag[0].toUpperCase();
-    if (!tagsByLetter.has(firstLetter)) {
-      tagsByLetter.set(firstLetter, []);
-    }
-    tagsByLetter.get(firstLetter)!.push([tag, count]);
-  });
-
-  const sortedLetters = Array.from(tagsByLetter.keys()).sort();
-  const topTagCount = sortedTags[0]?.[1] || 0;
-  const topTags = sortedTags.slice(0, 6);
+  const sortedLetters = Object.keys(tagsByLetter).sort();
 
   return (
-    <EditorialPageFrame currentPath="/tags" pageClassName="editorial-book-page">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Topics</p>
-          <h1 className="editorial-page-title">Tags</h1>
-          <p className="editorial-page-copy">
-            Explore topics across {posts.length} posts, with links preserved to every tag-specific archive and the broadest themes surfaced first.
+    <EditorialPageFrame currentPath="/tags">
+      <main className="mx-auto min-h-screen max-w-7xl px-8 py-20">
+        <section className="mb-20 max-w-3xl">
+          <span className="mb-4 block font-label text-xs font-bold uppercase tracking-widest text-secondary">
+            Archive &amp; Taxonomy
+          </span>
+          <h1 className="mb-6 font-headline text-6xl font-black tracking-tight text-on-surface">
+            Topic Index
+          </h1>
+          <p className="text-xl leading-relaxed text-on-surface-variant">
+            Browse the archive by subject, with the most-used topics surfaced first and every tag still linking through to its own post trail.
           </p>
-          <div className="editorial-chip-row">
-            {topTags.map(([tag, count]) => (
-              <Link key={tag} href={`/tags/${encodeURIComponent(tag)}`} className="editorial-chip">
-                {tag} <span>({count})</span>
-              </Link>
-            ))}
-          </div>
-        </div>
-        <aside className="editorial-page-aside">
-          <p className="editorial-home-card-label">Tag index</p>
-          <div className="editorial-page-metric-list">
-            <div>
-              <span className="editorial-page-metric-value">{sortedTags.length}</span>
-              <span className="editorial-page-metric-label">unique tags</span>
-            </div>
-            <div>
-              <span className="editorial-page-metric-value">{topTagCount}</span>
-              <span className="editorial-page-metric-label">posts for the most-used tag</span>
-            </div>
-          </div>
-          <p className="editorial-post-summary">
-            Every tag resolves to its own index, so topic browsing stays one click away from the underlying posts.
-          </p>
-        </aside>
-      </section>
+        </section>
 
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">All tags</p>
-          <h2 className="editorial-page-section-title">A weighted cloud for broad browsing.</h2>
-        </div>
-        <div className="tag-cloud">
-          <div className="tag-cloud-container">
-            {sortedTags.map(([tag, count]) => {
-              const maxCount = topTagCount || 1;
-              const minSize = 0.95;
-              const maxSize = 1.85;
-              const size = minSize + (count / maxCount) * (maxSize - minSize);
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-12">
+          {primaryTag ? (
+            <Link
+              href={`/tags/${encodeURIComponent(primaryTag.tag)}`}
+              className="cursor-pointer rounded-xl bg-surface-container-highest p-10 transition-colors hover:bg-surface-container-high md:col-span-8"
+            >
+              <div className="mb-8 flex items-start justify-between gap-6">
+                <span className="rounded-full bg-primary px-3 py-1 font-label text-xs font-bold text-on-primary">
+                  MOST USED
+                </span>
+                <span className="font-headline text-4xl font-bold text-on-surface">{primaryTag.count}</span>
+              </div>
+              <h2 className="mb-4 font-headline text-4xl font-extrabold transition-colors hover:text-primary">
+                {primaryTag.tag}
+              </h2>
+              <p className="max-w-xl text-lg text-on-surface-variant">
+                The densest topic cluster in the archive, currently spanning {primaryTag.count} post{primaryTag.count === 1 ? '' : 's'}.
+              </p>
+              <div className="mt-12 flex flex-wrap gap-3">
+                {posts
+                  .filter((post) => post.tags.includes(primaryTag.tag))
+                  .slice(0, 4)
+                  .map((post) => (
+                    <span
+                      key={post.slug}
+                      className="rounded bg-secondary-container px-2 py-1 font-label text-[10px] uppercase tracking-tighter text-on-secondary-container"
+                    >
+                      {post.title}
+                    </span>
+                  ))}
+              </div>
+            </Link>
+          ) : null}
 
-              return (
-                <Link
-                  key={tag}
-                  href={`/tags/${encodeURIComponent(tag)}`}
-                  className="tag-cloud-item"
-                  style={{ fontSize: `${size}rem` }}
-                  title={`${count} post${count !== 1 ? 's' : ''}`}
-                >
-                  {tag}
-                </Link>
-              );
-            })}
-          </div>
-        </div>
-      </section>
+          {secondaryTag ? (
+            <Link
+              href={`/tags/${encodeURIComponent(secondaryTag.tag)}`}
+              className="rounded-xl border border-outline-variant/10 bg-surface-container-low p-10 transition-colors hover:bg-surface-container-high md:col-span-4"
+            >
+              <div className="mb-8 flex justify-between">
+                <span className="font-headline text-3xl font-bold text-secondary">{secondaryTag.count}</span>
+              </div>
+              <h2 className="mb-4 font-headline text-3xl font-extrabold text-on-surface">
+                {secondaryTag.tag}
+              </h2>
+              <p className="text-on-surface-variant">
+                Another high-signal topic area that stays one click away from the underlying posts.
+              </p>
+              <span className="mt-8 inline-flex items-center gap-2 font-label text-xs font-bold uppercase tracking-widest text-primary">
+                Explore topic
+              </span>
+            </Link>
+          ) : null}
 
-      <section className="editorial-list-section">
-        <div className="editorial-list-heading">
-          <p className="editorial-home-section-label">Alphabetical</p>
-          <h2 className="editorial-page-section-title">The same index, re-sorted for precision.</h2>
-        </div>
-        <div className="tags-alphabetical">
-          {sortedLetters.map((letter) => (
-            <div key={letter} className="letter-group">
-              <h3 className="letter-heading">{letter}</h3>
-              <div className="letter-tags">
-                {tagsByLetter.get(letter)!.map(([tag, count]) => (
+          <div className="mt-12 md:col-span-12">
+            <div className="mb-8 flex flex-col gap-4 border-b border-outline-variant/10 pb-4 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h3 className="font-headline text-xl font-bold text-on-surface">Alphabetical Index</h3>
+                <p className="mt-2 font-body text-sm text-on-surface-variant">
+                  {sortedTags.length} tags across {posts.length} post{posts.length === 1 ? '' : 's'}.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {topTags.map((tagEntry) => (
                   <Link
-                    key={tag}
-                    href={`/tags/${encodeURIComponent(tag)}`}
-                    className="tag-link"
+                    key={tagEntry.tag}
+                    href={`/tags/${encodeURIComponent(tagEntry.tag)}`}
+                    className="rounded-full bg-surface-container-low px-3 py-1.5 font-label text-xs font-semibold text-secondary transition-colors hover:bg-secondary-container hover:text-on-secondary-container"
                   >
-                    {tag} <span className="tag-count">({count})</span>
+                    {tagEntry.tag}
                   </Link>
                 ))}
               </div>
             </div>
-          ))}
+
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+              {sortedLetters.map((letter) => (
+                <section key={letter} className="rounded-xl bg-surface p-6">
+                  <h4 className="mb-4 font-headline text-lg font-bold text-on-surface">{letter}</h4>
+                  <div className="space-y-3">
+                    {tagsByLetter[letter].map((tagEntry) => (
+                      <Link
+                        key={tagEntry.tag}
+                        href={`/tags/${encodeURIComponent(tagEntry.tag)}`}
+                        className="flex items-center justify-between border-b border-outline-variant/10 pb-3 transition-colors hover:text-primary"
+                      >
+                        <span className="font-headline font-semibold text-on-surface">{tagEntry.tag}</span>
+                        <span className="rounded bg-surface-container-highest px-2 py-1 font-label text-xs text-secondary">
+                          {tagEntry.count}
+                        </span>
+                      </Link>
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          </div>
         </div>
-      </section>
+
+        <section className="mx-auto mt-32 max-w-4xl rounded-xl border border-outline-variant/20 bg-surface-container-low p-12 text-center">
+          <h3 className="mb-4 font-headline text-2xl font-bold text-on-surface">Need a broader route in?</h3>
+          <p className="mb-8 font-body text-lg italic text-on-surface-variant">
+            Move from tags into the full archive or search the site directly if you know the subject already.
+          </p>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/archive"
+              className="rounded-md bg-primary-container px-6 py-3 font-label text-xs font-bold uppercase tracking-widest text-on-primary"
+            >
+              Browse archive
+            </Link>
+            <Link
+              href="/search"
+              className="rounded-md border border-outline-variant bg-surface px-6 py-3 font-label text-xs font-bold uppercase tracking-widest text-on-surface transition-colors hover:bg-surface-container-high"
+            >
+              Search site
+            </Link>
+          </div>
+        </section>
+      </main>
     </EditorialPageFrame>
   );
 }

--- a/app/talks/TalksClient.tsx
+++ b/app/talks/TalksClient.tsx
@@ -17,7 +17,7 @@ const getYouTubeUrl = (talk: Talk): string | null => {
 
 const getYouTubeEmbedUrl = (talk: Talk): string | null => {
   if (!talk.youtubeId) return null;
-  return `https://www.youtube.com/embed/${talk.youtubeId}?autoplay=1`;
+  return `https://www.youtube.com/embed/${talk.youtubeId}`;
 };
 
 const getSpotifyEmbedUrl = (talk: Talk): string | null => {
@@ -29,6 +29,14 @@ const getSpotifyEmbedUrl = (talk: Talk): string | null => {
   return `https://open.spotify.com/embed/episode/${match[1]}?utm_source=generator&theme=0`;
 };
 
+const getPrimarySourceLabel = (talk: Talk): string => {
+  if (talk.spotifyUrl && !talk.youtubeId) {
+    return 'Listen on Spotify';
+  }
+
+  return 'Watch on YouTube';
+};
+
 const getPrimaryActionLabel = (talk: Talk): string => {
   if (talk.spotifyUrl && !talk.youtubeId) {
     return 'Open player';
@@ -37,13 +45,169 @@ const getPrimaryActionLabel = (talk: Talk): string => {
   return 'Play in page';
 };
 
-const getPrimarySourceLabel = (talk: Talk): string => {
-  if (talk.spotifyUrl && !talk.youtubeId) {
-    return 'Listen on Spotify';
+const getPrimarySourceUrl = (talk: Talk): string | null => talk.spotifyUrl ?? getYouTubeUrl(talk);
+
+function TalkMediaPreview({
+  talk,
+  isOpen,
+  onOpen,
+}: {
+  talk: Talk;
+  isOpen: boolean;
+  onOpen: () => void;
+}) {
+  const spotifyEmbedUrl = getSpotifyEmbedUrl(talk);
+  const youtubeEmbedUrl = getYouTubeEmbedUrl(talk);
+  const isSpotifyOnly = Boolean(talk.spotifyUrl && !talk.youtubeId);
+
+  if (isOpen && isSpotifyOnly && spotifyEmbedUrl) {
+    return (
+      <iframe
+        src={spotifyEmbedUrl}
+        title={talk.title}
+        frameBorder="0"
+        sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-presentation"
+        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+        allowFullScreen
+        referrerPolicy="strict-origin-when-cross-origin"
+        loading="lazy"
+        className="h-full w-full"
+      />
+    );
   }
 
-  return 'Watch on YouTube';
-};
+  if (isOpen && youtubeEmbedUrl) {
+    return (
+      <iframe
+        src={youtubeEmbedUrl}
+        title={talk.title}
+        frameBorder="0"
+        sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-presentation"
+        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+        referrerPolicy="strict-origin-when-cross-origin"
+        loading="lazy"
+        className="h-full w-full"
+      />
+    );
+  }
+
+  if (talk.youtubeId) {
+    return (
+      <button
+        type="button"
+        onClick={onOpen}
+        className="group relative block h-full w-full overflow-hidden text-left"
+        aria-label={`Open ${talk.title} in the inline player`}
+      >
+        <img
+          src={`https://img.youtube.com/vi/${talk.youtubeId}/hqdefault.jpg`}
+          alt={talk.title}
+          className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-on-surface/40 via-transparent to-transparent" />
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary-container text-on-primary shadow-xl transition-transform duration-300 group-hover:scale-105">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-7 w-7">
+              <path d="M8 5v14l11-7z" />
+            </svg>
+          </div>
+        </div>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex h-full w-full items-center justify-center bg-[radial-gradient(circle_at_top_left,_rgba(180,197,255,0.45),_transparent_34%),linear-gradient(135deg,_#1d1c16,_#32302a)] text-left"
+      aria-label={`Open ${talk.title} in the inline player`}
+    >
+      <div className="space-y-3 p-10 text-[#fef9ef]">
+        <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary-fixed-dim">Recording</p>
+        <p className="max-w-sm font-headline text-2xl font-bold leading-tight">{talk.event}</p>
+        <p className="max-w-sm font-body text-lg text-[#e7e2d8]">Open this session in the inline player or jump straight to the source.</p>
+        <span className="inline-flex items-center gap-2 rounded-full bg-[#fef9ef]/10 px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest">
+          Open player
+        </span>
+      </div>
+    </button>
+  );
+}
+
+function FeaturedTalk({
+  talk,
+  isOpen,
+  onOpen,
+}: {
+  talk: Talk;
+  isOpen: boolean;
+  onOpen: () => void;
+}) {
+  const primarySourceUrl = getPrimarySourceUrl(talk);
+
+  return (
+    <article className="overflow-hidden rounded-2xl bg-surface-container-highest shadow-[0_24px_60px_rgba(29,28,22,0.06)]">
+      <div className="grid h-full gap-0 lg:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
+        <div className="min-h-[340px] bg-surface-container-low">
+          <TalkMediaPreview talk={talk} isOpen={isOpen} onOpen={onOpen} />
+        </div>
+        <div className="flex flex-col justify-between p-8 lg:p-10">
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="rounded-sm bg-secondary-fixed-dim px-3 py-1 font-label text-[10px] font-bold uppercase tracking-[0.2em] text-on-secondary-fixed-variant">
+                Featured recording
+              </span>
+              <span className="font-label text-xs uppercase tracking-widest text-secondary">{formatDate(talk.date)}</span>
+            </div>
+            <div className="space-y-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary">{talk.event}</p>
+              <h2 className="max-w-xl font-headline text-3xl font-bold tracking-tight text-on-surface lg:text-4xl">{talk.title}</h2>
+              <p className="max-w-xl font-body text-lg leading-relaxed text-secondary">{talk.description}</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {talk.topics.slice(0, 6).map((topic) => (
+                <span key={topic} className="rounded-full bg-surface-container-low px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
+                  {topic}
+                </span>
+              ))}
+            </div>
+          </div>
+          <div className="mt-8 flex flex-wrap gap-3">
+            {primarySourceUrl && (
+              <a
+                href={primarySourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center rounded-lg bg-primary-container px-5 py-3 font-label text-xs font-bold uppercase tracking-widest text-on-primary"
+              >
+                {getPrimarySourceLabel(talk)}
+              </a>
+            )}
+            {talk.transcriptUrl && (
+              <a
+                href={talk.transcriptUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center rounded-lg bg-surface-container-low px-5 py-3 font-label text-xs font-bold uppercase tracking-widest text-on-surface"
+              >
+                Read transcript
+              </a>
+            )}
+            <button
+              type="button"
+              onClick={onOpen}
+              className="inline-flex items-center justify-center rounded-lg bg-on-surface px-5 py-3 font-label text-xs font-bold uppercase tracking-widest text-surface"
+            >
+              {getPrimaryActionLabel(talk)}
+            </button>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
 
 function TalkCard({
   talk,
@@ -56,130 +220,108 @@ function TalkCard({
   isOpen: boolean;
   onOpen: () => void;
 }) {
-  const [isHovered, setIsHovered] = useState(false);
   const spotifyEmbedUrl = getSpotifyEmbedUrl(talk);
   const youtubeEmbedUrl = getYouTubeEmbedUrl(talk);
-  const youtubeUrl = getYouTubeUrl(talk);
+  const primarySourceUrl = getPrimarySourceUrl(talk);
   const isSpotifyOnly = Boolean(talk.spotifyUrl && !talk.youtubeId);
-  const primarySourceUrl = talk.spotifyUrl ?? youtubeUrl;
 
   return (
     <article
-      className={`talk-card ${isHovered ? 'talk-card-hovered' : ''} ${
-        viewMode === 'grid' ? 'talk-card-grid' : ''
-      } ${isOpen ? 'is-open' : ''}`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      className={`group overflow-hidden rounded-2xl border border-outline-variant/15 bg-surface-container-highest shadow-[0_18px_50px_rgba(29,28,22,0.04)] transition-transform duration-300 hover:-translate-y-1 ${
+        viewMode === 'grid' ? 'h-full' : 'lg:grid lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]'
+      }`}
     >
-      <div className="talk-card-video">
-        {isSpotifyOnly ? (
-          isOpen && spotifyEmbedUrl ? (
-            <iframe
-              src={spotifyEmbedUrl}
-              title={talk.title}
-              frameBorder="0"
-              allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-              allowFullScreen
-              loading="lazy"
-              className="spotify-embed"
-            />
-          ) : (
-            <div
-              className="talk-thumbnail-container spotify-container"
-              role="button"
-              tabIndex={0}
-              onClick={onOpen}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' || event.key === ' ') {
-                  event.preventDefault();
-                  onOpen();
-                }
-              }}
-              aria-label={`Open ${talk.title} in the inline player`}
-            >
-              <div className="spotify-placeholder">
-                <span className="spotify-label">Spotify episode</span>
-                <div className="talk-play-button" aria-hidden="true">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M8 5v14l11-7z" />
-                  </svg>
-                </div>
-                <span className="spotify-label">Open player</span>
-              </div>
-            </div>
-          )
+      <div className={`min-h-[240px] bg-surface-container-low ${viewMode === 'grid' ? '' : 'lg:min-h-full'}`}>
+        {isOpen && isSpotifyOnly && spotifyEmbedUrl ? (
+          <iframe
+            src={spotifyEmbedUrl}
+            title={talk.title}
+            frameBorder="0"
+            sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-presentation"
+            allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+            allowFullScreen
+            referrerPolicy="strict-origin-when-cross-origin"
+            loading="lazy"
+            className="h-full w-full"
+          />
         ) : isOpen && youtubeEmbedUrl ? (
           <iframe
             src={youtubeEmbedUrl}
             title={talk.title}
             frameBorder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-presentation"
+            allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
+            referrerPolicy="strict-origin-when-cross-origin"
+            loading="lazy"
+            className="h-full w-full"
           />
         ) : (
-          <div
-            className="talk-thumbnail-container"
-            role="button"
-            tabIndex={0}
+          <button
+            type="button"
             onClick={onOpen}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' || event.key === ' ') {
-                event.preventDefault();
-                onOpen();
-              }
-            }}
+            className="group relative block h-full w-full text-left"
             aria-label={`Open ${talk.title} in the inline player`}
           >
             {talk.youtubeId ? (
               <img
                 src={`https://img.youtube.com/vi/${talk.youtubeId}/hqdefault.jpg`}
                 alt={talk.title}
-                className="talk-thumbnail"
+                className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
               />
             ) : (
-              <div className="spotify-placeholder">
-                <span className="spotify-label">Recording</span>
-                <span className="spotify-label">Open to play</span>
+              <div className="flex h-full min-h-[240px] items-center justify-center bg-[radial-gradient(circle_at_top_left,_rgba(255,219,205,0.65),_transparent_36%),linear-gradient(135deg,_#fef9ef,_#ede8de)] p-8">
+                <div className="max-w-xs space-y-3 text-center">
+                  <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">Recording</p>
+                  <p className="font-headline text-2xl font-bold text-on-surface">{talk.event}</p>
+                  <p className="font-body text-base leading-relaxed text-secondary">Open this session in the inline player to watch or listen in place.</p>
+                </div>
               </div>
             )}
-            <div className="talk-play-button" aria-hidden="true">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M8 5v14l11-7z" />
-              </svg>
+            <div className="absolute inset-0 bg-gradient-to-t from-on-surface/40 via-transparent to-transparent" />
+            <div className="absolute inset-0 flex items-center justify-center">
+              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary-container text-on-primary shadow-xl transition-transform duration-300 group-hover:scale-105">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-6 w-6">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+              </div>
             </div>
-          </div>
+          </button>
         )}
       </div>
 
-      <div className="talk-card-content">
-        <div className="talk-card-header">
-          <h3 className="talk-card-title">{talk.title}</h3>
-          <div className="talk-card-meta">
-            <span className="talk-card-event">{talk.event}</span>
-            <span className="talk-card-date">{formatDate(talk.date)}</span>
-            {isOpen && <span>Playing in page</span>}
+      <div className="space-y-5 p-8">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-2">
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary">{talk.event}</p>
+            <h3 className="font-headline text-2xl font-bold leading-snug text-on-surface transition-colors group-hover:text-primary">
+              {talk.title}
+            </h3>
           </div>
+          <time className="font-label text-[10px] uppercase tracking-widest text-secondary">{formatDate(talk.date)}</time>
         </div>
 
-        {viewMode !== 'grid' && <p className="talk-card-description">{talk.description}</p>}
+        <p className={`font-body text-secondary ${viewMode === 'grid' ? 'text-base' : 'text-lg leading-relaxed'}`}>
+          {talk.description}
+        </p>
 
-        <div className="talk-card-topics">
+        <div className="flex flex-wrap gap-2">
           {talk.topics.slice(0, viewMode === 'grid' ? 4 : 6).map((topic) => (
-            <span key={topic} className="talk-topic-tag">
+            <span key={topic} className="rounded-full bg-surface-container-low px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
               {topic}
             </span>
           ))}
         </div>
 
-        <div className="talk-card-actions">
+        <div className="flex flex-wrap gap-3 pt-1">
           {primarySourceUrl && (
             <a
               href={primarySourceUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="watch-talk-button"
+              className="inline-flex items-center justify-center rounded-lg bg-surface-container-low px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-on-surface transition-colors hover:bg-secondary-container hover:text-primary"
             >
-              <span>{getPrimarySourceLabel(talk)}</span>
+              {getPrimarySourceLabel(talk)}
             </a>
           )}
           {talk.transcriptUrl && (
@@ -187,13 +329,17 @@ function TalkCard({
               href={talk.transcriptUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="watch-talk-button transcript-button"
+              className="inline-flex items-center justify-center rounded-lg bg-surface-container-low px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-on-surface transition-colors hover:bg-secondary-container hover:text-primary"
             >
-              <span>Read transcript</span>
+              Transcript
             </a>
           )}
-          <button type="button" className="watch-talk-button" onClick={onOpen}>
-            <span>{getPrimaryActionLabel(talk)}</span>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-lg bg-on-surface px-4 py-2 font-label text-[11px] font-bold uppercase tracking-widest text-surface"
+            onClick={onOpen}
+          >
+            {isOpen ? 'Playing in page' : getPrimaryActionLabel(talk)}
           </button>
         </div>
       </div>
@@ -206,9 +352,7 @@ export default function TalksClient() {
   const [viewMode, setViewMode] = useState<'list' | 'grid'>('grid');
   const { talks } = talksConfig;
 
-  const sortedTalks = [...talks].sort(
-    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-  );
+  const sortedTalks = [...talks].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const topicCounts = new Map<string, number>();
   sortedTalks.forEach((talk) => {
@@ -240,14 +384,63 @@ export default function TalksClient() {
     }
   }, [activeTalkId, filteredTalks]);
 
+  const featuredTalk = filteredTalks.find((talk) => talk.id === activeTalkId) ?? filteredTalks[0] ?? null;
+
   return (
-    <div className="talks-page">
-      <div className="talks-controls">
-        <div className="talks-filter" aria-label="Talk topics">
+    <section className="mx-auto max-w-7xl px-8 pb-32">
+      {featuredTalk && (
+        <div className="mb-16 grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+          <FeaturedTalk talk={featuredTalk} isOpen={featuredTalk.id === activeTalkId} onOpen={() => setActiveTalkId(featuredTalk.id)} />
+          <aside className="rounded-2xl bg-surface-container-low p-8">
+            <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">Browse recordings</p>
+            <h2 className="mt-4 font-headline text-3xl font-bold leading-tight text-on-surface">
+              {activeFilter === 'all' ? 'All talks, newest first.' : `Talks about ${activeFilter}.`}
+            </h2>
+            <p className="mt-4 font-body text-lg leading-relaxed text-secondary">
+              Open a card, play it in place, and use the source links that matter for that recording.
+            </p>
+            <div className="mt-8 flex flex-wrap gap-2">
+              <span className="rounded-full bg-surface-container-high px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
+                Inline playback
+              </span>
+              <span className="rounded-full bg-surface-container-high px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
+                Transcripts
+              </span>
+              <span className="rounded-full bg-surface-container-high px-3 py-1 font-label text-[10px] font-bold uppercase tracking-wider text-secondary">
+                Source links
+              </span>
+            </div>
+            <div className="mt-8 space-y-3">
+              {filteredTalks.slice(0, 3).map((talk) => (
+                <button
+                  key={talk.id}
+                  type="button"
+                  onClick={() => setActiveTalkId(talk.id)}
+                  className="flex w-full items-start justify-between gap-4 rounded-xl bg-surface-container-high/60 px-4 py-3 text-left transition-colors hover:bg-surface-container-high"
+                >
+                  <span className="min-w-0">
+                    <span className="block font-label text-[10px] font-bold uppercase tracking-[0.2em] text-primary">{talk.event}</span>
+                    <span className="mt-1 block line-clamp-2 font-headline text-sm font-bold leading-snug text-on-surface">{talk.title}</span>
+                  </span>
+                  <span className="shrink-0 font-label text-[10px] uppercase tracking-widest text-secondary">{formatDate(talk.date)}</span>
+                </button>
+              ))}
+            </div>
+          </aside>
+        </div>
+      )}
+
+      <div className="mb-8 flex flex-col gap-6 border-b border-outline-variant/30 pb-8 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-wrap gap-3" aria-label="Talk topics">
           <button
             type="button"
-            className={`filter-button ${activeFilter === 'all' ? 'active' : ''}`}
+            className={`rounded-full px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider transition-colors ${
+              activeFilter === 'all'
+                ? 'bg-surface-container-highest text-on-surface'
+                : 'bg-surface-container-low text-secondary hover:bg-secondary-container hover:text-primary'
+            }`}
             onClick={() => setActiveFilter('all')}
+            aria-pressed={activeFilter === 'all'}
           >
             All talks
           </button>
@@ -255,79 +448,65 @@ export default function TalksClient() {
             <button
               type="button"
               key={topic}
-              className={`filter-button ${activeFilter === topic ? 'active' : ''}`}
+              className={`rounded-full px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider transition-colors ${
+                activeFilter === topic
+                  ? 'bg-surface-container-highest text-on-surface'
+                  : 'bg-surface-container-low text-secondary hover:bg-secondary-container hover:text-primary'
+              }`}
               onClick={() => setActiveFilter(topic)}
+              aria-pressed={activeFilter === topic}
             >
               {topic}
             </button>
           ))}
         </div>
-      </div>
 
-      <div className="talks-component-box">
-        <div className="talks-component-header">
-          <h2 className="talks-component-title">
-            {activeFilter === 'all' ? 'Browse recordings' : `Talks about ${activeFilter}`}
-          </h2>
-          <div className="view-toggle" aria-label="Talk view mode">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2 rounded-lg bg-surface-container-low p-1">
             <button
               type="button"
-              className={`view-button ${viewMode === 'grid' ? 'active' : ''}`}
+              className={`rounded-md px-3 py-2 font-label text-[11px] font-bold uppercase tracking-wider transition-colors ${
+                viewMode === 'grid' ? 'bg-surface-container-lowest text-on-surface shadow-sm' : 'text-secondary hover:text-on-surface'
+              }`}
               onClick={() => setViewMode('grid')}
-              aria-label="Grid view"
-              title="Grid view"
+              aria-pressed={viewMode === 'grid'}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <rect x="3" y="3" width="7" height="7" />
-                <rect x="14" y="3" width="7" height="7" />
-                <rect x="14" y="14" width="7" height="7" />
-                <rect x="3" y="14" width="7" height="7" />
-              </svg>
+              Grid
             </button>
             <button
               type="button"
-              className={`view-button ${viewMode === 'list' ? 'active' : ''}`}
+              className={`rounded-md px-3 py-2 font-label text-[11px] font-bold uppercase tracking-wider transition-colors ${
+                viewMode === 'list' ? 'bg-surface-container-lowest text-on-surface shadow-sm' : 'text-secondary hover:text-on-surface'
+              }`}
               onClick={() => setViewMode('list')}
-              aria-label="List view"
-              title="List view"
+              aria-pressed={viewMode === 'list'}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <line x1="8" y1="6" x2="21" y2="6" />
-                <line x1="8" y1="12" x2="21" y2="12" />
-                <line x1="8" y1="18" x2="21" y2="18" />
-                <line x1="3" y1="6" x2="3.01" y2="6" />
-                <line x1="3" y1="12" x2="3.01" y2="12" />
-                <line x1="3" y1="18" x2="3.01" y2="18" />
-              </svg>
+              List
             </button>
           </div>
-        </div>
-
-        <div className="talks-component-content">
-          <div className={`talks-container ${viewMode === 'list' ? 'talks-list' : 'talks-grid'}`}>
-            {filteredTalks.map((talk) => (
-              <TalkCard
-                key={talk.id}
-                talk={talk}
-                viewMode={viewMode}
-                isOpen={talk.id === activeTalkId}
-                onOpen={() => setActiveTalkId(talk.id)}
-              />
-            ))}
+          <div className="hidden font-label text-[11px] uppercase tracking-widest text-secondary md:block">
+            {filteredTalks.length} recordings
           </div>
-
-          {filteredTalks.length === 0 && (
-            <div className="no-talks-message">
-              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="12" cy="12" r="10" />
-                <line x1="12" y1="8" x2="12" y2="12" />
-                <line x1="12" y1="16" x2="12.01" y2="16" />
-              </svg>
-              <p>No talks found for that topic.</p>
-            </div>
-          )}
         </div>
       </div>
-    </div>
+
+      {filteredTalks.length === 0 ? (
+        <div className="rounded-2xl bg-surface-container-low p-10 text-center">
+          <p className="font-headline text-2xl font-bold text-on-surface">No talks found for that topic.</p>
+        </div>
+      ) : (
+        <div className={viewMode === 'grid' ? 'grid gap-8 md:grid-cols-2 xl:grid-cols-3' : 'space-y-8'}>
+          {filteredTalks.map((talk) => (
+            <TalkCard
+              key={talk.id}
+              talk={talk}
+              viewMode={viewMode}
+              isOpen={talk.id === activeTalkId}
+              onOpen={() => setActiveTalkId(talk.id)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
   );
 }

--- a/app/talks/page.tsx
+++ b/app/talks/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { EditorialPageFrame } from '../components/EditorialPageFrame';
+import { talksConfig } from '../config/talksConfig';
 import TalksClient from './TalksClient';
 
 export const metadata: Metadata = {
@@ -8,28 +9,81 @@ export const metadata: Metadata = {
 };
 
 export default function TalksPage() {
+  const { talks, subtitle } = talksConfig;
+  const sortedTalks = [...talks].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  const featuredTalk = sortedTalks[0];
+  const sourceCounts = sortedTalks.reduce(
+    (counts, talk) => {
+      if (talk.youtubeId) {
+        counts.video += 1;
+      }
+
+      if (talk.spotifyUrl) {
+        counts.audio += 1;
+      }
+
+      if (talk.transcriptUrl) {
+        counts.transcripts += 1;
+      }
+
+      return counts;
+    },
+    { video: 0, audio: 0, transcripts: 0 }
+  );
+
   return (
     <EditorialPageFrame currentPath="/talks">
-      <section className="editorial-page-hero">
-        <div className="editorial-page-hero-copy">
-          <p className="editorial-home-kicker">Watch and listen</p>
-          <h1 className="editorial-page-title">Talks</h1>
-          <p className="editorial-page-copy">
-            Recorded talks, podcast conversations, and livestreams with inline playback, transcripts when available, and direct links back to the source.
+      <section className="mx-auto grid max-w-7xl grid-cols-1 gap-10 px-8 pb-12 pt-20 lg:grid-cols-12 lg:items-end">
+        <div className="lg:col-span-8">
+          <span className="mb-6 block font-label text-xs font-bold uppercase tracking-[0.2em] text-secondary">Watch and listen</span>
+          <h1 className="max-w-4xl font-headline text-5xl font-black tracking-tighter text-on-surface md:text-7xl">
+            Talks
+          </h1>
+          <p className="mt-6 max-w-3xl font-body text-xl leading-relaxed text-secondary md:text-2xl">
+            {subtitle}
           </p>
-          <div className="editorial-chip-row">
-            <span className="editorial-chip">Inline playback</span>
-            <span className="editorial-chip">Transcripts</span>
-            <span className="editorial-chip">Source links</span>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <span className="rounded-full bg-surface-container-low px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider text-secondary">
+              Inline playback
+            </span>
+            <span className="rounded-full bg-surface-container-low px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider text-secondary">
+              Transcripts
+            </span>
+            <span className="rounded-full bg-surface-container-low px-5 py-2 font-label text-[11px] font-bold uppercase tracking-wider text-secondary">
+              Source links
+            </span>
           </div>
         </div>
-        <aside className="editorial-page-aside">
-          <p className="editorial-post-summary">
-            Open a card, play it in place, and use the watch, listen, or transcript links that matter for that recording.
-          </p>
-          <p className="editorial-post-summary">
-            The page stays practical on purpose: no appearance counts, no latest-item badge, just a browsable set of recordings.
-          </p>
+
+        <aside className="rounded-2xl bg-surface-container-low p-8 lg:col-span-4">
+          <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-secondary">At a glance</p>
+          <div className="mt-6 grid gap-4 sm:grid-cols-3 lg:grid-cols-1">
+            <div className="rounded-xl bg-surface-container-highest p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Recordings</p>
+              <p className="mt-2 font-headline text-3xl font-bold text-on-surface">{sortedTalks.length}</p>
+            </div>
+            <div className="rounded-xl bg-surface-container-highest p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Video sessions</p>
+              <p className="mt-2 font-headline text-3xl font-bold text-on-surface">{sourceCounts.video}</p>
+            </div>
+            <div className="rounded-xl bg-surface-container-highest p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Audio sessions</p>
+              <p className="mt-2 font-headline text-3xl font-bold text-on-surface">{sourceCounts.audio}</p>
+            </div>
+            <div className="rounded-xl bg-surface-container-highest p-4">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.2em] text-secondary">Transcript links</p>
+              <p className="mt-2 font-headline text-3xl font-bold text-on-surface">{sourceCounts.transcripts}</p>
+            </div>
+          </div>
+          {featuredTalk && (
+            <div className="mt-8 border-t border-outline-variant/30 pt-6">
+              <p className="font-label text-[10px] font-bold uppercase tracking-[0.3em] text-primary">Featured talk</p>
+              <p className="mt-3 font-headline text-xl font-bold leading-snug text-on-surface">{featuredTalk.title}</p>
+              <p className="mt-3 font-body text-base leading-relaxed text-secondary">
+                Open the newest session first, then use the filters to jump by topic.
+              </p>
+            </div>
+          )}
         </aside>
       </section>
 


### PR DESCRIPTION
## Context

This branch assembles the browser-review stack on top of feat/site-stitch-integrate-shell-home by replaying the current shell-based child slice work for reading, discovery, book/code detail, and structured routes. The goal is to produce one coherent non-main site state for review without pulling in unrelated history or shell-only follow-ups.

Issue #43 tracks the stack assembly work. This PR references that issue and keeps the branch scoped to the route-bearing commits needed for review.

## What changed

- Posts reading slice: replayed 42a41ff to restore the /posts route on top of the shell base.
- Discovery routes: replayed f140dca to stitch /archive, /archives/[month], /search, and tag routes into the stack.
- Book and code detail: replayed 81e7114 to add /book and /code-ai/[id].
- Structured routes: replayed 90ddf7d to port /about, /publications, and /talks.

## Why this matters

Without this stack, browser review has to jump across multiple slice branches and follow-up fixes. This branch collapses those route-focused changes into one linear review target so the site can be exercised as a single integrated experience.

## Test plan

- npm run build
- http://127.0.0.1:3000/ returns 200
- http://127.0.0.1:3000/posts returns 200
- http://127.0.0.1:3000/talks returns 200
- http://127.0.0.1:3000/search returns 200
- http://127.0.0.1:3000/book returns 200
- http://127.0.0.1:3000/code-ai/beads-spec-driven-dev returns 200

Refs #43

Generated with Claude Code.
